### PR TITLE
Test domains are no longer hard-coded

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -1,12 +1,13 @@
-﻿using GeeksCoreLibrary.Modules.Templates.Models;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.Templates.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace GeeksCoreLibrary.Core.Helpers
 {
@@ -32,7 +33,7 @@ namespace GeeksCoreLibrary.Core.Helpers
                 return null;
             }
 
-            testDomains ??= new List<string> { "juicebv.nl", "juicedev.nl", "happygeeks.dev" };
+            testDomains ??= GclSettings.Current.TestDomains?.ToList() ?? new List<string>();
 
             var hostname = httpContext.Request.Host.Host.ToLower();
             if (includingTestWww == false && hostname.StartsWith("www", StringComparison.OrdinalIgnoreCase))

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -176,5 +176,10 @@ namespace GeeksCoreLibrary.Core.Models
         /// If you have a project that still needs to run on the old wiser 1 module (that uses the tables easy_templates and easy_dynamiccontent), set this to <see langword="true"/>.
         /// </summary>
         public bool UseLegacyWiser1TemplateModule { get; set; }
+
+        /// <summary>
+        /// A list of domain names that are considered to be test domains. E.g.: my-test-domain.com
+        /// </summary>
+        public string[] TestDomains { get; set; } = Array.Empty<string>();
     }
 }


### PR DESCRIPTION
The function GetHostName no longer has a list of hard-coded test domains
it uses as a fallback. Instead, they are now managed through AppSettings
in the GCL section.