### PR TITLE
Additional replaces for pagination

### DIFF
--- a/GeeksCoreLibrary/Components/Pagination/Pagination.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Pagination.cs
@@ -315,6 +315,13 @@ namespace GeeksCoreLibrary.Components.Pagination
 
             // Create the complete HTML.
             var resultHtml = Settings.FullTemplate.Replace("{summary}", summaryHtml).Replace("{pagination}", paginationHtml.ToString());
+            replaceData = new Dictionary<string, string>
+            {
+                ["pagenr"] = currentPage.ToString(),
+                ["lastpagenr"] = lastPageNumber.ToString(),
+                ["totalitems"] = totalItemCount.ToString()
+            };
+            resultHtml = StringReplacementsService.DoReplacements(resultHtml, replaceData);
 
             return await TemplatesService.DoReplacesAsync(resultHtml, handleRequest: Settings.HandleRequest, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables);
         }


### PR DESCRIPTION
The 'FullTemplate' now supports three new variables:
- pagenr: the current page number.
- lastpagenr: the last page number.
- totalitems: the total items in a result.