### PR TITLE
Added functionality for loading items up to a specified page number

### DIFF
--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
@@ -267,6 +267,15 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
         )]
         public bool ShowBaseHeaderAndFooterOnNoData { get; set; }
 
+        [CmsProperty(
+            PrettyName = "Loads the items up to the specified page number",
+            Description = "Use this property to load items up to the specified page number",
+            TabName = CmsAttributes.CmsTabName.Behavior,
+            GroupName = CmsAttributes.CmsGroupName.Basic,
+            DisplayOrder = 30
+        )]
+        public bool LoadItemsUpToPageNumber { get; set; }
+
         #endregion
     }
 }

--- a/GeeksCoreLibrary/Components/Repeater/Repeater.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Repeater.cs
@@ -305,9 +305,6 @@ namespace GeeksCoreLibrary.Components.Repeater
                                 pageNumber = 1;
                             }
 
-                            // Check if the property must be overruled
-                            bool.TryParse(httpContextAccessor.HttpContext.Request.Query["loadUptoPageNumberOverrule"].ToString(), out var loadUptoPageNumberOverrule);
-
                             var startIndex = (pageNumber - 1) * Settings.ItemsPerPage;
                             var totalBanners = 0;
                             var bannersForCurrentPage = 0;
@@ -321,20 +318,16 @@ namespace GeeksCoreLibrary.Components.Repeater
                                 }
                             }
 
-                            if (Settings.LoadItemsUpToPageNumber)
+                            // Check if the property must be overruled
+                            bool.TryParse(httpContextAccessor.HttpContext.Request.Query["loadUptoPageNumberOverrule"].ToString(), out var loadUptoPageNumberOverrule);
+
+                            if (Settings.LoadItemsUpToPageNumber && loadUptoPageNumberOverrule)
                             {
-                                if (loadUptoPageNumberOverrule)
-                                {
-                                    limitClause = $" LIMIT {startIndex - totalBanners + bannersForCurrentPage}, {Settings.ItemsPerPage - bannersForCurrentPage}";
-                                }
-                                else
-                                {
-                                    limitClause = $" LIMIT 0, {Settings.ItemsPerPage * pageNumber - bannersForCurrentPage}";
-                                }
+                                limitClause = $" LIMIT {startIndex - totalBanners + bannersForCurrentPage}, {Settings.ItemsPerPage - bannersForCurrentPage}";
                             }
                             else
                             {
-                                limitClause = $" LIMIT {startIndex - totalBanners + bannersForCurrentPage}, {Settings.ItemsPerPage - bannersForCurrentPage}";
+                                limitClause = $" LIMIT 0, {Settings.ItemsPerPage * pageNumber - bannersForCurrentPage}";
                             }
                         }
 


### PR DESCRIPTION
New functionality added for the repeater component for loading items up to a specific page number. This settings can be overruled using a querystring variable.

Also added functionality for replacing variabels of the firstrow in the between template of the repeater component.