### PR TITLE
Removed SkiaSharp reference

### DIFF
--- a/GeeksCoreLibrary/GeeksCoreLibrary.csproj
+++ b/GeeksCoreLibrary/GeeksCoreLibrary.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="106.12.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SkiaSharp" Version="2.80.3" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />


### PR DESCRIPTION
SkiaSharp has been replaced by Magick.NET a while back, so SkiaSharp is
longer needed.