### PR TITLE
Added casing formatters

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Extensions/StringReplacementsExtensions.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Extensions/StringReplacementsExtensions.cs
@@ -114,11 +114,11 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         /// </summary>
         /// <param name="input"></param>
         /// <param name="includeCurrencySymbol"></param>
-        /// <param name="cultureString"></param>
+        /// <param name="cultureName"></param>
         /// <returns></returns>
-        public static string CurrencySup(this decimal input, bool includeCurrencySymbol = true, string cultureString = null)
+        public static string CurrencySup(this decimal input, bool includeCurrencySymbol = true, string cultureName = null)
         {
-            var culture = !String.IsNullOrWhiteSpace(cultureString) ? new CultureInfo(cultureString) : CultureInfo.CurrentCulture;
+            var culture = !String.IsNullOrWhiteSpace(cultureName) ? new CultureInfo(cultureName) : CultureInfo.CurrentCulture;
 
             var output = input.ToString(includeCurrencySymbol ? "C" : $"N{culture.NumberFormat.CurrencyDecimalDigits}", culture);
 
@@ -132,7 +132,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         }
 
         /// <summary>
-        /// Returns a string with the first character in upper-case.
+        /// Returns a string with the first character in uppercase.
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
@@ -143,7 +143,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
                 return input;
             }
 
-            // Only one character; simply return the string in upper-case.
+            // Only one character; simply return the string in uppercase.
             if (input.Length == 1)
             {
                 return input.ToUpper();
@@ -157,7 +157,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         }
 
         /// <summary>
-        /// Returns a string with the first character in lower-case.
+        /// Returns a string with the first character in lowercase.
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
@@ -168,7 +168,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
                 return input;
             }
 
-            // Only one character; simply return the string in lower-case.
+            // Only one character; simply return the string in lowercase.
             if (input.Length == 1)
             {
                 return input.ToLower();
@@ -251,7 +251,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         /// Converts a date time to a string with the specified format.
         /// </summary>
         /// <param name="input"></param>
-        /// <param name="format"></param>
+        /// <param name="format">The format of the <see cref="DateTime"/>. Can be a default format or a custom format.</param>
         /// <returns></returns>
         public static string DateTime(this DateTime input, string format)
         {
@@ -266,6 +266,28 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         public static string Sha512(this string input)
         {
             return input?.ToSha512ForPasswords();
+        }
+
+        /// <summary>
+        /// Converts this string to uppercase.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="useInvariantCulture">Whether to use the casing rules of the invariant culture instead of those of the current culture.</param>
+        /// <returns>The string converted to uppercase.</returns>
+        public static string Uppercase(this string input, bool useInvariantCulture = false)
+        {
+            return useInvariantCulture ? input?.ToUpperInvariant() : input?.ToUpper();
+        }
+
+        /// <summary>
+        /// Converts this string to lowercase.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="useInvariantCulture">Whether to use the casing rules of the invariant culture instead of those of the current culture.</param>
+        /// <returns>The string converted to lowercase.</returns>
+        public static string Lowercase(this string input, bool useInvariantCulture = false)
+        {
+            return useInvariantCulture ? input?.ToLowerInvariant() : input?.ToLower();
         }
     }
 }


### PR DESCRIPTION
Adds the formatter "Lowercase" and "Uppercase" to convert a string to lowercase or uppercase respectively. Both functions have an optional parameter to use invariant culture casing rules instead of the current culture's casing rules.