### PR TITLE
Fixed filter default complete template HTML

### DIFF
--- a/GeeksCoreLibrary/Components/Filter/Models/FilterAggregationSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Filter/Models/FilterAggregationSettingsModel.cs
@@ -4,8 +4,8 @@ namespace GeeksCoreLibrary.Components.Filter.Models
 {
     internal class FilterAggregationSettingsModel
     {
-        [DefaultValue(@"{summary:Raw}<br />
-                        {filters:Raw}")]
+        [DefaultValue(@"{summary}<br />
+                        {filters}")]
         internal string TemplateFull { get; set; }
 
         [DefaultValue(@"<ul>


### PR DESCRIPTION
The default HTML for the complete template of the Filter component uses {filters:Raw} and {summary:Raw}, but the ':Raw' part would cause the filters and summary not to render.