### PR TITLE
StringReplacementsService fix

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -720,7 +720,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
             prefix = Regex.Escape(prefix);
             suffix = Regex.Escape(suffix);
 
-            var regex = new Regex($@"{prefix}(?<field>.*?){suffix}");
+            var regex = new Regex($@"{prefix}(?<field>[^\{{\}}]*?){suffix}");
 
             var result = new List<StringReplacementVariable>();
             foreach (Match match in regex.Matches(input))


### PR DESCRIPTION
Replacing variables inside variables (such as a request or database value inside a translation) now work correctly.