### PR TITLE
Added "UpdateItem" mode to ShoppingBasket

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
@@ -85,7 +85,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
         Task<string> ReplaceBasketInTemplateAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string template, bool replaceUserAccountVariables = false, bool stripNotExistingVariables = true, IDictionary<string, string> userDetails = null, bool isForConfirmationEmail = false, IDictionary<string, object> additionalReplacementData = null, bool forQuery = false);
 
         Task<decimal> GetPriceAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, ShoppingBasket.PriceTypes priceType = ShoppingBasket.PriceTypes.InVatInDiscount, string lineType = "", int onlyIfVatRate = -1, bool includeDiscountGettingVat = true);
-        
+
         /// <summary>
         /// Gets the total price of a single basket line.
         /// </summary>
@@ -133,9 +133,39 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
 
         Task<List<WiserItemModel>> RemoveLinesAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, ICollection<string> itemIdsOrUniqueIds);
 
+        /// <summary>
+        /// Adds multiple items to the basket.
+        /// </summary>
+        /// <param name="shoppingBasket">The current basket.</param>
+        /// <param name="basketLines">The current basket lines.</param>
+        /// <param name="settings">The settings of the ShoppingBasket component that called this function.</param>
+        /// <param name="uniqueId">The unique ID of the item. If null or empty, the <paramref name="itemId"/> value will be used.</param>
+        /// <param name="itemId">The ID of the item that will be added.</param>
+        /// <param name="quantity">The quantity that should be added.</param>
+        /// <param name="type">The type of the item. Defaults to "product".</param>
+        /// <param name="lineDetails">Additional properties for the basket line.</param>
+        /// <returns></returns>
         Task AddLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string uniqueId = null, ulong itemId = 0UL, decimal quantity = 1M, string type = "product", IDictionary<string, string> lineDetails = null);
 
+        /// <summary>
+        /// Adds multiple items to the basket.
+        /// </summary>
+        /// <param name="shoppingBasket">The current basket.</param>
+        /// <param name="basketLines">The current basket lines.</param>
+        /// <param name="settings">The settings of the ShoppingBasket component that called this function.</param>
+        /// <param name="items">The data of the lines that will be added.</param>
+        /// <returns></returns>
         Task AddLinesAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, IList<AddToShoppingBasketModel> items);
+
+        /// <summary>
+        /// Updates an existing line in the basket.
+        /// </summary>
+        /// <param name="shoppingBasket">The current basket.</param>
+        /// <param name="basketLines">The current basket lines.</param>
+        /// <param name="settings">The settings of the ShoppingBasket component that requested this update.</param>
+        /// <param name="item">The data of the line that will be replaced. The <see cref="UpdateItemModel.LineId"/> property of this object will determine which line will be replaced.</param>
+        /// <returns></returns>
+        Task UpdateLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, UpdateItemModel item);
 
         /// <summary>
         /// Attempts to update the quantity
@@ -171,14 +201,8 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
 
         Task<IList<VatRule>> GetVatRulesAsync();
 
-        /// <summary>
-        /// Creates a <see cref="ShoppingBasketCmsSettingsModel"/> object with various settings retrieved from system objects.
-        /// </summary>
-        /// <returns>A <see cref="ShoppingBasketCmsSettingsModel"/> object.</returns>
-        Task<ShoppingBasketCmsSettingsModel> GetSettingsAsync();
-
         Task<decimal> GetVatFactorByRateAsync(WiserItemModel shoppingBasket, ShoppingBasketCmsSettingsModel settings, int vatRate);
-        
+
         /// <summary>
         /// Function returns the VAT rule by given VAT rate, depending on the actual information and requirements of the rule.
         /// </summary>
@@ -187,5 +211,11 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
         /// <param name="vatRate"></param>
         /// <returns></returns>
         Task<VatRule> GetVatRuleByRateAsync(WiserItemModel shoppingBasket, ShoppingBasketCmsSettingsModel settings, int vatRate);
+
+        /// <summary>
+        /// Creates a <see cref="ShoppingBasketCmsSettingsModel"/> object with various settings retrieved from system objects.
+        /// </summary>
+        /// <returns>A <see cref="ShoppingBasketCmsSettingsModel"/> object.</returns>
+        Task<ShoppingBasketCmsSettingsModel> GetSettingsAsync();
     }
 }

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Models/ShoppingBasketUpdateItemSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Models/ShoppingBasketUpdateItemSettingsModel.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel;
+
+namespace GeeksCoreLibrary.Components.ShoppingBasket.Models
+{
+    internal class ShoppingBasketUpdateItemSettingsModel
+    {
+        [DefaultValue("shoppingbasket")]
+        internal string CookieName { get; }
+
+        [DefaultValue(7)]
+        internal int CookieAgeInDays { get; }
+
+        [DefaultValue("basket")]
+        internal string BasketEntityName { get; }
+
+        [DefaultValue("basketline")]
+        internal string BasketLineEntityName { get; }
+
+        [DefaultValue("quantity")]
+        internal string QuantityPropertyName { get; }
+        
+        [DefaultValue("factor")]
+        internal string FactorPropertyName { get; }
+        
+        [DefaultValue("price")]
+        internal string PricePropertyName { get; }
+        
+        [DefaultValue("includesvat")]
+        internal string IncludesVatPropertyName { get; }
+        
+        [DefaultValue("vatrate")]
+        internal string VatRatePropertyName { get; }
+        
+        [DefaultValue("discount")]
+        internal string DiscountPropertyName { get; }
+
+        [DefaultValue(100)]
+        internal decimal MaxItemQuantity { get; }
+    }
+}

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Models/UpdateItemModel.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Models/UpdateItemModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace GeeksCoreLibrary.Components.ShoppingBasket.Models
+{
+    public class UpdateItemModel
+    {
+        public ulong LineId { get; set; }
+
+        public string UniqueId { get; set; }
+
+        public IDictionary<string, string> LineDetails { get; set; }
+    }
+}

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
@@ -153,6 +153,12 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         {
             await shoppingBasketsService.AddLinesAsync(shoppingBasket, basketLines, settings, items);
         }
+        
+        /// <inheritdoc />
+        public async Task UpdateLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, UpdateItemModel item)
+        {
+            await shoppingBasketsService.UpdateLineAsync(shoppingBasket, basketLines, settings, item);
+        }
 
         /// <inheritdoc />
         public async Task UpdateBasketLineQuantityAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string itemIdOrUniqueId, decimal quantity)

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -20,7 +20,6 @@ using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Enums;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
-using LazyCache;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
@@ -39,13 +38,12 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         private readonly IAccountsService accountsService;
         private readonly ITemplatesService templatesService;
         private readonly IStringReplacementsService stringReplacementsService;
-        private readonly IAppCache cache;
         private readonly ITempDataDictionaryFactory tempDataDictionaryFactory;
         private readonly ILanguagesService languagesService;
 
         private SortedList<int, decimal> vatFactorsByRate;
 
-        public ShoppingBasketsService(IOptions<GclSettings> gclSettings, ILogger<ShoppingBasketsService> logger, IDatabaseConnection databaseConnection, IHttpContextAccessor httpContextAccessor, IObjectsService objectsService, IWiserItemsService wiserItemsService, IAccountsService accountsService, ITemplatesService templatesService, IStringReplacementsService stringReplacementsService, IAppCache cache, ITempDataDictionaryFactory tempDataDictionaryFactory, ILanguagesService languagesService)
+        public ShoppingBasketsService(IOptions<GclSettings> gclSettings, ILogger<ShoppingBasketsService> logger, IDatabaseConnection databaseConnection, IHttpContextAccessor httpContextAccessor, IObjectsService objectsService, IWiserItemsService wiserItemsService, IAccountsService accountsService, ITemplatesService templatesService, IStringReplacementsService stringReplacementsService, ITempDataDictionaryFactory tempDataDictionaryFactory, ILanguagesService languagesService)
         {
             this.gclSettings = gclSettings.Value;
             this.logger = logger;
@@ -56,7 +54,6 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             this.accountsService = accountsService;
             this.templatesService = templatesService;
             this.stringReplacementsService = stringReplacementsService;
-            this.cache = cache;
             this.tempDataDictionaryFactory = tempDataDictionaryFactory;
             this.languagesService = languagesService;
         }
@@ -1548,17 +1545,13 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         /// <inheritdoc />
         public async Task AddLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string uniqueId = null, ulong itemId = 0UL, decimal quantity = 1M, string type = "product", IDictionary<string, string> lineDetails = null)
         {
-            var languageCode = HttpContextHelpers.GetRequestValue(httpContextAccessor.HttpContext, "langCode") ?? "";
-
             if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
             {
                 var sqlQuery = settings.SqlQuery;
+                sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
                 sqlQuery = sqlQuery.Replace("{itemid}", itemId.ToString());
                 sqlQuery = sqlQuery.Replace("{quantity}", quantity.ToString(CultureInfo.InvariantCulture));
-                sqlQuery = sqlQuery.Replace("{language_code}", languageCode);
-
-                sqlQuery = stringReplacementsService.DoHttpRequestReplacements(sqlQuery, true);
-                sqlQuery = stringReplacementsService.DoSessionReplacements(sqlQuery, true);
+                sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
 
                 var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
                 if (getItemDetailsResult.Rows.Count > 0)
@@ -1573,7 +1566,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                 }
             }
 
-            var addItemLine = AddLineInternal(basketLines, uniqueId, itemId, quantity, type, lineDetails);
+            var addItemLine = AddLineInternal(basketLines, settings, uniqueId, itemId, quantity, type, lineDetails);
 
             // Write changes to database.
             await SaveAsync(shoppingBasket, basketLines, settings);
@@ -1612,21 +1605,16 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                 return;
             }
 
-            var languageCode = HttpContextHelpers.GetRequestValue(httpContextAccessor.HttpContext, "langCode") ?? "";
-
             var createLinksFor = new List<WiserItemModel>();
             foreach (var item in items)
             {
                 if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
                 {
                     var sqlQuery = settings.SqlQuery;
+                    sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
                     sqlQuery = sqlQuery.Replace("{itemid}", item.ItemId.ToString());
                     sqlQuery = sqlQuery.Replace("{quantity}", item.Quantity.ToString(CultureInfo.InvariantCulture));
-                    sqlQuery = sqlQuery.Replace("{language_code}", "?languageCode");
-                    databaseConnection.AddParameter("languageCode", languageCode);
-
-                    sqlQuery = stringReplacementsService.DoHttpRequestReplacements(sqlQuery, true);
-                    sqlQuery = stringReplacementsService.DoSessionReplacements(sqlQuery, true);
+                    sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
 
                     var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
                     if (getItemDetailsResult.Rows.Count > 0)
@@ -1641,7 +1629,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                     }
                 }
 
-                var addItemLine = AddLineInternal(basketLines, item.UniqueId, item.ItemId, item.Quantity, item.Type, item.LineDetails);
+                var addItemLine = AddLineInternal(basketLines, settings, item.UniqueId, item.ItemId, item.Quantity, item.Type, item.LineDetails);
                 createLinksFor.Add(addItemLine);
             }
 
@@ -1678,8 +1666,71 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                 await LoadAsync(settings, shoppingBasket.Id);
             }
 
-            // Recalculate sendcosts, coupons etc. after getting the extra fields (price can be selected with extra fields query).
+            // Recalculate shipping costs, coupons etc. after getting the extra fields (price can be selected with extra fields query).
             await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, items.First().Type);
+        }
+
+        /// <inheritdoc />
+        public async Task UpdateLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, UpdateItemModel item)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            // Find existing basket line.
+            var lineToUpdate = basketLines.Find(l => l.Id == item.LineId);
+            if (lineToUpdate == null)
+            {
+                return;
+            }
+
+            // Enrich the line details if a query is present.
+            if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
+            {
+                var sqlQuery = settings.SqlQuery;
+                sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
+                sqlQuery = sqlQuery.Replace("{itemid}", lineToUpdate.GetDetailValue<int>("connecteditemid").ToString());
+                sqlQuery = sqlQuery.Replace("{quantity}", lineToUpdate.GetDetailValue<decimal>(settings.QuantityPropertyName).ToString(CultureInfo.InvariantCulture));
+                sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
+
+                var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
+                if (getItemDetailsResult.Rows.Count > 0)
+                {
+                    var details = getItemDetailsResult.Columns.Cast<DataColumn>().Where(dataColumn => dataColumn.ColumnName != "id").ToDictionary(dataColumn => dataColumn.ColumnName, dataColumn => Convert.ToString(getItemDetailsResult.Rows[0][dataColumn]));
+
+                    item.LineDetails ??= new Dictionary<string, string>();
+                    foreach (var (key, value) in details)
+                    {
+                        item.LineDetails[key] = value;
+                    }
+                }
+            }
+
+            // Unique ID can be updated if it was provided in the JSON.
+            if (!String.IsNullOrWhiteSpace(item.UniqueId))
+            {
+                lineToUpdate.SetDetail("uniqueid", item.UniqueId);
+            }
+
+            if (item.LineDetails != null)
+            {
+                foreach (var (key, value) in item.LineDetails.Where(ld => !ld.Key.InList("uniqueid", "connecteditemid", "quantity", "type")))
+                {
+                    lineToUpdate.SetDetail(key, value);
+                }
+            }
+
+            // Write changes to database.
+            await SaveAsync(shoppingBasket, basketLines, settings);
+
+            if (!String.IsNullOrEmpty(settings.ExtraMainFieldsQuery) || !String.IsNullOrEmpty(settings.ExtraLineFieldsQuery))
+            {
+                await LoadAsync(settings, shoppingBasket.Id);
+            }
+
+            // Recalculate sendcosts, coupons etc. after getting the extra fields (price can be selected with extra fields query).
+            await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, lineToUpdate.GetDetailValue("type"));
         }
 
         /// <inheritdoc />
@@ -1838,26 +1889,6 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             }
 
             return vatRules;
-        }
-
-        /// <inheritdoc />
-        public async Task<ShoppingBasketCmsSettingsModel> GetSettingsAsync()
-        {
-            return new()
-            {
-                CookieName = await objectsService.FindSystemObjectByDomainNameAsync("BASKET_cookieName"),
-                B2BPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_B2bPropertyName"),
-                CountryPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_CountryPropertyName"),
-                DiscountPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_DiscountPropertyName"),
-                FactorPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_FactorPropertyName"),
-                IncludesVatPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_IncludesVatPropertyName"),
-                PricePropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_PricePropertyName"),
-                QuantityPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_QuantityProductDataProperty"),
-                VatRatePropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_VatrateProductDataProperty"),
-                BasketEntityName = await objectsService.FindSystemObjectByDomainNameAsync("basketEntityType"),
-                BasketLineEntityName = await objectsService.FindSystemObjectByDomainNameAsync("basketLineEntityType"),
-                HandleRequest = true
-            };
         }
 
         /// <inheritdoc />
@@ -2021,6 +2052,26 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             }
 
             return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<ShoppingBasketCmsSettingsModel> GetSettingsAsync()
+        {
+            return new()
+            {
+                CookieName = await objectsService.FindSystemObjectByDomainNameAsync("BASKET_cookieName"),
+                B2BPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_B2bPropertyName"),
+                CountryPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_CountryPropertyName"),
+                DiscountPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_DiscountPropertyName"),
+                FactorPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_FactorPropertyName"),
+                IncludesVatPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_IncludesVatPropertyName"),
+                PricePropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_PricePropertyName"),
+                QuantityPropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_QuantityProductDataProperty"),
+                VatRatePropertyName = await GetCheckoutObjectValueAsync("CHECKOUT_VatrateProductDataProperty"),
+                BasketEntityName = await objectsService.FindSystemObjectByDomainNameAsync("basketEntityType"),
+                BasketLineEntityName = await objectsService.FindSystemObjectByDomainNameAsync("basketLineEntityType"),
+                HandleRequest = true
+            };
         }
 
         #region Private functions (helper functions)
@@ -2529,17 +2580,17 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             return domainList.Count == 0 || domainList.Contains(HttpContextHelpers.GetHostName(httpContextAccessor.HttpContext));
         }
 
-
         /// <summary>
         /// Internal function used to add or update a line. This function does not save changes or recalculate values.
         /// </summary>
         /// <param name="basketLines"></param>
+        /// <param name="settings"></param>
         /// <param name="uniqueId"></param>
         /// <param name="itemId"></param>
         /// <param name="quantity"></param>
         /// <param name="type"></param>
         /// <param name="lineDetails"></param>
-        private static WiserItemModel AddLineInternal(ICollection<WiserItemModel> basketLines, string uniqueId = null, ulong itemId = 0UL, decimal quantity = 1M, string type = "product", IDictionary<string, string> lineDetails = null)
+        private static WiserItemModel AddLineInternal(ICollection<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string uniqueId = null, ulong itemId = 0UL, decimal quantity = 1M, string type = "product", IDictionary<string, string> lineDetails = null)
         {
             if (String.IsNullOrEmpty(uniqueId))
             {
@@ -2552,17 +2603,17 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             var existingLine = basketLines.FirstOrDefault(basketLine => basketLine.ContainsDetail("uniqueid") && basketLine.GetDetailValue("uniqueid") == uniqueId);
             if (existingLine != null)
             {
-                existingLine.SetDetail("quantity", (existingLine.GetDetailValue<decimal>("quantity") + quantity).ToString(CultureInfo.InvariantCulture));
+                existingLine.SetDetail(settings.QuantityPropertyName, (existingLine.GetDetailValue<decimal>(settings.QuantityPropertyName) + quantity).ToString(CultureInfo.InvariantCulture));
 
                 if (lineDetails != null)
                 {
-                    foreach (var lineDetail in lineDetails)
+                    foreach (var (key, value) in lineDetails)
                     {
-                        existingLine.SetDetail(lineDetail.Key, lineDetail.Value);
+                        existingLine.SetDetail(key, value);
                     }
-
-                    line = existingLine;
                 }
+
+                line = existingLine;
             }
 
             if (line != null)
@@ -2574,10 +2625,10 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
             line = new WiserItemModel();
             line.SetDetail("uniqueid", uniqueId);
             line.SetDetail("connecteditemid", itemId.ToString());
-            line.SetDetail("quantity", quantity.ToString(CultureInfo.InvariantCulture));
+            line.SetDetail(settings.QuantityPropertyName, quantity.ToString(CultureInfo.InvariantCulture));
             if (lineDetails != null)
             {
-                foreach (var (key, value) in lineDetails)
+                foreach (var (key, value) in lineDetails.Where(ld => !ld.Key.InList("uniqueid", "connecteditemid", "type")))
                 {
                     line.SetDetail(key, value);
                 }


### PR DESCRIPTION
A new component mode called "UpdateItem" has been added to the ShoppingBasket component. This mode can update an existing item in the basket, capable of overwriting almost all properties. Only "connecteditemid", "type" and "quantity" cannot be updated.