### PR TITLE
Fixed some issues with JS and (S)CSS templates

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/JavascriptController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/JavascriptController.cs
@@ -24,7 +24,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
         [HttpGet]
         public async Task<IActionResult> GeneralJavascript()
         {
-            var lastChangedDate = await templatesService.GetGeneralTemplateLastChangedDateAsync(TemplateTypes.Css) ?? DateTime.Now;
+            var lastChangedDate = await templatesService.GetGeneralTemplateLastChangedDateAsync(TemplateTypes.Js) ?? DateTime.Now;
             if (!this.IsModified(lastChangedDate))
             {
                 return StatusCode((int) HttpStatusCode.NotModified);

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -289,8 +289,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         public async Task<TemplateResponse> GetGeneralTemplateValueAsync(TemplateTypes templateType)
         {
             var templateTypeQueryPart = templateType is TemplateTypes.Css or TemplateTypes.Scss 
-                ? $"t.templatetype = '{templateType.ToString().ToMySqlSafeValue(false)}'"
-                : $"t.templatetype IN ('{TemplateTypes.Css.ToString().ToMySqlSafeValue(false)}', '{TemplateTypes.Scss.ToString().ToMySqlSafeValue(false)}')";
+                ? $"t.templatetype IN ('{TemplateTypes.Css.ToString().ToMySqlSafeValue(false)}', '{TemplateTypes.Scss.ToString().ToMySqlSafeValue(false)}')"
+                : $"t.templatetype = '{templateType.ToString().ToMySqlSafeValue(false)}'";
 
             var joinPart = gclSettings.Environment switch
             {


### PR DESCRIPTION
JavaScript templates checked for the last-change date of CSS templates, and the Legacy templates service always served CSS and SCSS templates, except for CSS requests.