### PR TITLE
Fixed no-image issue in image templating

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -696,8 +696,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
 
                 if (dataTable.Rows.Count == 0)
                 {
-                    var noImageFilePath = Path.Combine("/img", "noimg.png");
-                    input = string.Format("<img src=\"{0}\" />", noImageFilePath);
+                    input = input.ReplaceCaseInsensitive(m.Value, $"<img src=\"/img/noimg.png\" />");
                     continue;
                 }
 


### PR DESCRIPTION
This fixes an issue when the image templating couldn't find an image, that the no-image result would replace the entire template instead of just the image templating variable.