### PR TITLE
Language code through query string support

### DIFF
--- a/GeeksCoreLibrary/Modules/Languages/Models/Constants.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Models/Constants.cs
@@ -6,5 +6,6 @@
         public const string LegacyLanguageCodeSessionKey = "MlJclLanguageCode";
         public const string LanguageCodeCacheKey = "GCLLanguageCode";
         public const string LanguageCodeHeaderKey = "X-GCL-LanguageCode";
+        public const string LanguageCodeQueryStringKey = "GCLLanguageCode";
     }
 }

--- a/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
@@ -124,6 +124,14 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
         /// <inheritdoc />
         public async Task<string> GetLanguageCodeAsync()
         {
+            // Check if it should be overriden through a query string.
+            if (httpContextAccessor.HttpContext != null && httpContextAccessor.HttpContext.Request.Query.ContainsKey(Constants.LanguageCodeQueryStringKey) && !String.IsNullOrWhiteSpace(httpContextAccessor.HttpContext.Request.Query[Constants.LanguageCodeQueryStringKey]))
+            {
+                CurrentLanguageCode = httpContextAccessor.HttpContext.Request.Query[Constants.LanguageCodeQueryStringKey];
+                logger.LogDebug($"LanguageCode determined through query string: {CurrentLanguageCode}");
+                return CurrentLanguageCode;
+            }
+
             var cacheName = new StringBuilder(Constants.LanguageCodeCacheKey);
 
             if (gclSettings.MultiLanguageBasedOnUrlSegments)

--- a/GeeksCoreLibrary/Modules/Languages/Services/LanguagesService.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Services/LanguagesService.cs
@@ -93,7 +93,7 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
             // Check if it should be overriden through a query string.
             if (httpContextAccessor.HttpContext != null && httpContextAccessor.HttpContext.Request.Query.ContainsKey(Constants.LanguageCodeQueryStringKey) && !String.IsNullOrWhiteSpace(httpContextAccessor.HttpContext.Request.Query[Constants.LanguageCodeQueryStringKey]))
             {
-                CurrentLanguageCode = httpContextAccessor.HttpContext.Request.Headers[Constants.LanguageCodeQueryStringKey];
+                CurrentLanguageCode = httpContextAccessor.HttpContext.Request.Query[Constants.LanguageCodeQueryStringKey];
                 logger.LogDebug($"LanguageCode determined through query string: {CurrentLanguageCode}");
                 return CurrentLanguageCode;
             }

--- a/GeeksCoreLibrary/Modules/Languages/Services/LanguagesService.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Services/LanguagesService.cs
@@ -90,6 +90,14 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
         /// <inheritdoc />
         public async Task<string> GetLanguageCodeAsync()
         {
+            // Check if it should be overriden through a query string.
+            if (httpContextAccessor.HttpContext != null && httpContextAccessor.HttpContext.Request.Query.ContainsKey(Constants.LanguageCodeQueryStringKey) && !String.IsNullOrWhiteSpace(httpContextAccessor.HttpContext.Request.Query[Constants.LanguageCodeQueryStringKey]))
+            {
+                CurrentLanguageCode = httpContextAccessor.HttpContext.Request.Headers[Constants.LanguageCodeQueryStringKey];
+                logger.LogDebug($"LanguageCode determined through query string: {CurrentLanguageCode}");
+                return CurrentLanguageCode;
+            }
+
             // First check for a system object.
             var languageCode = await objectsService.FindSystemObjectByDomainNameAsync("W2LANGUAGES_LanguageCode");
             if (!String.IsNullOrWhiteSpace(languageCode))
@@ -102,7 +110,7 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
             if (httpContextAccessor.HttpContext != null && httpContextAccessor.HttpContext.Request.Headers.ContainsKey(Constants.LanguageCodeHeaderKey) && !String.IsNullOrWhiteSpace(httpContextAccessor.HttpContext.Request.Headers[Constants.LanguageCodeHeaderKey]))
             {
                 CurrentLanguageCode = httpContextAccessor.HttpContext.Request.Headers[Constants.LanguageCodeHeaderKey];
-                logger.LogDebug($"LanguageCode determined through HTTP header: {languageCode}");
+                logger.LogDebug($"LanguageCode determined through HTTP header: {CurrentLanguageCode}");
                 return CurrentLanguageCode;
             }
 


### PR DESCRIPTION
The language code can now be set through a query string with the name 'GCLLanguageCode'. This value will not be cached, and is only valid for that single request.