### PR TITLE
slider uses numeric values, when enclosed with quotes the query yields no results

### DIFF
--- a/GeeksCoreLibrary/Components/Filter/Services/FiltersService.cs
+++ b/GeeksCoreLibrary/Components/Filter/Services/FiltersService.cs
@@ -786,7 +786,7 @@ namespace GeeksCoreLibrary.Components.Filter.Services
                     }
                     else
                     {
-                        output = $"f{filterCounter}.filtergroup = {filterGroup.GetParamKey().ToMySqlSafeValue(true)} AND f{filterCounter}.filtervalue >= {filterValue.Split('-')[0].ToMySqlSafeValue(true)} AND f{filterCounter}.filtervalue <= {filterValue.Split('-')[1].ToMySqlSafeValue(true)}";
+                        output = $"f{filterCounter}.filtergroup = {filterGroup.GetParamKey().ToMySqlSafeValue(true)} AND f{filterCounter}.filtervalue >= {filterValue.Split('-')[0].ToMySqlSafeValue(false)} AND f{filterCounter}.filtervalue <= {filterValue.Split('-')[1].ToMySqlSafeValue(false)}";
                     }
                 }
                 else


### PR DESCRIPTION
er werd gebruik gemaakt van ToMySqlSafeValue(true), in de query zelf zag ik dat de vergelijking met de filterwaarde als onderstaande gedaan werd
0.filtervalue >= '2' AND f0.filtervalue <= '120' dit gaat niet werken voor een varchar kolom, dus dan wordt het '120'+0 of de quotes weghalen was mijn beredenering. Dit gaat op andere plekken op dezelfde manier verkeerd. ik heb dit nu alleen voor happy deco werkend gemaakt.