### PR TITLE
Fixed some shopping basket issues

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
@@ -30,7 +30,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace GeeksCoreLibrary.Components.ShoppingBasket
 {
@@ -40,7 +39,6 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket
     )]
     public class ShoppingBasket : CmsComponent<ShoppingBasketCmsSettingsModel, ShoppingBasket.ComponentModes>
     {
-        private readonly GclSettings gclSettings;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly IShoppingBasketsService shoppingBasketsService;
         private readonly IWebHostEnvironment webHostEnvironment;
@@ -209,9 +207,8 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket
         }
 
         [ActivatorUtilitiesConstructor]
-        public ShoppingBasket(IOptions<GclSettings> gclSettings, ILogger<ShoppingBasket> logger, IHttpContextAccessor httpContextAccessor, IDatabaseConnection databaseConnection, IShoppingBasketsService shoppingBasketsService, ITemplatesService templatesService, IWebHostEnvironment webHostEnvironment, IStringReplacementsService stringReplacementsService, IObjectsService objectsService, IAccountsService accountsService, IHtmlToPdfConverterService htmlToPdfConverterService, ICommunicationsService communicationsService)
+        public ShoppingBasket(ILogger<ShoppingBasket> logger, IHttpContextAccessor httpContextAccessor, IDatabaseConnection databaseConnection, IShoppingBasketsService shoppingBasketsService, ITemplatesService templatesService, IWebHostEnvironment webHostEnvironment, IStringReplacementsService stringReplacementsService, IObjectsService objectsService, IAccountsService accountsService, IHtmlToPdfConverterService htmlToPdfConverterService, ICommunicationsService communicationsService)
         {
-            this.gclSettings = gclSettings.Value;
             this.httpContextAccessor = httpContextAccessor;
             this.shoppingBasketsService = shoppingBasketsService;
             this.webHostEnvironment = webHostEnvironment;
@@ -403,13 +400,6 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket
             Lines = basketLines;
             basketLineValidityMessage = validityMessage;
             basketLineStockActionMessage = stockActionMessage;
-
-            // Check if we need to call a specific method and then do so. Skip everything else, because we don't want to render the entire component then.
-            if (!String.IsNullOrWhiteSpace(callMethod))
-            {
-                TempData["InvokeMethodResult"] = await InvokeMethodAsync(callMethod);
-                return new HtmlString("");
-            }
 
             var resultHtml = new StringBuilder();
             switch (Settings.ComponentMode)

--- a/GeeksCoreLibrary/Core/Cms/CmsComponent.cs
+++ b/GeeksCoreLibrary/Core/Cms/CmsComponent.cs
@@ -101,10 +101,16 @@ namespace GeeksCoreLibrary.Core.Cms
 
             var parameterValues = new List<object>();
             var methodParameters = method.GetParameters();
-            if (HttpContext.Request.ContentType == null || !HttpContext.Request.ContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
+            if (!HttpContext.Request.ContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
             {
                 foreach (var parameter in methodParameters)
                 {
+                    if (parameter.IsOptional && !HttpContextHelpers.RequestContainsKey(HttpContext, parameter.Name))
+                    {
+                        parameterValues.Add(parameter.DefaultValue);
+                        continue;
+                    }
+
                     parameterValues.Add(Convert.ChangeType(HttpContextHelpers.GetRequestValue(HttpContext, parameter.Name), parameter.ParameterType));
                 }
             }
@@ -122,6 +128,12 @@ namespace GeeksCoreLibrary.Core.Cms
                 foreach (var parameter in methodParameters)
                 {
                     var (key, value) = contentObject.FirstOrDefault(p => p.Key.Equals(parameter.Name, StringComparison.OrdinalIgnoreCase));
+                    if (parameter.IsOptional && !contentObject.ContainsKey(key))
+                    {
+                        parameterValues.Add(parameter.DefaultValue);
+                        continue;
+                    }
+
                     if (String.IsNullOrWhiteSpace(key))
                     {
                         continue;

--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -149,6 +149,30 @@ namespace GeeksCoreLibrary.Core.Helpers
         }
 
         /// <summary>
+        /// Checks if the specified key is present in <see cref="P:HttpContext.Request.Query" />, <see cref="P:HttpContext.Request.Form" />, <see cref="P:HttpContext.Request.Cookies" />, or <see cref="P:HttpContext.Request.ServerVariables" /> collection.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
+        /// <param name="key">The name of the collection member to get.</param>
+        /// <param name="includeServerVariables">Optional: Whether the server variables collection should also be checked. Default is <see langword="true"/>.</param>
+        /// <returns><see langword="true"/> if one of the collections (<see cref="P:HttpContext.Request.Query" />, <see cref="P:HttpContext.Request.Form" />, <see cref="P:HttpContext.Request.Cookies" />, and <see cref="P:HttpContext.Request.ServerVariables" />) contains an element with the key; otherwise, <see langword="false"/>.</returns>
+        public static bool RequestContainsKey(HttpContext httpContext, string key, bool includeServerVariables = true)
+        {
+            if (httpContext?.Request == null)
+            {
+                return false;
+            }
+            if (String.IsNullOrEmpty(key))
+            {
+                return false;
+            }
+
+            return httpContext.Request.Query.ContainsKey(key)
+                   || (httpContext.Request.HasFormContentType && httpContext.Request.Form.ContainsKey(key))
+                   || httpContext.Request.Cookies.ContainsKey(key)
+                   || (includeServerVariables && httpContext.GetServerVariable(key) != null);
+        }
+
+        /// <summary>
         /// Adds a new cookie to the response.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>


### PR DESCRIPTION
- After removing the last product from a basket, all non-product lines are also removed (coupons, shipping costs, etc.).
- Reloading the basket due to having an ExtraMainFieldsQuery or ExtraLineFieldsQuery now works.
- Invoking a method using callMethod will now add default values for optional parameters if they're absent.
- ShoppingBasket no longer supports callMethod. The forcedComponentMode functionality should be used instead.