### PR TITLE
Login required support for templates

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -258,7 +258,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
             templateContent = await templatesService.HandleIncludesAsync(templateContent);
             templateContent = await templatesService.ReplaceAllDynamicContentAsync(templateContent);
             templateContent = await dataSelectorsService.ReplaceAllDataSelectorsAsync(templateContent);
-            templateContent = await wiserItemsService.ReplaceAllEntityBlocksAsync(template);
+            templateContent = await wiserItemsService.ReplaceAllEntityBlocksAsync(templateContent);
 
             // Parse the html to get the partial template part.
             var htmlDocument = new HtmlDocument();

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -113,6 +113,16 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
                 template.ReturnNotFoundWhenPreLoadQueryHasNoData = Convert.ToInt16(await reader.GetFieldValueAsync<object>("return_not_found_when_pre_load_query_has_no_data")) > 0;
             }
 
+            if (reader.HasColumn("login_required"))
+            {
+                template.LoginRequired = Convert.ToBoolean(await reader.GetFieldValueAsync<object>("login_required"));
+            }
+
+            if (reader.HasColumn("login_redirect_url"))
+            {
+                template.LoginRedirectUrl = reader.GetStringHandleNull("login_redirect_url");
+            }
+
             if (!isQuery)
             {
                 return template;

--- a/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
@@ -127,5 +127,15 @@ namespace GeeksCoreLibrary.Modules.Templates.Models
         /// Gets or sets whether we should return an HTTP 404 result when the pre load query returns 0 rows.
         /// </summary>
         public bool ReturnNotFoundWhenPreLoadQueryHasNoData { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether it's required for a user to be logged when trying to access the template.
+        /// </summary>
+        public bool LoginRequired { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL the user should be sent to if <see cref="LoginRequired"/> is <see langword="true"/>, but no user is logged in.
+        /// </summary>
+        public string LoginRedirectUrl { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
@@ -139,6 +139,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 },
                 cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Templates));
 
+            // Check if a login is required (only for HTML and query templates.
+            if (template.Type.InList(TemplateTypes.Html, TemplateTypes.Query) && template.LoginRequired && template.Id == 0)
+            {
+                // If the template ID is 0, but "LoginRequired" is true, it means no user is logged in.
+                return template;
+            }
+
             if (!includeContent)
             {
                 return template;

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Enums;
+using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
@@ -116,6 +117,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultTemplateCacheDuration;
                     return await templatesService.GetTemplateAsync(id, name, type, parentId, parentName, !foundInOutputCache);
                 }, cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Templates));
+
+            // Check if a login is required (only for HTML and query templates.
+            if (template.Type.InList(TemplateTypes.Html, TemplateTypes.Query) && template.LoginRequired && template.Id == 0)
+            {
+                // If the template ID is 0, but "LoginRequired" is true, it means no user is logged in.
+                return template;
+            }
 
             if (!includeContent)
             {

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -1,19 +1,4 @@
-﻿using GeeksCoreLibrary.Core.Enums;
-using GeeksCoreLibrary.Core.Extensions;
-using GeeksCoreLibrary.Core.Models;
-using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
-using GeeksCoreLibrary.Modules.Templates.Enums;
-using GeeksCoreLibrary.Modules.Templates.Extensions;
-using GeeksCoreLibrary.Modules.Templates.Interfaces;
-using GeeksCoreLibrary.Modules.Templates.Models;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -23,14 +8,30 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using GeeksCoreLibrary.Components.Account.Interfaces;
 using GeeksCoreLibrary.Components.Filter.Interfaces;
+using GeeksCoreLibrary.Core.Enums;
+using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
+using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
+using GeeksCoreLibrary.Modules.Templates.Enums;
+using GeeksCoreLibrary.Modules.Templates.Extensions;
+using GeeksCoreLibrary.Modules.Templates.Interfaces;
+using GeeksCoreLibrary.Modules.Templates.Models;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Template = GeeksCoreLibrary.Modules.Templates.Models.Template;
 
@@ -54,6 +55,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         private readonly IObjectsService objectsService;
         private readonly ILanguagesService languagesService;
         private readonly IFiltersService filtersService;
+        private readonly IAccountsService accountsService;
 
         /// <summary>
         /// Initializes a new instance of <see cref="LegacyTemplatesService"/>.
@@ -69,7 +71,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             IWebHostEnvironment webHostEnvironment,
             IFiltersService filtersService,
             IObjectsService objectsService,
-            ILanguagesService languagesService)
+            ILanguagesService languagesService,
+            IAccountsService accountsService)
         {
             this.gclSettings = gclSettings.Value;
             this.logger = logger;
@@ -83,6 +86,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             this.filtersService = filtersService;
             this.objectsService = objectsService;
             this.languagesService = languagesService;
+            this.accountsService = accountsService;
         }
 
         /// <inheritdoc />
@@ -152,7 +156,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                             t.groupingKeyColumnName AS grouping_key_column_name,
                             t.groupingValueColumnName AS grouping_value_column_name,
                             t.groupingkey AS grouping_key,
-                            t.groupingprefix AS grouping_prefix
+                            t.groupingprefix AS grouping_prefix,
+                            t.issecure AS login_required
                         FROM easy_items i 
                         JOIN easy_templates t ON i.id=t.itemid
                         {joinPart}
@@ -171,7 +176,29 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             await using var reader = await databaseConnection.GetReaderAsync(query);
             var result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
 
-            return result;
+            // Check login requirement.
+            if (!result.Type.InList(TemplateTypes.Html, TemplateTypes.Query) || !result.LoginRequired)
+            {
+                // No login required; return template.
+                return result;
+            }
+
+            var emptyTemplate = new Template
+            {
+                Type = result.Type,
+                LoginRequired = true,
+                LoginRedirectUrl = await objectsService.FindSystemObjectByDomainNameAsync("defaultloginurl", "/")
+            };
+
+            if (httpContextAccessor.HttpContext == null)
+            {
+                // No context available; return empty template without doing a login check.
+                return emptyTemplate;
+            }
+
+            // Check current login.
+            var userData = await accountsService.GetUserDataFromCookieAsync();
+            return userData is { UserId: > 0 } ? result : emptyTemplate;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The "login required" option for templates is now supported. The templates service will return an empty template if a login is required, but no login is found (or if no HttpContext is available). The templates controller will redirect the user to whatever is set in the "login redirect URL" field, or return a 401 status (Unauthorized) if no redirect URL is set. Query and partial templates always return a 401 status if a login is required and no active login is found.