### PR TITLE
Limit template includes to own type

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -146,7 +146,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                 contentToWrite.Append(await pagesService.GetGlobalFooter(url, javascriptTemplates, cssTemplates));
             }
 
-            var newBodyHtml = await templatesService.DoReplacesAsync(contentToWrite.ToString());
+            var newBodyHtml = await templatesService.DoReplacesAsync(contentToWrite.ToString(), templateType: contentTemplate.Type);
             newBodyHtml = await dataSelectorsService.ReplaceAllDataSelectorsAsync(newBodyHtml);
             newBodyHtml = await wiserItemsService.ReplaceAllEntityBlocksAsync(newBodyHtml);
 
@@ -255,7 +255,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
             }
 
             var templateContent = template.Content;
-            templateContent = await templatesService.HandleIncludesAsync(templateContent);
+            templateContent = await templatesService.HandleIncludesAsync(templateContent, templateType: TemplateTypes.Html);
             templateContent = await templatesService.ReplaceAllDynamicContentAsync(templateContent);
             templateContent = await dataSelectorsService.ReplaceAllDataSelectorsAsync(templateContent);
             templateContent = await wiserItemsService.ReplaceAllEntityBlocksAsync(templateContent);

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -1,17 +1,17 @@
-﻿using GeeksCoreLibrary.Core.Extensions;
-using GeeksCoreLibrary.Modules.Templates.Enums;
-using GeeksCoreLibrary.Modules.Templates.Models;
-using System;
+﻿using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
+using GeeksCoreLibrary.Core.Extensions;
+using GeeksCoreLibrary.Modules.Templates.Enums;
+using GeeksCoreLibrary.Modules.Templates.Models;
 
 namespace GeeksCoreLibrary.Modules.Templates.Extensions
 {
     public static class DbDataReaderExtensions
     {
-        public static async Task<Template> ToTemplateModelAsync(this DbDataReader reader, TemplateTypes type = TemplateTypes.Html)
+        public static async Task<Template> ToTemplateModelAsync(this DbDataReader reader, TemplateTypes? type = null)
         {
             if (!Enum.TryParse(typeof(TemplateTypes), reader.GetStringHandleNull("template_type"), true, out var templateType))
             {
@@ -31,7 +31,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
                 cachingMode = TemplateCachingModes.NoCaching;
             }
 
-            var isQuery = type == TemplateTypes.Query || templateType is TemplateTypes.Query;
+            var isQuery = type is TemplateTypes.Query || templateType is TemplateTypes.Query;
             var template = isQuery ? new QueryTemplate() : new Template();
             template.Id = await reader.IsDBNullAsync("template_id") ? 0 : await reader.GetFieldValueAsync<int>("template_id");
             template.ParentId = await reader.IsDBNullAsync("parent_id") ? 0 : await reader.GetFieldValueAsync<int>("parent_id");
@@ -48,7 +48,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
             template.CachingMinutes = await reader.IsDBNullAsync("cache_minutes") ? 0 : await reader.GetFieldValueAsync<int>("cache_minutes");
             template.CachingLocation = !reader.HasColumn("caching_location") || await reader.IsDBNullAsync("caching_location") ? TemplateCachingLocations.InMemory : (TemplateCachingLocations)await reader.GetFieldValueAsync<int>("caching_location");
             template.CachingRegex = reader.GetStringHandleNull("cache_regex");
-            
+
             if (!await reader.IsDBNullAsync("changed_on"))
             {
                 template.LastChanged = await reader.GetFieldValueAsync<DateTime>("changed_on");
@@ -82,32 +82,32 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
             var cssTemplates = reader.GetStringHandleNull("css_templates");
             if (!String.IsNullOrWhiteSpace(cssTemplates))
             {
-                template.CssTemplates = cssTemplates.Split(new [] {';', ',' }, StringSplitOptions.RemoveEmptyEntries).Select(Int32.Parse).Where(id => id > 0).ToList();
+                template.CssTemplates = cssTemplates.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries).Select(Int32.Parse).Where(id => id > 0).ToList();
             }
 
             var javascriptTemplates = reader.GetStringHandleNull("javascript_templates");
             if (!String.IsNullOrWhiteSpace(javascriptTemplates))
             {
-                template.JavascriptTemplates = javascriptTemplates.Split(new [] {';', ',' }, StringSplitOptions.RemoveEmptyEntries).Select(Int32.Parse).Where(id => id > 0).ToList();
+                template.JavascriptTemplates = javascriptTemplates.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries).Select(Int32.Parse).Where(id => id > 0).ToList();
             }
 
             var externalFiles = reader.GetStringHandleNull("external_files");
             if (!String.IsNullOrWhiteSpace(externalFiles))
             {
-                template.ExternalFiles = externalFiles.Split(new [] {';', ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                template.ExternalFiles = externalFiles.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             }
 
             var cdnFiles = reader.HasColumn("wiser_cdn_files") ? reader.GetStringHandleNull("wiser_cdn_files") : null;
             if (!String.IsNullOrWhiteSpace(cdnFiles))
             {
-                template.WiserCdnFiles = cdnFiles.Split(new [] {';', ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                template.WiserCdnFiles = cdnFiles.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
             }
-            
+
             if (reader.HasColumn("pre_load_query"))
             {
                 template.PreLoadQuery = reader.GetStringHandleNull("pre_load_query");
             }
-            
+
             if (reader.HasColumn("return_not_found_when_pre_load_query_has_no_data"))
             {
                 template.ReturnNotFoundWhenPreLoadQueryHasNoData = Convert.ToInt16(await reader.GetFieldValueAsync<object>("return_not_found_when_pre_load_query_has_no_data")) > 0;

--- a/GeeksCoreLibrary/Modules/Templates/Interfaces/ITemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Interfaces/ITemplatesService.cs
@@ -16,12 +16,12 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// </summary>
         /// <param name="id">Optional: The ID of the template to get.</param>
         /// <param name="name">Optional: The name of the template to get.</param>
-        /// <param name="type">Optional: The type of template that is being searched for. Only used in combination with name. Default value is html.</param>
+        /// <param name="type">Optional: The type of template that is being searched for. Only used in combination with name. Default value is null, which is all template types.</param>
         /// <param name="parentId">Optional: The ID of the parent of the template to get.</param>
         /// <param name="parentName">Optional: The name of the parent of template to get.</param>
         /// <param name="includeContent">Optional: Whether or not to include the contents of the template. Default value is <see langword="true"/>.</param>
         /// <returns></returns>
-        Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes type = TemplateTypes.Html, int parentId = 0, string parentName = "", bool includeContent = true);
+        Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true);
 
         /// <summary>
         /// Gets the caching settings for a template.
@@ -113,8 +113,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="handleRequest">Optional: Whether or not to replace values from the request (such as query string, cookies and session). Default value is true.</param>
         /// <param name="removeUnknownVariables">Optional: Whether ot not to remove all left over variables after all replacements have been done. Default value is true.</param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="templateType">Optional: Limit which template type can be used for template includes. Use null for all template types.</param>
         /// <returns></returns>
-        Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false);
+        Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null);
 
         /// <summary>
         /// Do all replaces on a template. If you don't need to replace includes, please use IStringReplacementsService.DoAllReplacements() instead.
@@ -132,8 +133,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="handleRequest">Optional: Whether or not to replace values from the request (such as query string, cookies and session). Default value is true.</param>
         /// <param name="removeUnknownVariables">Optional: Whether ot not to remove all left over variables after all replacements have been done. Default value is true.</param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="templateType">Optional: Limit which template type can be used for template includes. Use null for all template types.</param>
         /// <returns></returns>
-        Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false);
+        Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null);
 
         /// <summary>
         /// Replaces [include[x]] with a template called 'x'.
@@ -143,8 +145,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="dataRow">Optional: All values from this <see cref="DataRow"/> will also be replaced in the output in the included template(s).</param>
         /// <param name="handleRequest">Optional: Whether or not to replace values from the request (such as query string, cookies and session) in the included template(s). Default value is true.</param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="templateType">Optional: Limit which template type can be included. Use null for all template types.</param>
         /// <returns>The replaced string.</returns>
-        Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false);
+        Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null);
 
         /// <summary>
         /// Replaces [include[x]] with a template called 'x'.
@@ -155,8 +158,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="dataRow">Optional: All values from this <see cref="DataRow"/> will also be replaced in the output in the included template(s).</param>
         /// <param name="handleRequest">Optional: Whether or not to replace values from the request (such as query string, cookies and session) in the included template(s). Default value is true.</param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="templateType">Optional: Limit which template type can be included. Use null for all template types.</param>
         /// <returns>The replaced string.</returns>
-        Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false);
+        Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null);
 
 
         /// <summary>

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
@@ -53,7 +53,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes type = TemplateTypes.Html, int parentId = 0, string parentName = "", bool includeContent = true)
+        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true)
         {
             if (id <= 0 && String.IsNullOrEmpty(name))
             {
@@ -262,27 +262,27 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> DoReplacesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public Task<string> DoReplacesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return templatesService.DoReplacesAsync(service, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return templatesService.DoReplacesAsync(service, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> HandleIncludesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public Task<string> HandleIncludesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return templatesService.HandleIncludesAsync(service, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return templatesService.HandleIncludesAsync(service, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
         
         /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
@@ -47,7 +47,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes type = TemplateTypes.Html, int parentId = 0, string parentName = "", bool includeContent = true)
+        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true)
         {
             if (id <= 0 && String.IsNullOrEmpty(name))
             {
@@ -231,27 +231,27 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> DoReplacesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public Task<string> DoReplacesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return templatesService.DoReplacesAsync(service, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return templatesService.DoReplacesAsync(service, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public Task<string> HandleIncludesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public Task<string> HandleIncludesAsync(ITemplatesService service, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return templatesService.HandleIncludesAsync(service, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return templatesService.HandleIncludesAsync(service, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
         
         /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -90,7 +90,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes type = TemplateTypes.Html, int parentId = 0, string parentName = "", bool includeContent = true)
+        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true)
         {
             if (id <= 0 && String.IsNullOrEmpty(name))
             {
@@ -106,31 +106,56 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 _ => throw new ArgumentOutOfRangeException(nameof(gclSettings.Environment), gclSettings.Environment.ToString())
             };
 
-            string whereClause;
+            var whereClause = new List<string>();
+
+            var useTypeFilter = false;
+
             if (id > 0)
             {
                 databaseConnection.AddParameter("id", id);
-                whereClause = "i.id = ?id";
+                whereClause.Add("i.id = ?id");
             }
             else
             {
                 databaseConnection.AddParameter("name", name);
-                whereClause = "i.name = ?name";
+                whereClause.Add("i.name = ?name");
+                useTypeFilter = type.HasValue;
             }
 
             if (parentId > 0)
             {
                 databaseConnection.AddParameter("parentId", parentId);
-                whereClause += " AND ip.id = ?parentId";
+                whereClause.Add(" AND ip.id = ?parentId");
             }
             else if (!String.IsNullOrWhiteSpace(parentName))
             {
                 databaseConnection.AddParameter("parentName", parentName);
-                whereClause = " AND ip.name = ?parentName";
+                whereClause.Add(" AND ip.name = ?parentName");
+            }
+
+            if (useTypeFilter && type.Value != TemplateTypes.Unknown)
+            {
+                switch (type.Value)
+                {
+                    case TemplateTypes.Query:
+                        // Query templates don't have a type.
+                        whereClause.Add("(t.templatetype IS NULL OR t.templatetype = '')");
+                        whereClause.Add("COALESCE(ippppp.`name`, ipppp.`name`, ippp.`name`, ipp.`name`, ip.`name`) = 'QUERY'");
+                        break;
+                    case TemplateTypes.Routine:
+                        databaseConnection.AddParameter("templateType1", "FUNCTION");
+                        databaseConnection.AddParameter("templateType2", "PROCEDURE");
+                        whereClause.Add("t.templatetype IN (?templateType1, ?templateType2)");
+                        break;
+                    default:
+                        databaseConnection.AddParameter("templateType", type.Value.ToString("G").ToLowerInvariant());
+                        whereClause.Add("t.templatetype = ?templateType");
+                        break;
+                }
             }
 
             var query = $@"SELECT
-                            IFNULL(ippppp.name, IFNULL(ipppp.name, IFNULL(ippp.name, IFNULL(ipp.name, ip.name)))) as root_name, 
+                            COALESCE(ippppp.name, ipppp.name, ippp.name, ipp.name, ip.name) AS root_name, 
                             ip.`name` AS parent_name, 
                             ip.id AS parent_id,
                             i.`name` AS template_name,
@@ -159,18 +184,18 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                             t.groupingprefix AS grouping_prefix,
                             t.issecure AS login_required
                         FROM easy_items i 
-                        JOIN easy_templates t ON i.id=t.itemid
+                        JOIN easy_templates t ON t.itemid = i.id
                         {joinPart}
-                        LEFT JOIN easy_items ip ON i.parent_id = ip.id
-                        LEFT JOIN easy_items ipp ON ip.parent_id = ipp.id
-                        LEFT JOIN easy_items ippp ON ipp.parent_id = ippp.id
-                        LEFT JOIN easy_items ipppp ON ippp.parent_id = ipppp.id
-                        LEFT JOIN easy_items ippppp ON ipppp.parent_id = ippppp.id
+                        LEFT JOIN easy_items ip ON ip.id = i.parent_id
+                        LEFT JOIN easy_items ipp ON ipp.id == ip.parent_id
+                        LEFT JOIN easy_items ippp ON ippp.id = ipp.parent_id
+                        LEFT JOIN easy_items ipppp ON ipppp.id = ippp.parent_id
+                        LEFT JOIN easy_items ippppp ON ippppp.id = ipppp.parent_id
                         WHERE i.moduleid = 143 
                         AND i.published = 1
                         AND i.deleted <= 0
                         AND t.deleted <= 0
-                        AND {whereClause}
+                        AND {String.Join(" AND ", whereClause)}
                         ORDER BY ippppp.volgnr, ipppp.volgnr, ippp.volgnr, ipp.volgnr, ip.volgnr, i.volgnr";
 
             await using var reader = await databaseConnection.GetReaderAsync(query);
@@ -598,13 +623,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public async Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return await DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return await DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public async Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public async Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
             // Input cannot be empty.
             if (String.IsNullOrEmpty(input))
@@ -621,7 +646,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             // HTML and mail templates.
             // Note: The string replacements service cannot handle the replacing of templates, because that would cause the StringReplacementsService to need
             // the TemplatesService, which in turn needs the StringReplacementsService, creating a circular dependency.
-            input = await templatesService.HandleIncludesAsync(input, forQuery: forQuery);
+            input = await templatesService.HandleIncludesAsync(input, forQuery: forQuery, templateType: templateType);
             input = await templatesService.HandleImageTemplating(input);
 
             // Replace dynamic content.
@@ -808,13 +833,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public async Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return await HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return await HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public async Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public async Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
             if (String.IsNullOrWhiteSpace(input))
             {
@@ -843,7 +868,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     {
                         // Contains a parent
                         var split = templateName.Split('\\');
-                        var template = await templatesService.GetTemplateAsync(name: split[1], parentName: split[0]);
+                        var template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
                         var templateContent = template.Content;
                         if (handleStringReplacements)
                         {
@@ -854,7 +879,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
                     else
                     {
-                        var template = await templatesService.GetTemplateAsync(name: templateName);
+                        var template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
                         var templateContent = template.Content;
                         if (handleStringReplacements)
                         {
@@ -881,7 +906,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     {
                         // Contains a parent
                         var split = templateName.Split('\\');
-                        var template = await templatesService.GetTemplateAsync(name: split[1], parentName: split[0]);
+                        var template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
                         var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
                         var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                         if (handleStringReplacements)
@@ -898,7 +923,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
                     else
                     {
-                        var template = await templatesService.GetTemplateAsync(name: templateName);
+                        var template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
                         var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
                         var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                         if (handleStringReplacements)
@@ -1148,7 +1173,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             queryTemplate.GroupingSettings ??= new QueryGroupingSettings();
-            query = await DoReplacesAsync(query, true, false, true, null, true, false, true);
+            query = await DoReplacesAsync(query, true, false, true, null, true, false, true, TemplateTypes.Query);
             if (query.Contains("{filters}", StringComparison.OrdinalIgnoreCase))
             {
                 query = query.ReplaceCaseInsensitive("{filters}", (await filtersService.GetFilterQueryPartAsync()).JoinPart);

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -90,7 +90,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes type = TemplateTypes.Html, int parentId = 0, string parentName = "", bool includeContent = true)
+        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true)
         {
             if (id <= 0 && String.IsNullOrEmpty(name))
             {
@@ -108,6 +108,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 whereClause.Add($"(template.published_environment & {(int)gclSettings.Environment}) = {(int)gclSettings.Environment}");
             }
 
+            var useTypeFilter = false;
+
             if (id > 0)
             {
                 databaseConnection.AddParameter("id", id);
@@ -117,6 +119,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             {
                 databaseConnection.AddParameter("name", name);
                 whereClause.Add("template.template_name = ?name");
+                useTypeFilter = type.HasValue;
             }
 
             if (parentId > 0)
@@ -130,18 +133,24 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 whereClause.Add("parent1.template_name = ?parentName");
             }
 
+            if (useTypeFilter)
+            {
+                databaseConnection.AddParameter("templateType", (int)type.Value);
+                whereClause.Add("template.template_type = ?templateType");
+            }
+
             whereClause.Add("template.removed = 0");
 
             var query = $@"SELECT
-                            IFNULL(parent5.template_name, IFNULL(parent4.template_name, IFNULL(parent3.template_name, IFNULL(parent2.template_name, parent1.template_name)))) as root_name, 
-                            parent1.template_name AS parent_name, 
+                            COALESCE(parent5.template_name, parent4.template_name, parent3.template_name, parent2.template_name, parent1.template_name) AS root_name,
+                            parent1.template_name AS parent_name,
                             template.parent_id,
                             template.template_name,
                             template.template_type,
                             template.ordering,
                             parent1.ordering AS parent_ordering,
                             template.template_id,
-                            GROUP_CONCAT(DISTINCT linkedCssTemplate.template_id) AS css_templates, 
+                            GROUP_CONCAT(DISTINCT linkedCssTemplate.template_id) AS css_templates,
                             GROUP_CONCAT(DISTINCT linkedJavascriptTemplate.template_id) AS javascript_templates,
                             template.load_always,
                             template.changed_on,
@@ -641,13 +650,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public async Task<string> DoReplacesAsync(string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return await DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery);
+            return await DoReplacesAsync(this, input, handleStringReplacements, handleDynamicContent, evaluateLogicSnippets, dataRow, handleRequest, removeUnknownVariables, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public async Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false)
+        public async Task<string> DoReplacesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, bool handleDynamicContent = true, bool evaluateLogicSnippets = true, DataRow dataRow = null, bool handleRequest = true, bool removeUnknownVariables = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
             // Input cannot be empty.
             if (String.IsNullOrEmpty(input))
@@ -670,7 +679,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             // HTML and mail templates.
             // Note: The string replacements service cannot handle the replacing of templates, because that would cause the StringReplacementsService to need
             // the TemplatesService, which in turn needs the StringReplacementsService, creating a circular dependency.
-            input = await templatesService.HandleIncludesAsync(input, forQuery: forQuery);
+            input = await templatesService.HandleIncludesAsync(input, forQuery: forQuery, templateType: templateType);
             input = await templatesService.HandleImageTemplating(input);
 
             // Replace dynamic content.
@@ -857,13 +866,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public async Task<string> HandleIncludesAsync(string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
-            return await HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery);
+            return await HandleIncludesAsync(this, input, handleStringReplacements, dataRow, handleRequest, forQuery, templateType);
         }
 
         /// <inheritdoc />
-        public async Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false)
+        public async Task<string> HandleIncludesAsync(ITemplatesService templatesService, string input, bool handleStringReplacements = true, DataRow dataRow = null, bool handleRequest = true, bool forQuery = false, TemplateTypes? templateType = null)
         {
             if (String.IsNullOrWhiteSpace(input))
             {
@@ -892,7 +901,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     {
                         // Contains a parent
                         var split = templateName.Split('\\');
-                        var template = await templatesService.GetTemplateAsync(name: split[1], parentName: split[0]);
+                        var template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
                         var templateContent = template.Content;
                         if (handleStringReplacements)
                         {
@@ -903,7 +912,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
                     else
                     {
-                        var template = await templatesService.GetTemplateAsync(name: templateName);
+                        var template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
                         var templateContent = template.Content;
                         if (handleStringReplacements)
                         {
@@ -930,7 +939,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     {
                         // Contains a parent
                         var split = templateName.Split('\\');
-                        var template = await templatesService.GetTemplateAsync(name: split[1], parentName: split[0]);
+                        var template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
                         var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
                         var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                         if (handleStringReplacements)
@@ -947,7 +956,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
                     else
                     {
-                        var template = await templatesService.GetTemplateAsync(name: templateName);
+                        var template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
                         var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
                         var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                         if (handleStringReplacements)
@@ -1123,7 +1132,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             queryTemplate.GroupingSettings ??= new QueryGroupingSettings();
-            query = await DoReplacesAsync(query, true, false, true, null, true, false, true);
+            query = await DoReplacesAsync(query, true, false, true, null, true, false, true, TemplateTypes.Query);
             if (query.Contains("{filters}", StringComparison.OrdinalIgnoreCase))
             {
                 query = query.ReplaceCaseInsensitive("{filters}", (await filtersService.GetFilterQueryPartAsync()).JoinPart);
@@ -1193,7 +1202,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 return true;
             }
 
-            var query = await DoReplacesAsync(templatesService, template.PreLoadQuery, forQuery: true);
+            var query = await DoReplacesAsync(templatesService, template.PreLoadQuery, forQuery: true, templateType: TemplateTypes.Query);
             var dataTable = await databaseConnection.GetAsync(query);
             if (dataTable.Rows.Count == 0)
             {


### PR DESCRIPTION
Templates can now only include templates of their own type (so HTML templates can only include other HTML templates, query templates can only include other query templates, etc.).