### PR TITLE
Fixed "login required" functionality for templates

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -198,8 +198,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                         AND {String.Join(" AND ", whereClause)}
                         ORDER BY ippppp.volgnr, ipppp.volgnr, ippp.volgnr, ipp.volgnr, ip.volgnr, i.volgnr";
 
-            await using var reader = await databaseConnection.GetReaderAsync(query);
-            var result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
+            Template result;
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
+            {
+                result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
+            }
 
             // Check login requirement.
             if (!result.Type.InList(TemplateTypes.Html, TemplateTypes.Query) || !result.LoginRequired)

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -187,8 +187,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                         GROUP BY template.template_id
                         ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
 
-            await using var reader = await databaseConnection.GetReaderAsync(query);
-            var result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
+            Template result;
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
+            {
+                result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
+            }
 
             // Check login requirement.
             if (!result.Type.InList(TemplateTypes.Html, TemplateTypes.Query) || !result.LoginRequired)
@@ -429,7 +432,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                         GROUP BY template.template_id
                         ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
 
-            using (var reader = await databaseConnection.GetReaderAsync(query))
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
             {
                 while (await reader.ReadAsync())
                 {
@@ -510,7 +513,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             var idsLoaded = new List<int>();
             var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor.HttpContext).ToString();
 
-            using (var reader = await databaseConnection.GetReaderAsync(query))
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
             {
                 while (await reader.ReadAsync())
                 {


### PR DESCRIPTION
The "login required" functionality didn't work due to issues with trying to open a DataReader while one is already opened. Also added a few "await" keywords to usings that call async functions.

Asana: https://app.asana.com/0/1201394730777422/1202458138134697