### PR TITLE
Use https for the Pro6PP API

### DIFF
--- a/GeeksCoreLibrary/Core/Services/GeoLocationService.cs
+++ b/GeeksCoreLibrary/Core/Services/GeoLocationService.cs
@@ -30,7 +30,7 @@ namespace GeeksCoreLibrary.Core.Services
             }
 
             // Create client and request.
-            var restClient = new RestClient("http://api.pro6pp.nl");
+            var restClient = new RestClient("https://api.pro6pp.nl");
             restClient.UseNewtonsoftJson();
 
             var restRequest = new RestRequest("/v1/autocomplete", Method.Get);


### PR DESCRIPTION
Small update so the API call for the Pro6PP API uses https instead of http.