### PR TITLE
Remove caching of the steps object.

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/CachedOrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/CachedOrderProcessesService.cs
@@ -56,13 +56,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
         /// <inheritdoc />
         public async Task<List<OrderProcessStepModel>> GetAllStepsGroupsAndFieldsAsync(ulong orderProcessId)
         {
-            var key = $"OrderProcessGetAllStepsGroupsAndFields_{orderProcessId}";
-            return await cache.GetOrAddAsync(key,
-                delegate(ICacheEntry cacheEntry)
-                {                    
-                    cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultOrderProcessCacheDuration;
-                    return orderProcessesService.GetAllStepsGroupsAndFieldsAsync(orderProcessId);
-                });
+            // Always return a new instance. The values of the fields will be set by the user, if a cached element is used each user will have a reference to the same object and thus sharing information.
+            return await orderProcessesService.GetAllStepsGroupsAndFieldsAsync(orderProcessId);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
the answers of users are added to the fields in the steps object. If the object is cached all users got the reference to the same object so people could see the information of others. By always creating a new element users won't have the same reference.

https://app.asana.com/0/1201394730777422/1202673941324689