### PR TITLE
Check if the previous filter group has a group.

### DIFF
--- a/GeeksCoreLibrary/Components/Filter/Filter.cs
+++ b/GeeksCoreLibrary/Components/Filter/Filter.cs
@@ -460,7 +460,7 @@ namespace GeeksCoreLibrary.Components.Filter
 
                 if (!String.IsNullOrEmpty(filterGroup.Group))
                 {
-                    if (filterGroup.Group != previousFilterGroup.Group)
+                    if (filterGroup.Group != previousFilterGroup.Group && previousFilterGroup.Group != null)
                     {
                         replaceData = new Dictionary<string, string>
                         {


### PR DESCRIPTION
An empty filter would be created the first time a group is used. This checks if there is actually a previous group.

https://app.asana.com/0/1200896832146623/1202486506923788