### PR TITLE
Update MySqlDatabaseConnection.cs

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -491,9 +491,14 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                     // Make sure we always use the correct timezone.
                     if (!String.IsNullOrWhiteSpace(gclSettings.DatabaseTimeZone))
                     {
-                        CommandForReading.CommandText = $"SET @@time_zone = {gclSettings.DatabaseTimeZone.ToMySqlSafeValue(true)};";
+                        CommandForReading.CommandText =
+                            $"SET @@time_zone = {gclSettings.DatabaseTimeZone.ToMySqlSafeValue(true)};";
                         await CommandForReading.ExecuteNonQueryAsync();
                     }
+                }
+                catch (MySqlException mySqlException)
+                {
+                    logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}'");
                 }
                 catch (Exception exception)
                 {

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -498,7 +498,15 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
                 catch (MySqlException mySqlException)
                 {
-                    logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}'");
+                    //Checks if the exception is about the timezone or something else related to MySQL. Not setting timezones on databases based at TransIP is okay.
+                    if (mySqlException.Code == 1298)
+                    {
+                        logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}'"); 
+                    }
+                    else
+                    {
+                        logger.LogWarning(mySqlException, $"An error occurred while trying to set the time zone to '{gclSettings.DatabaseTimeZone}'");
+                    }
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
Updating this error message because this is not an actual error. Timezones must be set on DigitalOcean databases because they are in a different timezone. This does not count for TransIP databases which have an empty timezone table because they are already set up with the correct timezone.