### PR TITLE
Add Open Graph support

### DIFF
--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
@@ -242,11 +242,28 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.Behavior,
             GroupName = CmsAttributes.CmsGroupName.Seo,
-            DisplayOrder = 10,
+            DisplayOrder = 20,
             HideInCms = false,
             ReadOnlyInCms = false
         )]
         public bool SetSeoInformationFromFirstItem { get; set; }
+
+        /// <summary>
+        /// Use the Open Graph Fields of the first item to add Open Graph meta tags to the head section.
+        /// These fields must start with "opengraph_". The part after the underscore will determine the
+        /// name of the Open Graph item, e.g.: "opengraph_title" will create a meta tag called "og:title".
+        /// </summary>
+        [CmsProperty(
+            PrettyName = "Set Open Graph info from first item",
+            Description = "Use the Open Graph Fields of the first item to add Open Graph meta tags to the head section.",
+            DeveloperRemarks = "These fields must start with \"opengraph_\" and the part that follows will be used as the name of the meta tag.",
+            TabName = CmsAttributes.CmsTabName.Behavior,
+            GroupName = CmsAttributes.CmsGroupName.Seo,
+            DisplayOrder = 30,
+            HideInCms = false,
+            ReadOnlyInCms = false
+        )]
+        public bool SetOpenGraphInformationFromFirstItem { get; set; }
 
         /// <summary>
         /// The amount of items each page will show.

--- a/GeeksCoreLibrary/Components/Repeater/Repeater.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Repeater.cs
@@ -232,6 +232,13 @@ namespace GeeksCoreLibrary.Components.Repeater
                     pagesService.SetPageSeoData(seoTitle, seoDescription, seoKeyWords, seoCanonical, noIndex, noFollow, robots?.Split(",", StringSplitOptions.RemoveEmptyEntries));
                 }
 
+                // Add Open Graph data.
+                if (Settings.SetOpenGraphInformationFromFirstItem)
+                {
+                    var openGraphValues = parsedData.Columns.Cast<DataColumn>().Where(c => c.ColumnName.StartsWith("opengraph_", StringComparison.OrdinalIgnoreCase)).ToDictionary(c => c.ColumnName, c => Convert.ToString(parsedData.Rows[0][c]));
+                    pagesService.SetOpenGraphData(openGraphValues);
+                }
+
                 if (Settings.GroupingTemplates.Keys.Count == 1)
                 {
                     // If we have only one layer, generate the HTML for that. It works differently for single layer repeater than for multiple layers, that's why it's a different function.

--- a/GeeksCoreLibrary/Modules/Seo/Models/PageMetaDataModel.cs
+++ b/GeeksCoreLibrary/Modules/Seo/Models/PageMetaDataModel.cs
@@ -20,6 +20,12 @@ namespace GeeksCoreLibrary.Modules.Seo.Models
         public Dictionary<string, string> MetaTags { get; set; } = new();
 
         /// <summary>
+        /// Gets or sets the Open Graph meta tags for a page. Note: Keys in this dictionary should not start with "og:" otherwise the property
+        /// attribute in the meta tag will start with "og:og:".
+        /// </summary>
+        public Dictionary<string, string> OpenGraphMetaTags { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the canonical URL.
         /// </summary>
         public string Canonical { get; set; }

--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Extensions;
@@ -102,18 +103,25 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                         return NotFound();
                     }
 
-                    // Set SEO information.
+                    // Set SEO and Open Graph information.
                     if (HttpContext.Items.ContainsKey(Constants.TemplatePreLoadQueryResultKey))
                     {
                         var dataRow = (DataRow)HttpContext.Items[Constants.TemplatePreLoadQueryResultKey];
-                        var seoTitle = dataRow.GetValueIfColumnExists<string>("SEOtitle");
-                        var seoDescription = dataRow.GetValueIfColumnExists<string>("SEOdescription");
-                        var seoKeyWords = dataRow.GetValueIfColumnExists<string>("SEOkeywords");
-                        var seoCanonical = dataRow.GetValueIfColumnExists<string>("SEOcanonical");
-                        var noIndex = Convert.ToBoolean(dataRow.GetValueIfColumnExists("noindex"));
-                        var noFollow = Convert.ToBoolean(dataRow.GetValueIfColumnExists("nofollow"));
-                        var robots = dataRow.GetValueIfColumnExists<string>("SEOrobots");
-                        pagesService.SetPageSeoData(seoTitle, seoDescription, seoKeyWords, seoCanonical, noIndex, noFollow, robots?.Split(",", StringSplitOptions.RemoveEmptyEntries));
+                        if (dataRow != null)
+                        {
+                            var seoTitle = dataRow.GetValueIfColumnExists<string>("SEOtitle");
+                            var seoDescription = dataRow.GetValueIfColumnExists<string>("SEOdescription");
+                            var seoKeyWords = dataRow.GetValueIfColumnExists<string>("SEOkeywords");
+                            var seoCanonical = dataRow.GetValueIfColumnExists<string>("SEOcanonical");
+                            var noIndex = Convert.ToBoolean(dataRow.GetValueIfColumnExists("noindex"));
+                            var noFollow = Convert.ToBoolean(dataRow.GetValueIfColumnExists("nofollow"));
+                            var robots = dataRow.GetValueIfColumnExists<string>("SEOrobots");
+                            pagesService.SetPageSeoData(seoTitle, seoDescription, seoKeyWords, seoCanonical, noIndex, noFollow, robots?.Split(",", StringSplitOptions.RemoveEmptyEntries));
+
+                            // Add Open Graph data.
+                            var openGraphValues = dataRow.Table.Columns.Cast<DataColumn>().Where(c => c.ColumnName.StartsWith("opengraph_", StringComparison.OrdinalIgnoreCase)).ToDictionary(c => c.ColumnName, c => Convert.ToString(dataRow[c]));
+                            pagesService.SetOpenGraphData(openGraphValues);
+                        }
                     }
 
                     break;

--- a/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
@@ -40,5 +40,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// Sets the SEO meta data for the current page.
         /// </summary>
         void SetPageSeoData(string seoTitle = null, string seoDescription = null, string seoKeyWords = null, string seoCanonical = null, bool noIndex = false, bool noFollow = false, IEnumerable<string> robots = null);
+
+        /// <summary>
+        /// Sets the Open Graph meta data for the current page.
+        /// </summary>
+        /// <param name="openGraphValues">Dictionary with all Open Graph values. Keys must start with "opengraph_" or they will be ignored.</param>
+        void SetOpenGraphData(IDictionary<string, string> openGraphValues);
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Views/Shared/Template.cshtml
+++ b/GeeksCoreLibrary/Modules/Templates/Views/Shared/Template.cshtml
@@ -98,6 +98,14 @@
             }
         }
 
+        if (Model?.MetaData?.OpenGraphMetaTags != null)
+        {
+            foreach (var (property, content) in Model.MetaData.OpenGraphMetaTags)
+            {
+                @:<meta property="og:@property" content="@content" />
+            }
+        }
+
         if (!String.IsNullOrWhiteSpace(Model?.MetaData?.Canonical))
         {
             @:<link href="@Model.MetaData.Canonical" rel="canonical" />


### PR DESCRIPTION
The Repeater component and the templates pre-load query can now set Open Graph meta tags.

https://app.asana.com/0/1201027711166952/1202945204173858