### PR TITLE
Adding default values

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
@@ -121,6 +121,15 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Interfaces
         string EvaluateTemplate(string input);
 
         /// <summary>
+        /// Searched input string for variables with default values and replaces them with those default values.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <param name="prefix">The prefix that variables start with.</param>
+        /// <param name="suffix">The suffix that variables end with.</param>
+        /// <returns></returns>
+        string HandledVariablesDefaultValues(string input, string prefix = "{", string suffix = "}");
+
+        /// <summary>
         /// Removes any template variables that are present in the input string.
         /// </summary>
         /// <param name="input"></param>

--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
@@ -121,13 +121,13 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Interfaces
         string EvaluateTemplate(string input);
 
         /// <summary>
-        /// Searched input string for variables with default values and replaces them with those default values.
+        /// Searches input string for variables with default values and replaces them with those default values.
         /// </summary>
         /// <param name="input">The input string.</param>
         /// <param name="prefix">The prefix that variables start with.</param>
         /// <param name="suffix">The suffix that variables end with.</param>
         /// <returns></returns>
-        string HandledVariablesDefaultValues(string input, string prefix = "{", string suffix = "}");
+        string HandleVariablesDefaultValues(string input, string prefix = "{", string suffix = "}");
 
         /// <summary>
         /// Removes any template variables that are present in the input string.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Models/StringReplacementVariable.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Models/StringReplacementVariable.cs
@@ -23,5 +23,10 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Models
         /// A list of formatters that were found on the variable.
         /// </summary>
         public List<string> Formatters { get; } = new();
+        
+        /// <summary>
+        /// The default value of the variable when given.
+        /// </summary>
+        public string DefaultValue { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
-using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 
 namespace GeeksCoreLibrary.Modules.GclReplacements.Services
@@ -173,7 +172,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
             }
             
             // Handle variables with default values that haven't been replaced yet.
-            input = HandledVariablesDefaultValues(input);
+            input = HandleVariablesDefaultValues(input);
 
             // Whether template variables that were not replaced should be removed.
             if (removeUnknownVariables)
@@ -370,7 +369,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 var value = Convert.ToString(replaceData[variableName], new CultureInfo("en-US"));
                 if (String.IsNullOrWhiteSpace(value))
                 {
-                    if (!variable.DefaultValue.IsNullOrEmpty())
+                    if (!String.IsNullOrEmpty(variable.DefaultValue))
                     {
                         value = variable.DefaultValue;
                     }
@@ -514,7 +513,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
         }
 
         /// <inheritdoc />
-        public string HandledVariablesDefaultValues(string input, string prefix = "{", string suffix = "}")
+        public string HandleVariablesDefaultValues(string input, string prefix = "{", string suffix = "}")
         {
             if (String.IsNullOrWhiteSpace(input))
             {

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -345,10 +345,6 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 // A variable is skipped if it exists in the input string, but not in the provided data.
                 if (!replaceData.ContainsKey(variable.VariableName) && !replaceData.ContainsKey(variable.OriginalVariableName))
                 {
-                    if (!variable.DefaultValue.IsNullOrEmpty())
-                    {
-                        variable.VariableName = variable.DefaultValue;
-                    }
                     continue;
                 }
 
@@ -371,6 +367,10 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 var value = Convert.ToString(replaceData[variableName], new CultureInfo("en-US"));
                 if (String.IsNullOrWhiteSpace(value))
                 {
+                    if (!variable.DefaultValue.IsNullOrEmpty())
+                    {
+                        value = variable.DefaultValue;
+                    }
                     // Replace the variable if it's an empty string or if it only contains whitespace and continue with the next variable.
                     output.Replace(variable.MatchString, value);
                     continue;
@@ -749,7 +749,8 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 {
                     var questionMarkIndexOf = fieldName.LastIndexOf("?");
                     var colonIndexOf = fieldName.LastIndexOf(":");
-                    defaultValue = colonIndexOf == -1 ? fieldName.Substring(questionMarkIndexOf) : fieldName.Substring(questionMarkIndexOf, colonIndexOf);
+                    var defaultValueWithQM = colonIndexOf == -1 ? fieldName.Substring(questionMarkIndexOf) : fieldName.Substring(questionMarkIndexOf, colonIndexOf);
+                    defaultValue = defaultValueWithQM.Remove(0, 1);
                 }
                 
                 // Colons that are escaped with a backslash are temporarily replaced with "~~COLON~~".

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 
 namespace GeeksCoreLibrary.Modules.GclReplacements.Services
@@ -344,6 +345,10 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 // A variable is skipped if it exists in the input string, but not in the provided data.
                 if (!replaceData.ContainsKey(variable.VariableName) && !replaceData.ContainsKey(variable.OriginalVariableName))
                 {
+                    if (!variable.DefaultValue.IsNullOrEmpty())
+                    {
+                        variable.VariableName = variable.DefaultValue;
+                    }
                     continue;
                 }
 
@@ -737,7 +742,16 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 var fieldName = match.Groups["field"].Value;
                 var originalFieldName = fieldName;
                 var formatters = "";
+                var defaultValue = "";
 
+                //Checks for default values
+                if (fieldName.Contains("?"))
+                {
+                    var questionMarkIndexOf = fieldName.LastIndexOf("?");
+                    var colonIndexOf = fieldName.LastIndexOf(":");
+                    defaultValue = colonIndexOf == -1 ? fieldName.Substring(questionMarkIndexOf) : fieldName.Substring(questionMarkIndexOf, colonIndexOf);
+                }
+                
                 // Colons that are escaped with a backslash are temporarily replaced with "~~COLON~~".
                 fieldName = fieldName.Replace("\\:", "~~COLON~~");
 
@@ -754,7 +768,8 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 {
                     MatchString = match.Value,
                     VariableName = fieldName,
-                    OriginalVariableName = originalFieldName
+                    OriginalVariableName = originalFieldName,
+                    DefaultValue = defaultValue
                 };
 
                 // Now replace "~~COLON~~" with an actual colon again.


### PR DESCRIPTION
It is now possible to add default values by adding a "?" and then the default value to a variable within a Wiser HTML template.
For example {variable?1234}
[GCL: default waarde op kunnen geven voor variabelen {naam:defaultvalue}]

Asana ticket:
(https://app.asana.com/0/1201027711166952/1202879712279705)
