### PR TITLE
LanguagesService - Fixed bug that the language code was always the same, when caching is enabled.

### DIFF
--- a/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
@@ -73,6 +73,9 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
             }
             
             var cacheName = new StringBuilder(Constants.LanguageCodeCacheKey);
+            
+            // Add hostname to cache key, because websites often have a different hostname per language.
+            cacheName.Append('_').Append(HttpContextHelpers.GetHostName(httpContextAccessor.HttpContext));
 
             if (gclSettings.MultiLanguageBasedOnUrlSegments)
             {


### PR DESCRIPTION

This is because the language code was being cached the first time a request is made. Then all following requests would get the same language code from the cache, even if they were from a different domain with a different language.

https://app.asana.com/0/1167986948634679/1202698312678304