### PR TITLE
User roles

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using GeeksCoreLibrary.Components.Account.Models;
+using GeeksCoreLibrary.Core.Models;
 
 namespace GeeksCoreLibrary.Components.Account.Interfaces
 {
@@ -27,9 +29,8 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// <param name="amountOfDaysToRememberCookie">The amount of days to remember the cookie for the user.</param>
         /// <param name="mainUserEntityType">The entity type for main accounts.</param>
         /// <param name="userEntityType">The entity type for sub accounts.</param>
-        /// <param name="role">Optional: The role of the user.</param>
         /// <returns>The value that should be saved in the cookie.</returns>
-        Task<string> GenerateNewCookieTokenAsync(ulong userId, ulong mainUserId, int amountOfDaysToRememberCookie, string mainUserEntityType = "relatie", string userEntityType = "account", string role = null);
+        Task<string> GenerateNewCookieTokenAsync(ulong userId, ulong mainUserId, int amountOfDaysToRememberCookie, string mainUserEntityType = "relatie", string userEntityType = "account");
         
         /// <summary>
         /// Deletes a cookie token from the database, so that the user cannot login with it anymore, even if it still has a cookie with that token.
@@ -50,5 +51,13 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
         /// <returns>The result string.</returns>
         Task<string> DoAccountReplacementsAsync(string input, bool forQuery = false);
+
+        /// <summary>
+        /// Gets all roles a user has.
+        /// </summary>
+        /// <param name="userId">The item ID of the user whose roles to retrieve.</param>
+        /// <param name="includePermissions">Optional: Whether to include all permissions that each role has. Default is <see langword="false"/>.</param>
+        /// <returns></returns>
+        Task<List<RoleModel>> GetUserRolesAsync(ulong userId, bool includePermissions = false);
     }
 }

--- a/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
@@ -240,11 +240,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         #region Tab datasource properties
 
         /// <summary>
-        /// The Wiser 2.0 entity type that is used for users that need to be able to login on the website.
+        /// The Wiser entity type that is used for users that need to be able to login on the website.
         /// </summary>
         [CmsProperty(
             PrettyName = "Entity type",
-            Description = "The Wiser 2.0 entity type that is used for users that need to be able to login on the website.",
+            Description = "The Wiser entity type that is used for users that need to be able to login on the website.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -266,11 +266,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string LoginFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that contains the SHA512 hashed password of the user. This should be the same in the HTML as in wiser_entityproperty.
+        /// The Wiser field/property name that contains the SHA512 hashed password of the user. This should be the same in the HTML as in wiser_entityproperty.
         /// </summary>
         [CmsProperty(
             PrettyName = "Password field name",
-            Description = "The Wiser 2.0 field/property name that contains the SHA512 hashed password of the user. This should be the same in the HTML as in wiser_entityproperty.",
+            Description = "The Wiser field/property name that contains the SHA512 hashed password of the user. This should be the same in the HTML as in wiser_entityproperty.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -279,11 +279,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string PasswordFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that should be used to remember the amount of failed login attempts of a user.
+        /// The Wiser field/property name that should be used to remember the amount of failed login attempts of a user.
         /// </summary>
         [CmsProperty(
             PrettyName = "Failed login attempts field name",
-            Description = "The Wiser 2.0 field/property name that should be used to remember the amount of failed login attempts of a user.",
+            Description = "The Wiser field/property name that should be used to remember the amount of failed login attempts of a user.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -293,11 +293,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string FailedLoginAttemptsFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that should be used to remember the date and time of the user's last login attempt.
+        /// The Wiser field/property name that should be used to remember the date and time of the user's last login attempt.
         /// </summary>
         [CmsProperty(
             PrettyName = "Last login attempt field name",
-            Description = "The Wiser 2.0 field/property name that should be used to remember the date and time of the user's last login attempt.",
+            Description = "The Wiser field/property name that should be used to remember the date and time of the user's last login attempt.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -307,11 +307,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string LastLoginAttemptFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name where the user's e-mail address is saved. This can be the same as 'LoginFieldName', if you use e-mail address for logging in.
+        /// The Wiser field/property name where the user's e-mail address is saved. This can be the same as 'LoginFieldName', if you use e-mail address for logging in.
         /// </summary>
         [CmsProperty(
             PrettyName = "Email address field name",
-            Description = "The Wiser 2.0 field/property name where the user's e-mail address is saved. This can be the same as 'LoginFieldName', if you use e-mail address for logging in.",
+            Description = "The Wiser field/property name where the user's e-mail address is saved. This can be the same as 'LoginFieldName', if you use e-mail address for logging in.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -320,11 +320,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string EmailAddressFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that should be used to save the date and time that the reset token will expire.
+        /// The Wiser field/property name that should be used to save the date and time that the reset token will expire.
         /// </summary>
         [CmsProperty(
             PrettyName = "Reset password expire date field name",
-            Description = "The Wiser 2.0 field/property name that should be used to save the date and time that the reset token will expire.",
+            Description = "The Wiser field/property name that should be used to save the date and time that the reset token will expire.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -334,11 +334,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string ResetPasswordTokenFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that should be used to save the date and time that the reset token will expire.
+        /// The Wiser field/property name that should be used to save the date and time that the reset token will expire.
         /// </summary>
         [CmsProperty(
             PrettyName = "Reset password expire date field name",
-            Description = "The Wiser 2.0 field/property name that should be used to save the date and time that the reset token will expire.",
+            Description = "The Wiser field/property name that should be used to save the date and time that the reset token will expire.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -348,11 +348,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string ResetPasswordExpireDateFieldName { get; set; }
 
         /// <summary>
-        /// The Wiser 2.0 field/property name that contains the role of the user.
+        /// The Wiser field/property name that contains the role of the user.
         /// </summary>
         [CmsProperty(
             PrettyName = "Role field name",
-            Description = "The Wiser 2.0 field/property name that contains the role of the user.",
+            Description = "The Wiser field/property name that contains the role of the user.",
             DeveloperRemarks = "Leave empty if you don't use roles.",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -387,11 +387,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string NewPasswordConfirmationFieldName { get; set; }
 
         /// <summary>
-        /// The name of the Wiser 2.0 property/field where the Client ID for Google Analytics should be saved.
+        /// The name of the Wiser property/field where the Client ID for Google Analytics should be saved.
         /// </summary>
         [CmsProperty(
             PrettyName = "Google client ID field name",
-            Description = "The name of the Wiser 2.0 property/field where the Client ID for Google Analytics should be saved.",
+            Description = "The name of the Wiser property/field where the Client ID for Google Analytics should be saved.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.Basic,
@@ -466,16 +466,16 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <p>For reset password mode, this needs to return the columns 'id', so we can verify that the e-mail address exists. You can use the following variables in this query, for mode ResetPassword:</p>
                                 <ul>
                                     <li><strong>?email or {email}:</strong> Required: The e-mail address that the user entered in the reset password form.</li>
-                                    <li><strong>?emailAddressFieldName or {emailAddressFieldName}:</strong> Optional: The Wiser 2.0 field name where the e-mail address is stored.</li>
+                                    <li><strong>?emailAddressFieldName or {emailAddressFieldName}:</strong> Optional: The Wiser field name where the e-mail address is stored.</li>
                                     <li><strong>?emailAddress or {emailAddress}:</strong> Required: The e-mail address that the user entered.</li>
-                                    <li><strong>?entityType or {entityType}:</strong> Optional: The Wiser 2.0 entity type that is used for users that login on the website.</li>
+                                    <li><strong>?entityType or {entityType}:</strong> Optional: The Wiser entity type that is used for users that login on the website.</li>
                                 </ul>
                                 <p>For CreateOrUpdateAccount, if the query returns one row for each field/property and at least a column with the name 'property_name', it will be secured so that nobody can save custom values. If your query doesn't contain a column with that name, there will be no security, unless you also write a custom create and update query.</p>
                                 <p>You can use all data from this query in the main template and you can use the following variables in this query:</p>
                                 <ul>
                                     <li><strong>{loginFieldName} or ?loginFieldName:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{passwordFieldName} or ?passwordFieldName:</strong> The value of the property in this component with the same name.</li>
-                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser 2.0 field name where the e-mail address is stored.</li>
+                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser field name where the e-mail address is stored.</li>
                                     <li><strong>{entityType} or ?entityType:</strong> The value of the property in this component with the same name.</li>
                                 </ul>
                                 <p>For SubAccountsManagement this query should get the list of sub accounts for the logged in user. Please make sure you only get items that are of the correct entity type.</p>
@@ -515,8 +515,8 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <ul>
                                     <li><strong>{loginFieldName} or ?loginFieldName:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{passwordFieldName} or ?passwordFieldName:</strong> The value of the property in this component with the same name.</li>
-                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser 2.0 field name where the e-mail address is stored.</li>
-                                    <li><strong>{roleFieldName} or ?roleFieldName:</strong> The Wiser 2.0 field name where the role of the user is stored.</li>
+                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser field name where the e-mail address is stored.</li>
+                                    <li><strong>{roleFieldName} or ?roleFieldName:</strong> The Wiser field name where the role of the user is stored.</li>
                                     <li><strong>{login} or ?login:</strong> The value that the user entered in the HTML field with the same name as the value in the property 'loginFieldName'.</li>
                                     <li><strong>{entityType} or ?entityType:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{subAccountEntityType} or ?subAccountEntityType:</strong> The value of the property in this component with the same name.</li>
@@ -560,9 +560,9 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <ul>
                                     <li><strong>{userId} or ?userId:</strong> Required: The ID of the user.</li>
                                     <li><strong>{resetPasswordToken} or ?resetPasswordToken:</strong> Required: The newly generated token that will be sent in the e-mail to the user.</li>
-                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> Optional: The Wiser 2.0 field/property name for the above value.</li>
+                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> Optional: The Wiser field/property name for the above value.</li>
                                     <li><strong>{resetPasswordExpireDate} or ?resetPasswordExpireDate:</strong> Required: The date and time that the reset token will expire.</li>
-                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> Optional: The Wiser 2.0 field/property name for the above value.</li>
+                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> Optional: The Wiser field/property name for the above value.</li>
                                 </ul>",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.CustomSql,
@@ -583,9 +583,9 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <ul>
                                     <li><strong>{userId} or ?userId:</strong> The ID of the user.</li>
                                     <li><strong>{token} or ?token:</strong> The value of the token in the query string.</li>
-                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> The Wiser 2.0 property name that is used to save the reset password token.</li>
-                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> The Wiser 2.0 property name that is used to save the expire date of the reset password token.</li>
-                                    <li><strong>{loginFieldName} or ?loginFieldName:</strong> Optional: The Wiser 2.0 field name where the value is stored that the user logins with (ie username or e-mail).</li>
+                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> The Wiser property name that is used to save the reset password token.</li>
+                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> The Wiser property name that is used to save the expire date of the reset password token.</li>
+                                    <li><strong>{loginFieldName} or ?loginFieldName:</strong> Optional: The Wiser field name where the value is stored that the user logins with (ie username or e-mail).</li>
                                     <li><strong>{entityType} or ?entityType:</strong> The entity type that is set in this component, in the property 'EntityType'.</li>
                                 </ul>",
             TabName = CmsAttributes.CmsTabName.DataSource,
@@ -607,9 +607,9 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <ul>
                                     <li><strong>{userId} or ?userId:</strong> The ID of the user.</li>
                                     <li><strong>{newPasswordHash} or ?newPasswordHash:</strong> The SHA512 hash of the new password.</li>
-                                    <li><strong>{passwordFieldName} or ?passwordFieldName:</strong> The Wiser 2.0 property name that is used to save the password of the user.</li>
-                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> The Wiser 2.0 property name that is used to save the reset password token.</li>
-                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> The Wiser 2.0 property name that is used to save the expire date of the reset password token.</li>
+                                    <li><strong>{passwordFieldName} or ?passwordFieldName:</strong> The Wiser property name that is used to save the password of the user.</li>
+                                    <li><strong>{resetPasswordTokenFieldName} or ?resetPasswordTokenFieldName:</strong> The Wiser property name that is used to save the reset password token.</li>
+                                    <li><strong>{resetPasswordExpireDateFieldName} or ?resetPasswordExpireDateFieldName:</strong> The Wiser property name that is used to save the expire date of the reset password token.</li>
                                 </ul>",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.CustomSql,
@@ -628,11 +628,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
             DeveloperRemarks = @"<p>Make sure that this query returns a column named 'id', which contains the ID of the user, or no results if the user doesn't exist.</p>
                                 <p>You can also use the following default variables:<p>
                                 <ul>
-                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser 2.0 property name that is used to save the e-mail address of the user.</li>
+                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser property name that is used to save the e-mail address of the user.</li>
                                     <li><strong>{emailAddress} or ?emailAddress:</strong> The e-mail address that the user entered.</li>
                                     <li><strong>{emailAddressGclAesEncrypted} or ?emailAddressGclAesEncrypted:</strong> The e-mail address that the user entered, encrypted using the AESEncode function.</li>
                                     <li><strong>{emailAddressAesEncrypted} or ?emailAddressAesEncrypted:</strong> The e-mail address that the user entered, encrypted using the EncryptWithAes function.</li>
-                                    <li><strong>{entityType} or ?entityType:</strong> The Wiser 2.0 entity type that is used for users that can login on the website.</li>
+                                    <li><strong>{entityType} or ?entityType:</strong> The Wiser entity type that is used for users that can login on the website.</li>
                                 </ul>",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.CustomSql,
@@ -653,11 +653,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <p>Also make sure that you exclude the logged in user in your check, like the default query does, so that they don't get an error when they change something in their account.</p>
                                 <p>You can also use the following default variables:<p>
                                 <ul>
-                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser 2.0 property name that is used to save the e-mail address of the user.</li>
+                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser property name that is used to save the e-mail address of the user.</li>
                                     <li><strong>{emailAddress} or ?emailAddress:</strong> The e-mail address that the user entered.</li>
                                     <li><strong>{loginFieldName} or ?loginFieldName:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{login} or ?login:</strong> The value that the user entered in the HTML field with the same name as the value in the property 'loginFieldName'.</li>
-                                    <li><strong>{entityType} or ?entityType:</strong> The Wiser 2.0 entity type that is used for users that can login on the website.</li>
+                                    <li><strong>{entityType} or ?entityType:</strong> The Wiser entity type that is used for users that can login on the website.</li>
                                 </ul>",
             TabName = CmsAttributes.CmsTabName.DataSource,
             GroupName = CmsAttributes.CmsGroupName.CustomSql,
@@ -756,12 +756,12 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string DeleteAccountQuery { get; set; }
 
         /// <summary>
-        /// The query for inserting/updating a value for a Wiser 2.0 property/field. This query will be executed for every submitted field in the form, which was originally on the page.
+        /// The query for inserting/updating a value for a Wiser property/field. This query will be executed for every submitted field in the form, which was originally on the page.
         /// </summary>
         [CmsProperty(
             PrettyName = "Set value in Wiser entity property query",
-            Description = "The query for inserting/updating a value for a Wiser 2.0 property/field. <strong>This query will be executed for every submitted field in the form that was originally on the page.</strong>",
-            DeveloperRemarks = @"<p>Leave this property empty if you're not using the Wiser 2.0 data model, or if you're using a custom create/update query that already sets all values correctly.<p>
+            Description = "The query for inserting/updating a value for a Wiser property/field. <strong>This query will be executed for every submitted field in the form that was originally on the page.</strong>",
+            DeveloperRemarks = @"<p>Leave this property empty if you're not using the Wiser data model, or if you're using a custom create/update query that already sets all values correctly.<p>
                                 <p>You can use the following variables:</p>
                                 <ul>
                                     <li><strong>{value} or ?value:</strong> The submitted value</li>
@@ -778,12 +778,11 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string SetValueInWiserEntityPropertyQuery { get; set; }
 
         /// <summary>
-        /// The query for inserting/updating a value for a Wiser 2.0 property/field. This query will be executed for every submitted field in the form, which was originally on the page.
+        /// The query for inserting/updating a value for a Wiser property/field. This query will be executed for every submitted field in the form, which was originally on the page.
         /// </summary>
         [CmsProperty(
             PrettyName = "Get sub account query",
-            Description =
-                "The query for getting all values and fields for a sub account. If you use the default HTML template, this query should return a row for each field that needs to be shown on the page. If you use custom HTML, this query can return whatever you need in that HTML.",
+            Description = "The query for getting all values and fields for a sub account. If you use the default HTML template, this query should return a row for each field that needs to be shown on the page. If you use custom HTML, this query can return whatever you need in that HTML.",
             DeveloperRemarks = @"<p>You can use the following variables:</p>
                                 <ul>
                                     <li><strong>{subAccountEntityType} or ?subAccountEntityType:</strong> The entity type that is used for sub accounts.</li>
@@ -798,6 +797,30 @@ namespace GeeksCoreLibrary.Components.Account.Models
             TextEditorType = CmsAttributes.CmsTextEditorType.QueryEditor
         )]
         public string GetSubAccountQuery { get; set; }
+
+        /// <summary>
+        /// The query that will determine the roles for a new or existing account.
+        /// </summary>
+        [CmsProperty(
+            PrettyName = "Account roles Query",
+            Description = "The query that will determine the roles for a new or existing account.",
+            DeveloperRemarks = @"<p>Please note that any roles returned by this query are absolute, meaning that the account will only receive the roles returned by this query, and any roles it was previously assigned that are not in the result will be removed.</p>
+                                <p>Make sure the query returns at least the following columns:</p>
+                                <ul>
+                                    <li><strong>roleId:</strong> The ID of a role in wiser_roles.</li>
+                                </ul>
+                                <p>In case of updating the roles of an existing user, you can use the following variables:</p>
+                                <ul>
+                                    <li><strong>{userId} or ?userId:</strong> The ID of the account/user being updated.</li>
+                                </ul>
+                                <p>You can use any value in the submitted form as a variable.</p>",
+            TabName = CmsAttributes.CmsTabName.DataSource,
+            GroupName = CmsAttributes.CmsGroupName.CustomSql,
+            DisplayOrder = 130,
+            ComponentMode = "CreateOrUpdateAccount",
+            TextEditorType = CmsAttributes.CmsTextEditorType.QueryEditor
+        )]
+        public string AccountRolesQuery { get; set; }
 
         /// <summary>
         /// The query that validates an ID for auto login via Wiser.
@@ -816,8 +839,8 @@ namespace GeeksCoreLibrary.Components.Account.Models
                                 <ul>
                                     <li><strong>{loginFieldName} or ?loginFieldName:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{passwordFieldName} or ?passwordFieldName:</strong> The value of the property in this component with the same name.</li>
-                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser 2.0 field name where the e-mail address is stored.</li>
-                                    <li><strong>{roleFieldName} or ?roleFieldName:</strong> The Wiser 2.0 field name where the role of the user is stored.</li>
+                                    <li><strong>{emailAddressFieldName} or ?emailAddressFieldName:</strong> The Wiser field name where the e-mail address is stored.</li>
+                                    <li><strong>{roleFieldName} or ?roleFieldName:</strong> The Wiser field name where the role of the user is stored.</li>
                                     <li><strong>{entityType} or ?entityType:</strong> The value of the property in this component with the same name.</li>
                                     <li><strong>{subAccountEntityType} or ?subAccountEntityType:</strong> The value of the property in this component with the same name.</li>
                                 </ul>",

--- a/GeeksCoreLibrary/Components/Account/Models/Constants.cs
+++ b/GeeksCoreLibrary/Components/Account/Models/Constants.cs
@@ -12,8 +12,8 @@
         internal const string LoginColumn = "login";
         internal const string EmailAddressColumn = "email";
         internal const string MainAccountIdColumn = "mainAccountId";
-        internal const string RoleColumn = "role";
         internal const string PropertyNameColumn = "property_name";
+        internal const string RoleIdColumn = "roleId";
         
         // Table names.
         internal const string AuthenticationTokensTableName = "gcl_user_auth_token";

--- a/GeeksCoreLibrary/Components/Account/Models/UserCookieDataModel.cs
+++ b/GeeksCoreLibrary/Components/Account/Models/UserCookieDataModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GeeksCoreLibrary.Core.Models;
 
 namespace GeeksCoreLibrary.Components.Account.Models
 {
@@ -34,9 +35,9 @@ namespace GeeksCoreLibrary.Components.Account.Models
         public string MainUserEntityType { get; set; }
 
         /// <summary>
-        /// The role of the logged in user.
+        /// The roles of the logged in user.
         /// </summary>
-        public string Role { get; set; }
+        public List<RoleModel> Roles { get; set; }
 
         /// <summary>
         /// The date and time that the user logged in.

--- a/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
@@ -9,6 +9,7 @@ using GeeksCoreLibrary.Components.Account.Models;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
+using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
@@ -27,8 +28,9 @@ namespace GeeksCoreLibrary.Components.Account.Services
         private readonly IObjectsService objectsService;
         private readonly ILogger<AccountsService> logger;
         private readonly IDatabaseHelpersService databaseHelpersService;
+        private readonly IRolesService rolesService;
 
-        public AccountsService(IOptions<GclSettings> gclSettings, IDatabaseConnection databaseConnection, IHttpContextAccessor httpContextAccessor, IObjectsService objectsService, ILogger<AccountsService> logger, IDatabaseHelpersService databaseHelpersService)
+        public AccountsService(IOptions<GclSettings> gclSettings, IDatabaseConnection databaseConnection, IHttpContextAccessor httpContextAccessor, IObjectsService objectsService, ILogger<AccountsService> logger, IDatabaseHelpersService databaseHelpersService, IRolesService rolesService)
         {
             this.gclSettings = gclSettings.Value;
             this.databaseConnection = databaseConnection;
@@ -36,6 +38,7 @@ namespace GeeksCoreLibrary.Components.Account.Services
             this.objectsService = objectsService;
             this.logger = logger;
             this.databaseHelpersService = databaseHelpersService;
+            this.rolesService = rolesService;
         }
         
         /// <inheritdoc />
@@ -131,7 +134,7 @@ namespace GeeksCoreLibrary.Components.Account.Services
                     IpAddress = dataSetFirstRow.Field<string>("ip_address"),
                     UserAgent = dataSetFirstRow.Field<string>("user_agent"),
                     MainUserEntityType = dataSetFirstRow.Field<string>("main_user_entity_type"),
-                    Role = dataSetFirstRow.Field<string>("role"),
+                    Roles = await GetUserRolesAsync(userId),
                     ExtraData = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
                 };
 
@@ -214,7 +217,7 @@ namespace GeeksCoreLibrary.Components.Account.Services
         }
         
         /// <inheritdoc />
-        public async Task<string> GenerateNewCookieTokenAsync(ulong userId, ulong mainUserId, int amountOfDaysToRememberCookie, string mainUserEntityType = "relatie", string userEntityType = "account", string role = null)
+        public async Task<string> GenerateNewCookieTokenAsync(ulong userId, ulong mainUserId, int amountOfDaysToRememberCookie, string mainUserEntityType = "relatie", string userEntityType = "account")
         {
             // Make sure we always have a valid main user ID. If the user is logging in with a main user, this should be the same as the user ID.
             if (mainUserId == 0)
@@ -238,7 +241,6 @@ namespace GeeksCoreLibrary.Components.Account.Services
             databaseConnection.AddParameter("main_user_id", mainUserId);
             databaseConnection.AddParameter("entity_type", entityTypeToUse);
             databaseConnection.AddParameter("main_user_entity_type", mainUserEntityType);
-            databaseConnection.AddParameter("role", role);
             databaseConnection.AddParameter("ip_address", HttpContextHelpers.GetUserIpAddress(httpContextAccessor.HttpContext));
             databaseConnection.AddParameter("user_agent", HttpContextHelpers.GetHeaderValueAs<string>(httpContextAccessor.HttpContext, HeaderNames.UserAgent));
             databaseConnection.AddParameter("expires", DateTime.Now.AddDays(amountOfDaysToRememberCookie));
@@ -398,6 +400,26 @@ namespace GeeksCoreLibrary.Components.Account.Services
             }
 
             return input;
+        }
+
+        /// <inheritdoc />
+        public async Task<List<RoleModel>> GetUserRolesAsync(ulong userId, bool includePermissions = false)
+        {
+            databaseConnection.AddParameter("userId", userId);
+            var rolesData = await databaseConnection.GetAsync($"SELECT role_id FROM `{WiserTableNames.WiserUserRoles}` WHERE user_id = ?userId");
+            if (rolesData.Rows.Count == 0)
+            {
+                return new List<RoleModel>(0);
+            }
+
+            // Turn the retrieved role IDs into a List of integers.
+            var userRoleIds = rolesData.Rows.Cast<DataRow>().Select(dataRow => Convert.ToInt32(dataRow["role_id"])).ToList();
+
+            // Retrieve all rows.
+            var roles = await rolesService.GetRolesAsync(includePermissions);
+
+            // Filter the roles based on the user's role IDs and return a List of the remaining rows.
+            return roles.Where(role => userRoleIds.Contains(role.Id)).ToList();
         }
     }
 }

--- a/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
@@ -267,6 +267,7 @@ namespace GeeksCoreLibrary.Core.Extensions
             services.Decorate<IShoppingBasketsService, CachedShoppingBasketsService>();
             services.Decorate<IDataSelectorParsersService, CachedDataSelectorParsersService>();
             services.Decorate<IOrderProcessesService, CachedOrderProcessesService>();
+            services.Decorate<IRolesService, CachedRolesService>();
             
             if (gclSettings.UseLegacyWiser1TemplateModule)
             {

--- a/GeeksCoreLibrary/Core/Models/CoreConstants.cs
+++ b/GeeksCoreLibrary/Core/Models/CoreConstants.cs
@@ -5,5 +5,7 @@
         public const string UrlsToSkipForMiddlewaresRegex = @"(\.jpe?g|\.gif|\.png|\.webp|\.svg|\.bmp|\.tif|\.ico|\.woff2?|\.css|\.js|\.[gj]cl|\.webmanifest)(?:\?.*)?$";
         
         public const string SeoTitlePropertyName = "title_seo";
+
+        internal const string RolesDataCachingKey = "GCLRoles";
     }
 }

--- a/GeeksCoreLibrary/Core/Services/CachedRolesService.cs
+++ b/GeeksCoreLibrary/Core/Services/CachedRolesService.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using GeeksCoreLibrary.Core.Enums;
+using GeeksCoreLibrary.Core.Interfaces;
+using GeeksCoreLibrary.Core.Models;
+using LazyCache;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GeeksCoreLibrary.Core.Services;
+
+public class CachedRolesService : IRolesService
+{
+    private readonly IRolesService rolesService;
+    private readonly IAppCache cache;
+    private readonly ICacheService cacheService;
+    private readonly GclSettings gclSettings;
+    private readonly ILogger<CachedRolesService> logger;
+
+    public CachedRolesService(IRolesService rolesService, IAppCache cache, ICacheService cacheService, IOptions<GclSettings> gclSettings, ILogger<CachedRolesService> logger)
+    {
+        this.rolesService = rolesService;
+        this.cache = cache;
+        this.cacheService = cacheService;
+        this.gclSettings = gclSettings.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<RoleModel>> GetRolesAsync(bool includePermissions = false)
+    {
+        var cacheName = new StringBuilder(CoreConstants.RolesDataCachingKey);
+
+        // Base the cache name on whether permissions are included.
+        cacheName.Append(includePermissions ? "WithPermissions" : "WithoutPermissions");
+
+        var roles = await cache.GetOrAddAsync(
+            cacheName.ToString(),
+            async cacheEntry =>
+            {
+                // Use the normal roles service to get the roles.
+                var roles = await rolesService.GetRolesAsync(includePermissions);
+                cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;
+                logger.LogDebug($"Cached roles {(includePermissions ? "with" : "without")} permissions in cache key '{cacheName}'.");
+                return roles;
+            }, cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Database));
+
+        return roles;
+    }
+}

--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -193,7 +193,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
             var result = (QueryTemplate)await templatesService.GetTemplateAsync(templateId, templateName, TemplateTypes.Query);
             if (result.Id <= 0)
             {
-                // If ID is 0 and LoginRequired is true, it means no user is logged in while the template requires a login.
+                // If ID is 0 and LoginRequired is true, it means no user is logged in while the template requires a login, or that the templates requires a role the user doesn't have.
                 if (result.LoginRequired)
                 {
                     return Unauthorized();

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -120,7 +120,14 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
 
             if (reader.HasColumn("login_role"))
             {
-                template.LoginRoles = (await reader.GetFieldValueAsync<string>("login_required"))?.Split(",").ToList();
+                if (await reader.IsDBNullAsync(reader.GetOrdinal("login_role")))
+                {
+                    template.LoginRoles = null;
+                }
+                else
+                {
+                    template.LoginRoles = (await reader.GetFieldValueAsync<string>("login_role"))?.Split(",", StringSplitOptions.RemoveEmptyEntries).Select(i => Convert.ToInt32(i)).ToList();
+                }
             }
 
             if (reader.HasColumn("login_redirect_url"))

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -118,6 +118,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
                 template.LoginRequired = Convert.ToBoolean(await reader.GetFieldValueAsync<object>("login_required"));
             }
 
+            if (reader.HasColumn("login_role"))
+            {
+                template.LoginRoles = (await reader.GetFieldValueAsync<string>("login_required"))?.Split(",").ToList();
+            }
+
             if (reader.HasColumn("login_redirect_url"))
             {
                 template.LoginRedirectUrl = reader.GetStringHandleNull("login_redirect_url");

--- a/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
@@ -137,7 +137,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Models
         /// Gets or sets the roles that are allowed to open this template.
         /// If empty, all roles can see it.
         /// </summary>
-        public List<string> LoginRoles { get; set; }
+        public List<int> LoginRoles { get; set; }
 
         /// <summary>
         /// Gets or sets the URL the user should be sent to if <see cref="LoginRequired"/> is <see langword="true"/>, but no user is logged in.

--- a/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
@@ -134,6 +134,12 @@ namespace GeeksCoreLibrary.Modules.Templates.Models
         public bool LoginRequired { get; set; }
 
         /// <summary>
+        /// Gets or sets the roles that are allowed to open this template.
+        /// If empty, all roles can see it.
+        /// </summary>
+        public List<string> LoginRoles { get; set; }
+
+        /// <summary>
         /// Gets or sets the URL the user should be sent to if <see cref="LoginRequired"/> is <see langword="true"/>, but no user is logged in.
         /// </summary>
         public string LoginRedirectUrl { get; set; }

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
@@ -146,7 +146,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             // Check if a login is required (only for HTML and query templates.
             if (template.Type.InList(TemplateTypes.Html, TemplateTypes.Query) && template.LoginRequired && template.Id == 0)
             {
-                // If the template ID is 0, but "LoginRequired" is true, it means no user is logged in.
+                // If the template ID is 0, but "LoginRequired" is true, it means no user is logged in, or that the user doesn't have any of the required roles.
                 return template;
             }
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -215,10 +215,10 @@ ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, paren
                 return emptyTemplate;
             }
 
-            // Check current login.
+            // Check current login, and match user's roles against required roles of the template.
             var userData = await accountsService.GetUserDataFromCookieAsync();
 
-            if (userData is not {UserId: > 0})
+            if (userData is not {UserId: > 0} || (userData.Roles != null && !userData.Roles.Any(role => result.LoginRoles.Contains(role.Id))))
             {
                 return emptyTemplate;
             }

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -142,50 +142,51 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             whereClause.Add("template.removed = 0");
 
             var query = $@"SELECT
-                            COALESCE(parent5.template_name, parent4.template_name, parent3.template_name, parent2.template_name, parent1.template_name) AS root_name,
-                            parent1.template_name AS parent_name,
-                            template.parent_id,
-                            template.template_name,
-                            template.template_type,
-                            template.ordering,
-                            parent1.ordering AS parent_ordering,
-                            template.template_id,
-                            GROUP_CONCAT(DISTINCT linkedCssTemplate.template_id) AS css_templates,
-                            GROUP_CONCAT(DISTINCT linkedJavascriptTemplate.template_id) AS javascript_templates,
-                            template.load_always,
-                            template.changed_on,
-                            template.external_files,
-                            {(includeContent ? "template.template_data_minified, template.template_data," : "")}
-                            template.url_regex,
-                            template.use_cache,
-                            template.cache_minutes,
-                            template.cache_location,
-                            template.cache_regex,
-                            0 AS use_obfuscate,
-                            template.insert_mode,
-                            template.grouping_create_object_instead_of_array,
-                            template.grouping_key_column_name,
-                            template.grouping_value_column_name,
-                            template.grouping_key,
-                            template.grouping_prefix,
-                            template.pre_load_query,
-                            template.return_not_found_when_pre_load_query_has_no_data,
-                            template.login_required,
-                            template.login_redirect_url
-                        FROM {WiserTableNames.WiserTemplate} AS template
-                        {joinPart}
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS parent2 ON parent2.template_id = parent1.parent_id AND parent2.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent1.parent_id)
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS parent3 ON parent3.template_id = parent2.parent_id AND parent3.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent2.parent_id)
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS parent4 ON parent4.template_id = parent3.parent_id AND parent4.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent3.parent_id)
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS parent5 ON parent5.template_id = parent4.parent_id AND parent5.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent4.parent_id)
+    COALESCE(parent5.template_name, parent4.template_name, parent3.template_name, parent2.template_name, parent1.template_name) AS root_name,
+    parent1.template_name AS parent_name,
+    template.parent_id,
+    template.template_name,
+    template.template_type,
+    template.ordering,
+    parent1.ordering AS parent_ordering,
+    template.template_id,
+    GROUP_CONCAT(DISTINCT linkedCssTemplate.template_id) AS css_templates,
+    GROUP_CONCAT(DISTINCT linkedJavascriptTemplate.template_id) AS javascript_templates,
+    template.load_always,
+    template.changed_on,
+    template.external_files,
+    {(includeContent ? "template.template_data_minified, template.template_data," : "")}
+    template.url_regex,
+    template.use_cache,
+    template.cache_minutes,
+    template.cache_location,
+    template.cache_regex,
+    0 AS use_obfuscate,
+    template.insert_mode,
+    template.grouping_create_object_instead_of_array,
+    template.grouping_key_column_name,
+    template.grouping_value_column_name,
+    template.grouping_key,
+    template.grouping_prefix,
+    template.pre_load_query,
+    template.return_not_found_when_pre_load_query_has_no_data,
+    template.login_required,
+    template.login_role,
+    template.login_redirect_url
+FROM {WiserTableNames.WiserTemplate} AS template
+{joinPart}
+LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
+LEFT JOIN {WiserTableNames.WiserTemplate} AS parent2 ON parent2.template_id = parent1.parent_id AND parent2.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent1.parent_id)
+LEFT JOIN {WiserTableNames.WiserTemplate} AS parent3 ON parent3.template_id = parent2.parent_id AND parent3.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent2.parent_id)
+LEFT JOIN {WiserTableNames.WiserTemplate} AS parent4 ON parent4.template_id = parent3.parent_id AND parent4.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent3.parent_id)
+LEFT JOIN {WiserTableNames.WiserTemplate} AS parent5 ON parent5.template_id = parent4.parent_id AND parent5.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent4.parent_id)
 
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS linkedCssTemplate ON FIND_IN_SET(linkedCssTemplate.template_id, template.linked_templates) AND linkedCssTemplate.template_type IN (2, 3) AND linkedCssTemplate.removed = 0
-                        LEFT JOIN {WiserTableNames.WiserTemplate} AS linkedJavascriptTemplate ON FIND_IN_SET(linkedJavascriptTemplate.template_id, template.linked_templates) AND linkedJavascriptTemplate.template_type = 4 AND linkedJavascriptTemplate.removed = 0
+LEFT JOIN {WiserTableNames.WiserTemplate} AS linkedCssTemplate ON FIND_IN_SET(linkedCssTemplate.template_id, template.linked_templates) AND linkedCssTemplate.template_type IN (2, 3) AND linkedCssTemplate.removed = 0
+LEFT JOIN {WiserTableNames.WiserTemplate} AS linkedJavascriptTemplate ON FIND_IN_SET(linkedJavascriptTemplate.template_id, template.linked_templates) AND linkedJavascriptTemplate.template_type = 4 AND linkedJavascriptTemplate.removed = 0
 
-                        WHERE {String.Join(" AND ", whereClause)}
-                        GROUP BY template.template_id
-                        ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
+WHERE {String.Join(" AND ", whereClause)}
+GROUP BY template.template_id
+ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
 
             Template result;
             await using (var reader = await databaseConnection.GetReaderAsync(query))
@@ -204,7 +205,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             {
                 Type = result.Type,
                 LoginRequired = true,
-                LoginRedirectUrl = result.LoginRedirectUrl
+                LoginRedirectUrl = result.LoginRedirectUrl,
+                LoginRoles = result.LoginRoles
             };
 
             if (httpContextAccessor.HttpContext == null)
@@ -215,7 +217,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
 
             // Check current login.
             var userData = await accountsService.GetUserDataFromCookieAsync();
-            return userData is { UserId: > 0 } ? result : emptyTemplate;
+
+            if (userData is not {UserId: > 0})
+            {
+                return emptyTemplate;
+            }
+
+            return result;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The Account component can now assign roles to users when creating or updating. The new query "Account roles Query" can be used for determining which roles a user will have when creating or updating. In addition, templates that require users to have a certain role will no longer load if the user doesn't have one of the required roles.

https://app.asana.com/0/1201027711166952/1202879712279688