### PR TITLE
Fixed shopping basket service transactions issues

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
@@ -107,7 +107,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
         /// <param name="basketLines"></param>
         /// <param name="settings"></param>
         /// <param name="skipType">An optional parameter to skip lines of a certain type.</param>
-        /// <param name="createNewTransaction">Will be passed to the SaveAsync call.</param>
+        /// <param name="createNewTransaction">Will be passed to the CalculateShippingCostsAsync, CalculatePaymentMethodCostsAsync, and SaveAsync calls.</param>
         Task RecalculateVariablesAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string skipType = null, bool createNewTransaction = true);
 
         /// <summary>
@@ -123,14 +123,22 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
         /// <summary>
         /// Calculates the shipping costs based on the shipping costs query defined in the settings module.
         /// </summary>
-        /// <returns></returns>
-        Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings);
+        /// <param name="shoppingBasket">The main shopping basket item.</param>
+        /// <param name="basketLines">The basket lines items.</param>
+        /// <param name="settings">The settings of the shopping basket.</param>
+        /// <param name="createNewTransaction">Will be passed to the AddLineAsync call.</param>
+        /// <returns>The calculated shipping costs.</returns>
+        Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true);
 
         /// <summary>
         /// Calculates the payment method costs based on the payment method costs query defined in the settings module.
         /// </summary>
-        /// <returns></returns>
-        Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings);
+        /// <param name="shoppingBasket">The main shopping basket item.</param>
+        /// <param name="basketLines">The basket lines items.</param>
+        /// <param name="settings">The settings of the shopping basket.</param>
+        /// <param name="createNewTransaction">Will be passed to the AddLineAsync call.</param>
+        /// <returns>The calculated payment method costs.</returns>
+        Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true);
 
         Task<List<WiserItemModel>> RemoveLinesAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, ICollection<string> itemIdsOrUniqueIds);
 

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
@@ -125,15 +125,15 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         }
 
         /// <inheritdoc />
-        public async Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings)
+        public async Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true)
         {
-            return await shoppingBasketsService.CalculateShippingCostsAsync(shoppingBasket, basketLines, settings);
+            return await shoppingBasketsService.CalculateShippingCostsAsync(shoppingBasket, basketLines, settings, createNewTransaction);
         }
 
         /// <inheritdoc />
-        public async Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings)
+        public async Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true)
         {
-            return await shoppingBasketsService.CalculatePaymentMethodCostsAsync(shoppingBasket, basketLines, settings);
+            return await shoppingBasketsService.CalculatePaymentMethodCostsAsync(shoppingBasket, basketLines, settings, createNewTransaction);
         }
 
         /// <inheritdoc />

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -218,8 +218,8 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
 
             if (!skipType.InList("shipping_costs", "paymentmethod_costs", Constants.BasketLineCouponType))
             {
-                await CalculateShippingCostsAsync(shoppingBasket, basketLines, settings);
-                await CalculatePaymentMethodCostsAsync(shoppingBasket, basketLines, settings);
+                await CalculateShippingCostsAsync(shoppingBasket, basketLines, settings, createNewTransaction);
+                await CalculatePaymentMethodCostsAsync(shoppingBasket, basketLines, settings, createNewTransaction);
 
                 foreach (var couponLine in GetLines(basketLines, Constants.BasketLineCouponType))
                 {
@@ -1113,7 +1113,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         }
 
         /// <inheritdoc />
-        public async Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings)
+        public async Task<decimal> CalculateShippingCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true)
         {
             var shippingCosts = 0M;
 
@@ -1264,7 +1264,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                         ["vatrate"] = vatRate,
                         ["description"] = friendlyName
                     };
-                    await AddLineAsync(shoppingBasket, basketLines, settings, id, type: "shipping_costs", lineDetails: details);
+                    await AddLineAsync(shoppingBasket, basketLines, settings, id, type: "shipping_costs", lineDetails: details, createNewTransaction: createNewTransaction);
                 }
             }
             else
@@ -1276,7 +1276,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         }
 
         /// <inheritdoc />
-        public async Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings)
+        public async Task<decimal> CalculatePaymentMethodCostsAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, bool createNewTransaction = true)
         {
             var paymentMethodCosts = 0M;
 
@@ -1364,7 +1364,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
                         ["vatrate"] = vatRate,
                         ["description"] = friendlyName
                     };
-                    await AddLineAsync(shoppingBasket, basketLines, settings, id, type: "paymentmethod_costs", lineDetails: details);
+                    await AddLineAsync(shoppingBasket, basketLines, settings, id, type: "paymentmethod_costs", lineDetails: details, createNewTransaction: createNewTransaction);
                 }
             }
             else


### PR DESCRIPTION
The `CalculateShippingCostsAsync` and `CalculatePaymentMethodCostsAsync` both called the `AddLineAsync` function which starts a transaction by default. However, in the flow of adding a product, a transaction would already be started at that point, causing an error. This is now fixed.

https://app.asana.com/0/1201394730777422/1202805894433129