### PR TITLE
Fixed issue with determining ordering number

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -199,8 +199,8 @@ namespace GeeksCoreLibrary.Core.Services
                     wiserItem.ParentItemId = parentId.Value;
                     databaseConnection.AddParameter("newItemId", wiserItem.Id);
                     databaseConnection.AddParameter("parentId", parentId);
-                    await databaseConnection.ExecuteAsync($@"SET @newOrderNumber = (SELECT IFNULL(MAX(ordering), 0) + 1 FROM {tablePrefix}{WiserTableNames.WiserItem} WHERE parent_item_id = ?parentId);
-UPDATE {tablePrefix}{WiserTableNames.WiserItem} SET parent_item_id = ?parentId, ordering = @newOrderNumber WHERE id = ?newItemId");
+                    await databaseConnection.ExecuteAsync($@"SET @newOrdering = (SELECT IFNULL(MAX(ordering), 0) + 1 FROM {tablePrefix}{WiserTableNames.WiserItem} WHERE parent_item_id = ?parentId);
+UPDATE {tablePrefix}{WiserTableNames.WiserItem} SET parent_item_id = ?parentId, ordering = @newOrdering WHERE id = ?newItemId");
                 }
                 else
                 {


### PR DESCRIPTION
When trying to create an item and immediately linking it to a parent ID, the `@newOrderNumber` user variable would get overwritten by the `newOrderNumber` paremeter value in some cases. The user paremeter has been renamed to `@newOrdering` to fix this issue.

https://app.asana.com/0/1200729155901577/1203271506272167