### PR TITLE
Made WebPages cache clearable

### DIFF
--- a/GeeksCoreLibrary/Core/Enums/CacheAreas.cs
+++ b/GeeksCoreLibrary/Core/Enums/CacheAreas.cs
@@ -12,6 +12,7 @@
         WiserItems,
         ShoppingBaskets,
         DataSelectors,
-        Configurators
+        Configurators,
+        WebPages
     }
 }


### PR DESCRIPTION
The `WebPages` cache couldn't be cleared because the caching functions didn't assign a cancellation token to the cache entries. Also updated the `GetOrAddAsync` calls to not use delegates (so it's consistent with the rest of the GCL).

Asana: https://app.asana.com/0/1201394730777422/1203311324495588