### PR TITLE
Return external files in template data endpoint

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Models/TemplateDataModel.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/TemplateDataModel.cs
@@ -1,4 +1,6 @@
-﻿namespace GeeksCoreLibrary.Modules.Templates.Models
+﻿using System.Collections.Generic;
+
+namespace GeeksCoreLibrary.Modules.Templates.Models
 {
     public class TemplateDataModel
     {
@@ -16,5 +18,15 @@
         /// Gets or sets the js content of the template.
         /// </summary>
         public string LinkedJavascript { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of URLs for CSS libraries, usually hosted on some CDN.
+        /// </summary>
+        public List<string> ExternalCssFiles { get; init; } = new();
+
+        /// <summary>
+        /// Gets or sets a collection of URLs for JavaScript libraries, usually hosted on some CDN.
+        /// </summary>
+        public List<string> ExternalJavaScriptFiles { get; init; } = new();
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -1224,17 +1224,22 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
 
             var cssStringBuilder = new StringBuilder();
             var jsStringBuilder = new StringBuilder();
+            var externalCssFilesList = new List<string>();
+            var externalJavaScriptFilesList = new List<string>();
             foreach (var templateId in template.CssTemplates.Concat(template.JavascriptTemplates))
             {
                 var linkedTemplate = await templatesService.GetTemplateAsync(templateId);
                 (linkedTemplate.Type == TemplateTypes.Css ? cssStringBuilder : jsStringBuilder).Append(linkedTemplate.Content);
+                (linkedTemplate.Type == TemplateTypes.Css ? externalCssFilesList : externalJavaScriptFilesList).AddRange(linkedTemplate.ExternalFiles);
             }
 
             return new TemplateDataModel
             {
                 Content = template.Content,
                 LinkedCss = cssStringBuilder.ToString(),
-                LinkedJavascript = jsStringBuilder.ToString()
+                LinkedJavascript = jsStringBuilder.ToString(),
+                ExternalCssFiles = externalCssFilesList,
+                ExternalJavaScriptFiles = externalJavaScriptFilesList
             };
         }
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1212,17 +1212,22 @@ ORDER BY ORDINAL_POSITION ASC";
 
             var cssStringBuilder = new StringBuilder();
             var jsStringBuilder = new StringBuilder();
+            var externalCssFilesList = new List<string>();
+            var externalJavaScriptFilesList = new List<string>();
             foreach (var templateId in template.CssTemplates.Concat(template.JavascriptTemplates))
             {
                 var linkedTemplate = await templatesService.GetTemplateAsync(templateId);
                 (linkedTemplate.Type == TemplateTypes.Css ? cssStringBuilder : jsStringBuilder).Append(linkedTemplate.Content);
+                (linkedTemplate.Type == TemplateTypes.Css ? externalCssFilesList : externalJavaScriptFilesList).AddRange(linkedTemplate.ExternalFiles);
             }
 
             return new TemplateDataModel
             {
                 Content = template.Content,
                 LinkedCss = cssStringBuilder.ToString(),
-                LinkedJavascript = jsStringBuilder.ToString()
+                LinkedJavascript = jsStringBuilder.ToString(),
+                ExternalCssFiles = externalCssFilesList,
+                ExternalJavaScriptFiles = externalJavaScriptFilesList
             };
         }
 


### PR DESCRIPTION
The external files of the linked JS and CSS templates are now also returned when calling the template endpoint of the templates controller.

Asana: https://app.asana.com/0/1200346761113317/1203224263717539