### PR TITLE
Cache folder changes

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
@@ -11,25 +11,13 @@ namespace GeeksCoreLibrary.Core.Helpers
         public static string GetContentFilesFolderPath(IWebHostEnvironment webHostEnvironment)
         {
             var result = Path.Combine(webHostEnvironment.WebRootPath, Modules.ItemFiles.Models.Constants.DefaultFilesDirectory);
-
-            if (!Directory.Exists(result))
-            {
-                Directory.CreateDirectory(result);
-            }
-
-            return result;
+            return !Directory.Exists(result) ? null : result;
         }
 
         public static string GetContentCacheFolderPath(IWebHostEnvironment webHostEnvironment)
         {
             var result = Path.Combine(webHostEnvironment.WebRootPath, "contentcache");
-
-            if (!Directory.Exists(result))
-            {
-                Directory.CreateDirectory(result);
-            }
-
-            return result;
+            return !Directory.Exists(result) ? null : result;
         }
 
         public static string SaveFileToContentFilesFolder(IWebHostEnvironment webHostEnvironment, string filename, byte[] fileBytes)

--- a/GeeksCoreLibrary/Core/Services/CacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/CacheService.cs
@@ -85,6 +85,11 @@ namespace GeeksCoreLibrary.Core.Services
         public void ClearOutputCache()
         {
             var outputCacheFolder = FileSystemHelpers.GetContentCacheFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(outputCacheFolder))
+            {
+                return;
+            }
+
             var directoryInfo = new DirectoryInfo(outputCacheFolder);
             if (!directoryInfo.Exists)
             {
@@ -112,6 +117,11 @@ namespace GeeksCoreLibrary.Core.Services
         public void ClearFilesCache()
         {
             var contentFilesFolder = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(contentFilesFolder))
+            {
+                return;
+            }
+
             var directoryInfo = new DirectoryInfo(contentFilesFolder);
             if (!directoryInfo.Exists)
             {

--- a/GeeksCoreLibrary/Modules/Barcodes/Services/CachedBarcodesService.cs
+++ b/GeeksCoreLibrary/Modules/Barcodes/Services/CachedBarcodesService.cs
@@ -4,6 +4,7 @@ using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Barcodes.Interfaces;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZXing;
 
@@ -15,23 +16,36 @@ public class CachedBarcodesService : IBarcodesService
     private readonly GclSettings gclSettings;
     private readonly IBarcodesService barcodesService;
     private readonly IWebHostEnvironment webHostEnvironment;
+    private readonly ILogger<CachedBarcodesService> logger;
 
     /// <summary>
     /// Creates a new instance of <see cref="CachedBarcodesService"/>.
     /// </summary>
-    public CachedBarcodesService(IOptions<GclSettings> gclSettings, IBarcodesService barcodesService, IWebHostEnvironment webHostEnvironment)
+    public CachedBarcodesService(IOptions<GclSettings> gclSettings, IBarcodesService barcodesService, IWebHostEnvironment webHostEnvironment, ILogger<CachedBarcodesService> logger)
     {
         this.gclSettings = gclSettings.Value;
         this.barcodesService = barcodesService;
         this.webHostEnvironment = webHostEnvironment;
+        this.logger = logger;
     }
 
     /// <inheritdoc />
     public byte[] GenerateBarcode(string input, BarcodeFormat format, int width, int height)
     {
-        var basePath = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        byte[] fileBytes;
+
+        // Retrieve the path of the cache directory.
+        var cacheBasePath = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        if (String.IsNullOrWhiteSpace(cacheBasePath))
+        {
+            // Log a warning if the directory doesn't exist, and generate a new barcode.
+            logger.LogWarning($"Files cache is enabled but the directory '{ItemFiles.Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+            fileBytes = barcodesService.GenerateBarcode(input, format, width, height);
+            return fileBytes;
+        }
+
         var filename = $"barcode_{format:G}_{width}x{height}_{input}.png";
-        var filePath = Path.Combine(basePath, filename);
+        var filePath = Path.Combine(cacheBasePath, filename);
 
         var file = new FileInfo(filePath);
         if (file.Exists && DateTime.UtcNow.Subtract(file.LastWriteTimeUtc) <= gclSettings.DefaultItemFileCacheDuration)
@@ -40,7 +54,7 @@ public class CachedBarcodesService : IBarcodesService
         }
 
         // Generate new barcode if it doesn't exist yet or if it's older than one hour.
-        var fileBytes = barcodesService.GenerateBarcode(input, format, width, height);
+        fileBytes = barcodesService.GenerateBarcode(input, format, width, height);
         FileSystemHelpers.SaveFileToContentFilesFolder(webHostEnvironment, filename, fileBytes);
         return fileBytes;
     }

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -67,6 +67,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve image because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"image_wiser2_{finalItemId}_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
@@ -103,6 +109,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve image because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"image_wiser2_{finalItemLinkId}_itemlink_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{filename}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
@@ -136,6 +148,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve image because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"image_wiser2_{finalItemId}_direct_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
@@ -172,6 +190,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve file because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"file_wiser2_{finalItemId}_{propertyName}_{fileNumber}_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
@@ -207,6 +231,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve file because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"file_wiser2_{finalItemLinkId}_itemlink_{propertyName}_{fileNumber}_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
@@ -239,6 +269,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             }
 
             var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(localDirectory))
+            {
+                logger.LogError($"Could not retrieve file because the directory '{Models.Constants.DefaultFilesDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                return (null, DateTime.MinValue);
+            }
+
             var localFilename = $"file_wiser2_{finalItemId}_direct_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 

--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/OutputCachingMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/OutputCachingMiddleware.cs
@@ -108,6 +108,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
 
             // Get folder and file name.
             var cacheFolder = FileSystemHelpers.GetContentCacheFolderPath(webHostEnvironment);
+            if (String.IsNullOrWhiteSpace(cacheFolder))
+            {
+                logger.LogWarning("Content cache is enabled but the directory 'contentcache' does not exist. Please create it and give it modify permissions to the user that is running the website.");
+                await next.Invoke(context);
+                return;
+            }
+
             var cacheFileName = await templatesService.GetTemplateOutputCacheFileNameAsync(contentTemplate);
             var fullCachePath = Path.Combine(cacheFolder, cacheFileName);
             var cacheKey = Path.GetFileNameWithoutExtension(cacheFileName);
@@ -165,7 +172,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
 
                 return;
             }
-            
+
             logger.LogDebug($"Content cache file NOT found for page '{HttpContextHelpers.GetOriginalRequestUri(context)}', creating new one...");
 
             // Remember the original body.
@@ -193,7 +200,6 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
 
                 // Copy the new body to the original body.
                 await newStream.CopyToAsync(originalBody);
-
 
                 switch (contentTemplate.CachingLocation)
                 {

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
@@ -89,7 +89,6 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 // Get folder and file name.
                 var cacheFolder = FileSystemHelpers.GetContentCacheFolderPath(webHostEnvironment);
                 var cacheFileName = await GetTemplateOutputCacheFileNameAsync(cacheSettings, cacheSettings.Type.ToString());
-                fullCachePath = Path.Combine(cacheFolder, cacheFileName);
 
                 switch (cacheSettings.CachingLocation)
                 {
@@ -104,25 +103,33 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
                     case TemplateCachingLocations.OnDisk:
                     {
-                        logger.LogDebug($"Content cache enabled for template '{cacheSettings.Id}', cache file location: {fullCachePath}.");
-
-                        // Check if a cache file already exists and if it hasn't expired yet.
-                        var fileInfo = new FileInfo(fullCachePath);
-                        if (fileInfo.Exists)
+                        if (String.IsNullOrWhiteSpace(cacheFolder))
                         {
-                            if (fileInfo.LastWriteTimeUtc.AddMinutes(cacheSettings.CachingMinutes) > DateTime.UtcNow)
+                            logger.LogWarning($"Content cache enabled for template '{cacheSettings.Id}' but the cache folder 'contentcache' does not exist. Please create the folder and give it modify rights to the user running the website.");
+                        }
+                        else
+                        {
+                            logger.LogDebug($"Content cache enabled for template '{cacheSettings.Id}', cache file location: {fullCachePath}.");
+
+                            // Check if a cache file already exists and if it hasn't expired yet.
+                            fullCachePath = Path.Combine(cacheFolder, cacheFileName);
+                            var fileInfo = new FileInfo(fullCachePath);
+                            if (fileInfo.Exists)
                             {
-                                using var fileReader = new StreamReader(fileInfo.OpenRead(), Encoding.UTF8);
-                                var fileContents = await fileReader.ReadToEndAsync();
-                                templateContent = cacheSettings.Type != TemplateTypes.Html
-                                    ? fileContents
-                                    : $"<!-- START PARTIAL TEMPLATE FROM CACHE ({cacheSettings.Id}) -->{fileContents}<!-- END PARTIAL TEMPLATE FROM CACHE ({cacheSettings.Id}) -->";
-                                foundInOutputCache = true;
-                            }
-                            else
-                            {
-                                // Cleanup the old cache file if it has expired.
-                                fileInfo.Delete();
+                                if (fileInfo.LastWriteTimeUtc.AddMinutes(cacheSettings.CachingMinutes) > DateTime.UtcNow)
+                                {
+                                    using var fileReader = new StreamReader(fileInfo.OpenRead(), Encoding.UTF8);
+                                    var fileContents = await fileReader.ReadToEndAsync();
+                                    templateContent = cacheSettings.Type != TemplateTypes.Html
+                                        ? fileContents
+                                        : $"<!-- START PARTIAL TEMPLATE FROM CACHE ({cacheSettings.Id}) -->{fileContents}<!-- END PARTIAL TEMPLATE FROM CACHE ({cacheSettings.Id}) -->";
+                                    foundInOutputCache = true;
+                                }
+                                else
+                                {
+                                    // Cleanup the old cache file if it has expired.
+                                    fileInfo.Delete();
+                                }
                             }
                         }
 
@@ -159,7 +166,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             {
                 template.Content = templateContent;
             }
-            else if (!String.IsNullOrEmpty(fullCachePath))
+            else
             {
                 switch (cacheSettings.CachingLocation)
                 {
@@ -167,8 +174,14 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                         cache.Add(contentCacheKey, template.Content, DateTimeOffset.UtcNow.AddMinutes(cacheSettings.CachingMinutes));
                         break;
                     case TemplateCachingLocations.OnDisk:
-                        await File.WriteAllTextAsync(fullCachePath, template.Content);
+                    {
+                        if (!String.IsNullOrEmpty(fullCachePath))
+                        {
+                            await File.WriteAllTextAsync(fullCachePath, template.Content);
+                        }
+
                         break;
+                    }
                     default:
                         throw new ArgumentOutOfRangeException(nameof(cacheSettings.CachingLocation), cacheSettings.CachingLocation.ToString());
                 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedTemplatesService.cs
@@ -171,7 +171,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 switch (cacheSettings.CachingLocation)
                 {
                     case TemplateCachingLocations.InMemory:
-                        cache.Add(contentCacheKey, template.Content, DateTimeOffset.UtcNow.AddMinutes(cacheSettings.CachingMinutes));
+                        if (!String.IsNullOrWhiteSpace(contentCacheKey))
+                        {
+                            cache.Add(contentCacheKey, template.Content, DateTimeOffset.UtcNow.AddMinutes(cacheSettings.CachingMinutes));
+                        }
+
                         break;
                     case TemplateCachingLocations.OnDisk:
                     {

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
@@ -146,7 +146,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 switch (cacheSettings.CachingLocation)
                 {
                     case TemplateCachingLocations.InMemory:
-                        cache.Add(contentCacheKey, template.Content, DateTimeOffset.UtcNow.AddMinutes(cacheSettings.CachingMinutes));
+                        if (!String.IsNullOrWhiteSpace(contentCacheKey))
+                        {
+                            cache.Add(contentCacheKey, template.Content, DateTimeOffset.UtcNow.AddMinutes(cacheSettings.CachingMinutes));
+                        }
+
                         break;
                     case TemplateCachingLocations.OnDisk:
                     {


### PR DESCRIPTION
* The folders no longer get automatically created because often the user running the website does not have enough permissions.
* Reading and writing to the content or files cache folder will generate warnings in the logs when the folder is missing.
* If the content files folder is missing, all images and files will return a 404.
* The barcodes service will generate a warning in the logs when the content cache folder is missing.

Asana: https://app.asana.com/0/1200346761113317/1203064603974583