### PR TITLE
Return 404 when pagination page nr higher than max

### DIFF
--- a/GeeksCoreLibrary/Components/Pagination/Pagination.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Pagination.cs
@@ -190,6 +190,14 @@ namespace GeeksCoreLibrary.Components.Pagination
             {
                 return String.Empty;
             }
+            
+            // If the currently requested page is higher than the max possible page, return a 404 with a description of the issue.
+            if (currentPage > lastPageNumber)
+            {
+                WriteToTrace("GCL 404 Because trying to fetch a page that's higher than allowed", true);
+                HttpContextHelpers.Return404(httpContextAccessor.HttpContext);
+                return String.Empty;
+            }
 
             // Add links to the first and previous page when not on the first page.
             if (currentPage > 1)


### PR DESCRIPTION
Added functionality to return a 404 when the user requests a page nr which is higher than the allowed max.