### PR TITLE
Fixed Pagination component on empty results

### DIFF
--- a/GeeksCoreLibrary/Components/Pagination/Pagination.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Pagination.cs
@@ -190,9 +190,10 @@ namespace GeeksCoreLibrary.Components.Pagination
             {
                 return String.Empty;
             }
-            
+
             // If the currently requested page is higher than the max possible page, return a 404 with a description of the issue.
-            if (currentPage > lastPageNumber)
+            // Only do this if there's at least one page. Otherwise this component will always return a 404 response on empty results, which is not always desired.
+            if (lastPageNumber > 0 && currentPage > lastPageNumber)
             {
                 WriteToTrace("GCL 404 Because trying to fetch a page that's higher than allowed", true);
                 HttpContextHelpers.Return404(httpContextAccessor.HttpContext);


### PR DESCRIPTION
The Pagination component would always return a 404 response when the result was empty. This is because the current page number always starts at one, but the last page number will be zero if the SQL query returned an empty result set.

Asana: https://app.asana.com/0/1200923549887805/1203352369676148