### PR TITLE
Ignore header and footer when template is requested that is a partial.

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -214,7 +214,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
             new WiserTableDefinitionModel
             {
                 Name = WiserTableNames.WiserTemplate,
-                LastUpdate = new DateTime(2022, 10, 28),
+                LastUpdate = new DateTime(2022, 12, 9),
                 Columns = new List<ColumnSettingsModel>
                 {
                     new("id", MySqlDbType.Int32, notNull: true, isPrimaryKey: true, autoIncrement: true),
@@ -269,6 +269,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
                     new("is_default_header", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),
                     new("is_default_footer", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),
                     new("default_header_footer_regex", MySqlDbType.VarChar, 255),
+                    new("is_partial", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0")
                 },
                 Indexes = new List<IndexSettingsModel>
                 {

--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -87,7 +87,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                 return Unauthorized();
             }
 
-            var ombouw = !String.Equals(HttpContextHelpers.GetRequestValue(context, "ombouw"), "false", StringComparison.OrdinalIgnoreCase);
+            var ombouw = !String.Equals(HttpContextHelpers.GetRequestValue(context, "ombouw"), "false", StringComparison.OrdinalIgnoreCase) && !contentTemplate.IsPartial;
             switch (contentTemplate.Type)
             {
                 case TemplateTypes.Js:

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -50,6 +50,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
             template.CachingMinutes = await reader.IsDBNullAsync("cache_minutes") ? 0 : await reader.GetFieldValueAsync<int>("cache_minutes");
             template.CachingLocation = !reader.HasColumn("caching_location") || await reader.IsDBNullAsync("caching_location") ? TemplateCachingLocations.InMemory : (TemplateCachingLocations)await reader.GetFieldValueAsync<int>("caching_location");
             template.CachingRegex = reader.GetStringHandleNull("cache_regex");
+            template.IsPartial = !reader.HasColumn("is_partial") ? false : Convert.ToBoolean(reader.GetValue("is_partial"));
 
             if (!await reader.IsDBNullAsync("changed_on"))
             {

--- a/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
@@ -158,5 +158,10 @@ namespace GeeksCoreLibrary.Modules.Templates.Models
         /// Gets or sets the regular expression that is matched against the URL of the page, to decide whether to use the default header or footer.
         /// </summary>
         public string DefaultHeaderFooterRegex { get; set; }
+
+        /// <summary>
+        /// Gets or sets if this template is only a partial.
+        /// </summary>
+        public bool IsPartial { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -178,7 +178,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
     template.routine_return_type,
     template.trigger_timing,
     template.trigger_event,
-    template.trigger_table_name
+    template.trigger_table_name,
+    template.is_partial
 FROM {WiserTableNames.WiserTemplate} AS template
 {joinPart}
 LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)


### PR DESCRIPTION
Add functionality to mark an HTML template as a partial to ignore the header and footer template when requesting a template through an XHR call. Templates marked as partial no longer need to use "ombouw=false".

Combined with Wiser pull request: https://github.com/happy-geeks/wiser/pull/194

https://app.asana.com/0/1200346761113317/1203257614129593/