### PR TITLE
Pagination "rel=prev" and "rel=next" support

### DIFF
--- a/GeeksCoreLibrary/Components/Pagination/Models/PaginationCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Models/PaginationCmsSettingsModel.cs
@@ -149,6 +149,18 @@ namespace GeeksCoreLibrary.Components.Pagination.Models
         )]
         public bool RenderForSinglePage { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether "rel=next" and "rel=prev" link tags should be added to the page head.
+        /// </summary>
+        [CmsProperty(
+            PrettyName = "Add previous and next link relation tags",
+            Description = "Whether \"rel=next\" and \"rel=prev\" link tags should be added to the page head.",
+            TabName = CmsAttributes.CmsTabName.Behavior,
+            GroupName = CmsAttributes.CmsGroupName.Seo,
+            DisplayOrder = 10
+        )]
+        public bool AddPreviousAndNextLinkRelationTags { get; set; }
+
         #endregion
 
         #region Tab Layout properties

--- a/GeeksCoreLibrary/Components/Pagination/Models/PaginationLegacySettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Models/PaginationLegacySettingsModel.cs
@@ -58,6 +58,8 @@ namespace GeeksCoreLibrary.Components.Pagination.Models
 
         public bool showPagingOnOnePage { get; set; }
 
+        public bool AddRelPrevNextLinkTags { get; set; }
+
         public PaginationCmsSettingsModel ToSettingsModel()
         {
             var paginationCmsSettingsModel = new PaginationCmsSettingsModel
@@ -84,6 +86,7 @@ namespace GeeksCoreLibrary.Components.Pagination.Models
                 DotsTemplate = DotsTemplate,
                 DotsOffset = Convert.ToInt32(DotsOffset),
                 RenderForSinglePage = showPagingOnOnePage,
+                AddPreviousAndNextLinkRelationTags = AddRelPrevNextLinkTags,
 
                 // Inherited items from abstract parent
                 HandleRequest = HandleRequest,
@@ -118,6 +121,7 @@ namespace GeeksCoreLibrary.Components.Pagination.Models
                 LinkFormat = settings.LinkFormat,
                 DotsTemplate = settings.DotsTemplate,
                 DotsOffset = settings.DotsOffset.ToString(),
+                AddRelPrevNextLinkTags = settings.AddPreviousAndNextLinkRelationTags,
 
                 showPagingOnOnePage = settings.RenderForSinglePage,
                 HandleRequest = settings.HandleRequest,

--- a/GeeksCoreLibrary/Components/Pagination/Pagination.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Pagination.cs
@@ -15,15 +15,14 @@ using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Models;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 namespace GeeksCoreLibrary.Components.Pagination
 {
     public class Pagination : CmsComponent<PaginationCmsSettingsModel, Pagination.ComponentModes>
     {
-        private readonly IHttpContextAccessor httpContextAccessor;
         private readonly IFiltersService filtersService;
+        private readonly IPagesService pagesService;
 
         #region Enums
 
@@ -51,10 +50,10 @@ namespace GeeksCoreLibrary.Components.Pagination
 
         #region Constructor
 
-        public Pagination(ILogger<Pagination> logger, IStringReplacementsService stringReplacementsService, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IAccountsService accountsService, IHttpContextAccessor httpContextAccessor, IFiltersService filtersService)
+        public Pagination(ILogger<Pagination> logger, IStringReplacementsService stringReplacementsService, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IAccountsService accountsService, IFiltersService filtersService, IPagesService pagesService)
         {
-            this.httpContextAccessor = httpContextAccessor;
             this.filtersService = filtersService;
+            this.pagesService = pagesService;
 
             Logger = logger;
             StringReplacementsService = stringReplacementsService;
@@ -170,21 +169,59 @@ namespace GeeksCoreLibrary.Components.Pagination
                 }
             }
 
-            var resultHtml = new StringBuilder();
-            resultHtml.Append(await CreatePaginationHtml());
-            return new HtmlString(resultHtml.ToString());
-        }
-
-        private async Task<string> CreatePaginationHtml()
-        {
-            var paginationHtml = new StringBuilder();
-
-            if (!UInt32.TryParse(HttpContextHelpers.GetRequestValue(httpContextAccessor.HttpContext, Settings.PageNumberVariableName), out var currentPage))
+            if (!UInt32.TryParse(HttpContextHelpers.GetRequestValue(HttpContext, Settings.PageNumberVariableName), out var currentPage))
             {
                 currentPage = 1U;
             }
 
             var lastPageNumber = Convert.ToUInt32(Math.Ceiling(Convert.ToDecimal(totalItemCount) / Convert.ToDecimal(Settings.ItemsPerPage)));
+
+            if (Settings.AddPreviousAndNextLinkRelationTags)
+            {
+                string previousPageLink = null;
+                string nextPageLink = null;
+
+                // Check if link tags for the next and/or previous page should be added.
+                if (currentPage > 1)
+                {
+                    // Create previous page link.
+                    previousPageLink = ParseLinkFormat(currentPage - 1, true);
+                    if (!String.IsNullOrWhiteSpace(previousPageLink))
+                    {
+                        previousPageLink = await StringReplacementsService.DoAllReplacementsAsync(previousPageLink, handleRequest: Settings.HandleRequest, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables);
+                    }
+                }
+
+                if (currentPage < lastPageNumber)
+                {
+                    // Create next page link.
+                    nextPageLink = ParseLinkFormat(currentPage + 1, true);
+                    if (!String.IsNullOrWhiteSpace(nextPageLink))
+                    {
+                        nextPageLink = await StringReplacementsService.DoAllReplacementsAsync(nextPageLink, handleRequest: Settings.HandleRequest, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables);
+                    }
+                }
+
+                if (!String.IsNullOrWhiteSpace(previousPageLink) || !String.IsNullOrWhiteSpace(nextPageLink))
+                {
+                    pagesService.SetPageSeoData(previousPageLink: previousPageLink, nextPageLink: nextPageLink);
+                }
+            }
+
+            var resultHtml = new StringBuilder();
+            resultHtml.Append(await CreatePaginationHtml(currentPage, lastPageNumber));
+            return new HtmlString(resultHtml.ToString());
+        }
+
+        /// <summary>
+        /// Generates the complete pagination HTML.
+        /// </summary>
+        /// <param name="currentPage">The current page being viewed.</param>
+        /// <param name="lastPageNumber">The last page number, or total amount of pages.</param>
+        /// <returns>The complete pagination HTML as a string.</returns>
+        private async Task<string> CreatePaginationHtml(uint currentPage, uint lastPageNumber)
+        {
+            var paginationHtml = new StringBuilder();
 
             if (lastPageNumber <= 1 && !Settings.RenderForSinglePage)
             {
@@ -196,7 +233,7 @@ namespace GeeksCoreLibrary.Components.Pagination
             if (lastPageNumber > 0 && currentPage > lastPageNumber)
             {
                 WriteToTrace("GCL 404 Because trying to fetch a page that's higher than allowed", true);
-                HttpContextHelpers.Return404(httpContextAccessor.HttpContext);
+                HttpContextHelpers.Return404(HttpContext);
                 return String.Empty;
             }
 
@@ -356,6 +393,12 @@ namespace GeeksCoreLibrary.Components.Pagination
             return await TemplatesService.DoReplacesAsync(resultHtml, handleRequest: Settings.HandleRequest, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables);
         }
 
+        /// <summary>
+        /// Creates the HTML for a page template for the given page number.
+        /// </summary>
+        /// <param name="template">One of the page templates.</param>
+        /// <param name="pageNumber">The page number for the template.</param>
+        /// <returns>The parsed and evaluated HTML of a page template.</returns>
         private string ParsePageTemplate(string template, uint pageNumber)
         {
             if (String.IsNullOrWhiteSpace(template))
@@ -363,17 +406,29 @@ namespace GeeksCoreLibrary.Components.Pagination
                 return String.Empty;
             }
 
-            var linkFormat = Settings.LinkFormat.Replace("{pnr}", pageNumber.ToString()).Replace("{variablename}", Settings.PageNumberVariableName);
+            var link = ParseLinkFormat(pageNumber);
+            return template.Replace("{link}", link).Replace("{pnr}", pageNumber.ToString());
+        }
 
-            var originalQueryString = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor.HttpContext)?.Query;
+        /// <summary>
+        /// Parses and evaluates the link format.
+        /// </summary>
+        /// <param name="pageNumber">The page number to be used in the link format.</param>
+        /// <param name="absoluteUrl">Optional: Whether the URL should always be an absolute URL. The default is false.</param>
+        /// <returns>The URL for the given page number.</returns>
+        private string ParseLinkFormat(uint pageNumber, bool absoluteUrl = false)
+        {
+            var link = Settings.LinkFormat.Replace("{pnr}", pageNumber.ToString()).Replace("{variablename}", Settings.PageNumberVariableName);
+
+            var originalQueryString = HttpContextHelpers.GetOriginalRequestUri(HttpContext)?.Query;
             if (Settings.AddPageQueryStringToLinkFormat)
             {
                 var queryStringBuilder = HttpUtility.ParseQueryString(originalQueryString ?? "");
-                if (linkFormat.Contains("?", StringComparison.Ordinal))
+                if (link.Contains("?", StringComparison.Ordinal))
                 {
                     // Link format contains a query string; combine it with the request's query string.
-                    var qsIndex = linkFormat.IndexOf("?", StringComparison.Ordinal);
-                    var linkFormatQueryString = HttpUtility.ParseQueryString(linkFormat[(qsIndex + 1)..]);
+                    var qsIndex = link.IndexOf("?", StringComparison.Ordinal);
+                    var linkFormatQueryString = HttpUtility.ParseQueryString(link[(qsIndex + 1)..]);
 
                     foreach (var key in linkFormatQueryString.AllKeys)
                     {
@@ -381,35 +436,74 @@ namespace GeeksCoreLibrary.Components.Pagination
                     }
 
                     // Strip the query string from the query string (it will be added again afterwards).
-                    linkFormat = linkFormat[..qsIndex];
+                    link = link[..qsIndex];
                 }
 
-                var newLinkFormat = new StringBuilder(linkFormat);
+                var newLinkFormat = new StringBuilder(link);
                 newLinkFormat.Append('?').Append(queryStringBuilder);
-                linkFormat = newLinkFormat.ToString();
+                link = newLinkFormat.ToString();
             }
 
-            if (Settings.RemoveFirstPageFromUrl && pageNumber == 1U)
+            if (!Settings.RemoveFirstPageFromUrl || pageNumber != 1U) return absoluteUrl ? TurnRelativeUrlIntoAbsoluteUrl(link) : link;
+
+            // Remove the "&<PageNumberVariableName>=1" and "?<PageNumberVariableName>=1" parts from the link URL.
+            // If this results in an empty string, replace the entire URL with the "original request URI".
+            link = link.Replace($"&{Settings.PageNumberVariableName}=1", String.Empty);
+            link = link.Replace($"?{Settings.PageNumberVariableName}=1", String.Empty);
+
+            // Return the link if the removal of the page number variable didn't result in an empty link.
+            if (!String.IsNullOrEmpty(link)) return absoluteUrl ? TurnRelativeUrlIntoAbsoluteUrl(link) : link;
+
+            // If the link was empty after removing the page number variable, build a new URL using the absolute URL.
+            var originalRequestUri = HttpContextHelpers.GetOriginalRequestUri(HttpContext);
+            var uriWithoutQueryString = originalRequestUri.GetLeftPart(UriPartial.Path);
+
+            // Rebuild the query string to make sure it doesn't contain the page number variable name.
+            var newQueryString = HttpUtility.ParseQueryString(originalRequestUri.Query);
+            newQueryString.Remove(Settings.PageNumberVariableName);
+
+            link = newQueryString.Count > 0 ? $"{uriWithoutQueryString}?{newQueryString}" : uriWithoutQueryString;
+
+            return absoluteUrl ? TurnRelativeUrlIntoAbsoluteUrl(link) : link;
+        }
+
+        /// <summary>
+        /// Turns a URL into an absolute URL. If the URL is already an absolute URL, the original URL is returned and
+        /// nothing is changed.
+        /// </summary>
+        /// <param name="url">The URL to turn into an absolute URL.</param>
+        /// <returns>An absolute URL.</returns>
+        private string TurnRelativeUrlIntoAbsoluteUrl(string url)
+        {
+            if (url.StartsWith("http", StringComparison.Ordinal))
             {
-                // Remove the "&<PageNumberVariableName>=1" and "?<PageNumberVariableName>=1" parts from the link URL.
-                // If this results in an empty string, replace the entire URL with the "original request URI".
-                linkFormat = linkFormat.Replace($"&{Settings.PageNumberVariableName}=1", String.Empty);
-                linkFormat = linkFormat.Replace($"?{Settings.PageNumberVariableName}=1", String.Empty);
-
-                if (linkFormat == String.Empty)
-                {
-                    var originalRequestUri = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor.HttpContext);
-                    var uriWithoutQueryString = originalRequestUri.GetLeftPart(UriPartial.Path);
-
-                    // Rebuild the query string to make sure it doesn't contain the page number variable name.
-                    var newQueryString = HttpUtility.ParseQueryString(originalRequestUri.Query);
-                    newQueryString.Remove(Settings.PageNumberVariableName);
-
-                    linkFormat = newQueryString.Count > 0 ? $"{uriWithoutQueryString}?{newQueryString}" : uriWithoutQueryString;
-                }
+                // URL is already absolute.
+                return url;
             }
 
-            return template.Replace("{link}", linkFormat).Replace("{pnr}", pageNumber.ToString());
+            // Build a new URI.
+            var uriBuilder = new UriBuilder
+            {
+                Host = HttpContext.Request.Host.Host,
+                Scheme = HttpContext.Request.Scheme,
+                Port = HttpContext.Request.Host.Port ?? (HttpContext.Request.IsHttps ? 443 : 80)
+            };
+
+            if (!url.Contains('?', StringComparison.Ordinal))
+            {
+                // No query string in the URL, just set the path.
+                uriBuilder.Path = url;
+            }
+            else
+            {
+                // Have to split up the path and query, otherwise the question mark will be URL-encoded.
+                var split = url.Split('?');
+                uriBuilder.Path = split[0];
+                uriBuilder.Query = split[1];
+            }
+
+            // Turn the builder into a string and return it.
+            return uriBuilder.Uri.ToString();
         }
 
         #endregion

--- a/GeeksCoreLibrary/Modules/Seo/Models/PageMetaDataModel.cs
+++ b/GeeksCoreLibrary/Modules/Seo/Models/PageMetaDataModel.cs
@@ -53,5 +53,15 @@ namespace GeeksCoreLibrary.Modules.Seo.Models
         /// If the body HTML contains a variable like '\[{seomodule_h3header}\|(.*?)\]', then that will be replaced with this text.
         /// </summary>
         public string H3Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the previous page. This is for pages that have pagination.
+        /// </summary>
+        public string PreviousPageLink { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the next page. This is for pages that have pagination.
+        /// </summary>
+        public string NextPageLink { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
@@ -39,7 +39,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <summary>
         /// Sets the SEO meta data for the current page.
         /// </summary>
-        void SetPageSeoData(string seoTitle = null, string seoDescription = null, string seoKeyWords = null, string seoCanonical = null, bool noIndex = false, bool noFollow = false, IEnumerable<string> robots = null);
+        void SetPageSeoData(string seoTitle = null, string seoDescription = null, string seoKeyWords = null, string seoCanonical = null, bool noIndex = false, bool noFollow = false, IEnumerable<string> robots = null, string previousPageLink = null, string nextPageLink = null);
 
         /// <summary>
         /// Sets the Open Graph meta data for the current page.

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -525,6 +525,16 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 {
                     viewModel.MetaData.SeoText = componentSeoData.SeoText;
                 }
+
+                if (!String.IsNullOrWhiteSpace(componentSeoData.PreviousPageLink) && String.IsNullOrWhiteSpace(viewModel.MetaData.PreviousPageLink))
+                {
+                    viewModel.MetaData.PreviousPageLink = componentSeoData.PreviousPageLink;
+                }
+
+                if (!String.IsNullOrWhiteSpace(componentSeoData.NextPageLink) && String.IsNullOrWhiteSpace(viewModel.MetaData.NextPageLink))
+                {
+                    viewModel.MetaData.NextPageLink = componentSeoData.NextPageLink;
+                }
             }
 
             // See if we need to add canonical to self, but only if no other canonical has been added yet.
@@ -596,14 +606,14 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public void SetPageSeoData(string seoTitle = null, string seoDescription = null, string seoKeyWords = null, string seoCanonical = null, bool noIndex = false, bool noFollow = false, IEnumerable<string> robots = null)
+        public void SetPageSeoData(string seoTitle = null, string seoDescription = null, string seoKeyWords = null, string seoCanonical = null, bool noIndex = false, bool noFollow = false, IEnumerable<string> robots = null, string previousPageLink = null, string nextPageLink = null)
         {
             if (httpContextAccessor.HttpContext == null)
             {
                 return;
             }
 
-            if (String.IsNullOrWhiteSpace(seoTitle) && String.IsNullOrWhiteSpace(seoDescription) && String.IsNullOrWhiteSpace(seoKeyWords) && String.IsNullOrWhiteSpace(seoCanonical) && !noIndex && !noFollow && robots == null)
+            if (String.IsNullOrWhiteSpace(seoTitle) && String.IsNullOrWhiteSpace(seoDescription) && String.IsNullOrWhiteSpace(seoKeyWords) && String.IsNullOrWhiteSpace(seoCanonical) && !noIndex && !noFollow && robots == null && String.IsNullOrWhiteSpace(previousPageLink) && String.IsNullOrWhiteSpace(nextPageLink))
             {
                 return;
             }
@@ -652,6 +662,16 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 {
                     componentSeoData.MetaTags.Add("robots", String.Join(",", allRobots));
                 }
+            }
+
+            if (!String.IsNullOrWhiteSpace(previousPageLink) && String.IsNullOrWhiteSpace(componentSeoData.PreviousPageLink))
+            {
+                componentSeoData.PreviousPageLink = previousPageLink;
+            }
+
+            if (!String.IsNullOrWhiteSpace(nextPageLink) && String.IsNullOrWhiteSpace(componentSeoData.NextPageLink))
+            {
+                componentSeoData.NextPageLink = nextPageLink;
             }
 
             httpContextAccessor.HttpContext.Items[Constants.PageMetaDataFromComponentKey] = componentSeoData;

--- a/GeeksCoreLibrary/Modules/Templates/Views/Shared/Template.cshtml
+++ b/GeeksCoreLibrary/Modules/Templates/Views/Shared/Template.cshtml
@@ -133,6 +133,16 @@
         {
             @:<link href="@Model.MetaData.Canonical" rel="canonical" />
         }
+
+        if (!String.IsNullOrWhiteSpace(Model?.MetaData?.PreviousPageLink))
+        {
+            @:<link href="@Model.MetaData.PreviousPageLink" rel="prev" />
+        }
+
+        if (!String.IsNullOrWhiteSpace(Model?.MetaData?.NextPageLink))
+        {
+            @:<link href="@Model.MetaData.NextPageLink" rel="next" />
+        }
     }
 }
 


### PR DESCRIPTION
Adds a new option to the `Pagination` component called `AddPreviousAndNextLinkRelationTags` that will add `<link>` tags to the `<head>` section of the page for the next and previous page.

Asana: https://app.asana.com/0/1201926624799606/1202014165901940