### PR TITLE
Default canonical URL fixes

### DIFF
--- a/GeeksCoreLibrary/Modules/Seo/Services/CachedSeoService.cs
+++ b/GeeksCoreLibrary/Modules/Seo/Services/CachedSeoService.cs
@@ -29,7 +29,7 @@ namespace GeeksCoreLibrary.Modules.Seo.Services
         /// <inheritdoc />
         public async Task<PageMetaDataModel> GetSeoDataForPageAsync(Uri pageUri)
         {
-            return await cache.GetOrAddAsync($"Seo_{pageUri.AbsolutePath}",
+            return await cache.GetOrAddAsync($"Seo_{pageUri.AbsoluteUri}",
                 async cacheEntry =>
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultSeoModuleCacheDuration;

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -575,7 +575,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                         }
                     }
 
-                    viewModel.MetaData.Canonical = canonicalUrl.ToString();
+                    // Call the Uri's ToString method instead of the UriBuilder's ToString, otherwise default ports will
+                    // be added (like 443 for https and 80 for http).
+                    viewModel.MetaData.Canonical = canonicalUrl.Uri.ToString();
                 }
             }
 


### PR DESCRIPTION
* Default port no longer gets added to hostname (e.g. site.com:443).
* The SEO information is now saved with the entire URL in the cache key to avoid issues with pages getting the wrong canonical URL.

Asana: https://app.asana.com/0/1201926624799606/1202014165901938