### PR TITLE
Improve the query for the path contains functionality in webpages.

### DIFF
--- a/GeeksCoreLibrary/Components/WebPage/Services/WebPagesService.cs
+++ b/GeeksCoreLibrary/Components/WebPage/Services/WebPagesService.cs
@@ -130,12 +130,12 @@ LEFT JOIN `{WiserTableNames.WiserItemDetail}` AS `{seoTitleAlias}` ON `{seoTitle
 
                 if (!String.IsNullOrWhiteSpace(pathMustContain) && settings.SearchNumberOfLevels > 0)
                 {
-                    query.Append(" AND CONCAT_WS('/'");
+                    query.Append(" AND CONCAT_WS('/', ''");
                     for (var i = settings.SearchNumberOfLevels; i > 0; i--)
                     {
                         query.Append($", IFNULL(`item{i}SeoName`.`value`, `item{i}SeoName`.`value`)");
                     }
-                    query.Append(") LIKE CONCAT('%', ?path, '%')");
+                    query.Append(", '') LIKE CONCAT('%', ?path, '%')");
                 }
             }
             query.AppendLine();


### PR DESCRIPTION
When a webpage is in two folders and those folders have a shared part the order was deciding in which webpage was selected.

For example a webpage named "information" in the folders "about products" and "about" would give the webpage in the "about products" folder instead of "about" when the path must contain "about".

By adding an empty string before and after the path it will create a "/" before and after so the path contains can be set with "/about/" to refer to the correct folder.

https://app.asana.com/0/1200346761113317/1203198059524791/