### PR TITLE
Ignore API paths when checking templates.

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
@@ -49,6 +49,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
             }
 
             var path = context.Request.Path.ToUriComponent();
+            if (path.StartsWith("/api/", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // An API URL is called, no need to find a template.
+                await this.next.Invoke(context);
+                return;
+            }
+            
             var queryString = context.Request.QueryString;
             if (!context.Items.ContainsKey(Constants.OriginalPathKey))
             {


### PR DESCRIPTION
If a path starts with "/api/" don't try to get a corresponding template. This way custom endpoints can be called without the regex of a template finding a match on the path.

Ticket: https://app.asana.com/0/1200923549887805/1203320858738332