### PR TITLE
Update for the string replacements service

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Extensions/StringReplacementsExtensions.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Extensions/StringReplacementsExtensions.cs
@@ -328,5 +328,24 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Extensions
         {
             return useInvariantCulture ? input?.ToLowerInvariant() : input?.ToLower();
         }
+
+        /// <summary>
+        /// Converts an input string to an image URL. Note that the URL is always relative, starting with a '<c>/</c>'.
+        /// </summary>
+        /// <param name="input">The string to encode.</param>
+        /// <param name="width">The width of the image.</param>
+        /// <param name="height">The height of the image.</param>
+        /// <returns>The image URL.</returns>
+        public static string QrCode(this string input, int width, int height)
+        {
+            if (String.IsNullOrWhiteSpace(input) || width <= 0 || height <= 0)
+            {
+                return String.Empty;
+            }
+
+            var url = $"/barcodes/generate?input={Uri.EscapeDataString(input)}&format=qr_code&width={width}&height={height}";
+
+            return url;
+        }
     }
 }

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -605,7 +605,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
         /// <inheritdoc />
         public string FillStringByClassList(JToken input, string inputString, bool evaluateTemplate = false, string repeatVariableName = "repeat")
         {
-            var output = "";
+            var output = new StringBuilder();
 
             if (input.Type == JTokenType.Array)
             {
@@ -626,25 +626,26 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                         subtemplate = subtemplate.Replace("{index}", index.ToString());
                         subtemplate = subtemplate.Replace("{volgnr}", (index + 1).ToString());
                         subtemplate = subtemplate.Replace("{count}", "{~count~}"); // Temporary replace count variable, otherwise this variable is replaced by the FillStringByClass function
-                        output += FillStringByClass(item, subtemplate, evaluateTemplate).Replace("{~count~}", "{count}"); // Set back the count variable
+                        output.Append(FillStringByClass(item, subtemplate, evaluateTemplate).Replace("{~count~}", "{count}")); // Set back the count variable
                         index += 1;
                     }
 
-                    output = m.Groups[1].Value + output + m.Groups[3].Value;
-                    output = output.Replace("{count}", index.ToString());
+                    output.Insert(0, m.Groups[1].Value);
+                    output.Append(m.Groups[3].Value);
+                    output.Replace("{count}", index.ToString());
                 }
                 else
                 {
                     // Use only the first item in the JSON
-                    output = FillStringByClass(input.First, inputString, evaluateTemplate);
+                    output.Append(FillStringByClass(input.First, inputString, evaluateTemplate));
                 }
             }
             else
             {
-                output = FillStringByClass(input, inputString, evaluateTemplate);
+                output.Append(FillStringByClass(input, inputString, evaluateTemplate));
             }
 
-            return output;
+            return output.ToString();
         }
 
         /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -626,7 +626,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                         subtemplate = subtemplate.Replace("{index}", index.ToString());
                         subtemplate = subtemplate.Replace("{volgnr}", (index + 1).ToString());
                         subtemplate = subtemplate.Replace("{count}", "{~count~}"); // Temporary replace count variable, otherwise this variable is replaced by the FillStringByClass function
-                        output += FillStringByClass(item, subtemplate).Replace("{~count~}", "{count}"); // Set back the count variable
+                        output += FillStringByClass(item, subtemplate, evaluateTemplate).Replace("{~count~}", "{count}"); // Set back the count variable
                         index += 1;
                     }
 
@@ -636,7 +636,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                 else
                 {
                     // Use only the first item in the JSON
-                    output = FillStringByClass(input.First, inputString);
+                    output = FillStringByClass(input.First, inputString, evaluateTemplate);
                 }
             }
             else
@@ -686,7 +686,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                             subTemplateItem = subTemplateItem.Replace($"{{/repeat:{repeaterName}", $"{{/repeat:{repeaterName}({index})");
                             subTemplateItem = subTemplateItem.Replace($"{{~{repeaterName}.count~}}", $"{{{repeaterName}.count}}");
 
-                            subTemplateItem = FillStringByClassList(subObject, subTemplateItem);
+                            subTemplateItem = FillStringByClassList(subObject, subTemplateItem, evaluateTemplate);
 
                             templates.Append(subTemplateItem);
 


### PR DESCRIPTION
Added new formatter called `QrCode` which will return a URL to generate a QR code for a string. Also fixed the `FillStringByClass` and `FillStringByClassList` functions not passing the `evaluateTemplate` parameter to recursive calls.

Asana: https://app.asana.com/0/272408684267078/1203234477426276