### PR TITLE
Configurator sub steps placement

### DIFF
--- a/GeeksCoreLibrary/Components/Configurator/Models/SubStepHtmlModel.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Models/SubStepHtmlModel.cs
@@ -1,0 +1,22 @@
+﻿namespace GeeksCoreLibrary.Components.Configurator.Models;
+
+/// <summary>
+/// Model that represents a rendered sub step.
+/// </summary>
+public class SubStepHtmlModel
+{
+    /// <summary>
+    /// Gets or sets the Wiser item ID of the sub step.
+    /// </summary>
+    public ulong Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Wiser item title of the sub step.
+    /// </summary>
+    public string Name { get; init; }
+
+    /// <summary>
+    /// Gets or sets the rendered HTML of the sub step.
+    /// </summary>
+    public string Html { get; init; }
+}


### PR DESCRIPTION
Changed the way the sub steps can be placed in the HTML by allowing only certain sub steps (by either ID or name) to be placed in specific parts of the HTML, by using pipes to separate the IDs or names of the substeps, like so: `{substeps|789|123}` or `{substeps|Step 4|Step 2}`. The regular `{substeps}` variable is also still available.

Asana: https://app.asana.com/0/1200346761113317/1202855528276892