### PR TITLE
Don't save history when creating a configuration.

### DIFF
--- a/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
@@ -743,7 +743,7 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
             configuration.Details.AddRange(input.QueryStringItems.Select(x => new WiserItemDetailModel { Key = x.Key, Value = x.Value }));
 
             // save main item
-            await wiserItemsService.SaveAsync(configuration, parentId, skipPermissionsCheck: true);
+            await wiserItemsService.SaveAsync(configuration, parentId, skipPermissionsCheck: true, saveHistory: false);
 
             // save configuration line query, we run this query to get all the other variables that need to be added to the configuration line like ean, purchaseprice etc.
             var saveConfigLineQuery = await objectsService.GetSystemObjectValueAsync("CONFIGURATOR_SaveConfigurationLineQuery");
@@ -787,7 +787,7 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                 }
 
                 // save configuration line
-                await wiserItemsService.SaveAsync(configurationItem, skipPermissionsCheck: true);
+                await wiserItemsService.SaveAsync(configurationItem, skipPermissionsCheck: true, saveHistory: false);
             }
 
             var dataTable = await GetConfiguratorDataAsync(input.Configurator);


### PR DESCRIPTION
When a configuration is created about half the time is spend on the history, since each (selected/answered) option in the configurator is saved the time needed increases.

When creating the configuration all the previous values are nothing, therefore the history is useless at this stage.

https://app.asana.com/0/1200923549887805/1203802664624132