### PR TITLE
Fixed problem that sometimes translations were missing

### DIFF
--- a/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
+++ b/GeeksCoreLibrary/Modules/Languages/Services/CachedLanguagesService.cs
@@ -57,7 +57,8 @@ namespace GeeksCoreLibrary.Modules.Languages.Services
         /// <inheritdoc />
         public async Task<string> GetTranslationAsync(string original, string languageItemCode = null, string defaultValue = null)
         {
-            var cachedLanguages = await CacheLanguageAsync(!String.IsNullOrWhiteSpace(languageItemCode) ? languageItemCode : CurrentLanguageCode);
+            var languageCode = !String.IsNullOrWhiteSpace(languageItemCode) ? languageItemCode : (CurrentLanguageCode ?? await GetLanguageCodeAsync());
+            var cachedLanguages = await CacheLanguageAsync(languageCode);
             return cachedLanguages.ContainsKey(original) && !String.IsNullOrEmpty(cachedLanguages[original]?.ToString()) ? cachedLanguages[original]?.ToString() : (defaultValue ?? original);
         }
 


### PR DESCRIPTION
In some cases the CurrentLanguageCode was null, which caused a problem with missing translations. This commit should fix that.

Asana ticket: https://app.asana.com/0/1200923549887805/1203513747164244