### PR TITLE
Improve performance for saving items.

### DIFF
--- a/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
@@ -863,7 +863,6 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                         Value = requestJson,
                         GroupName = saveApi.Title
                     });
-                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true);
                     
                     var restResponse = await restClient.ExecuteAsync(restRequest);
                     
@@ -873,7 +872,6 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                         Value = restResponse.Content,
                         GroupName = saveApi.Title
                     });
-                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true);
                     
                     if (!restResponse.IsSuccessful || restResponse.Content == null)
                     {
@@ -883,6 +881,7 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                     // If the call only needed to be made and no supplier ID needs to be retrieved the last part can be skipped.
                     if (String.IsNullOrWhiteSpace(supplierIdKey))
                     {
+                        await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true, saveHistory: false);
                         continue;
                     }
 
@@ -905,7 +904,7 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                         Value = supplierId,
                         GroupName = saveApi.Title
                     });
-                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true);
+                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true, saveHistory: false);
                 }
                 catch (Exception e)
                 {
@@ -917,7 +916,7 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
                         Value = e.ToString(),
                         GroupName = saveApi.Title
                     });
-                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true);
+                    await wiserItemsService.SaveAsync(configuration, skipPermissionsCheck: true, saveHistory: false);
                 }
             }
 

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -98,6 +98,9 @@ namespace GeeksCoreLibrary.Core.Services
                 if (wiserItem.Id == 0)
                 {
                     wiserItem = await wiserItemsService.CreateAsync(wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, false, skipPermissionsCheck);
+                    
+                    // When a new item has been created the values always need to be saved. There is no use to check if they have been changed since they are all new.
+                    alwaysSaveValues = true;
                 }
 
                 var result = await wiserItemsService.UpdateAsync(wiserItem.Id, wiserItem, userId, username, encryptionKey, alwaysSaveValues, saveHistory, false, skipPermissionsCheck);


### PR DESCRIPTION
Refactored the way the configurator saves the logging of save API calls.

Set "alwaysSavesValues" to true when creating a new item. Since all values are new there is no need to check if the value has been updated.