### PR TITLE
Fix multiple bugs in the order processing.

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -436,7 +436,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                     case OrderProcessStepTypes.OrderConfirmation:
                     case OrderProcessStepTypes.OrderPending:
                         var order = new WiserItemModel();
-                        string errorMessage = null;
+                        var errorMessage = "";
                         if (httpContextAccessor.HttpContext == null || !httpContextAccessor.HttpContext.Request.Query.ContainsKey("order"))
                         {
                             errorMessage = "Order not found, please contact us";
@@ -466,12 +466,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                         }
 
                         var confirmationHtml = ReplaceEntityDataInTemplate(order, currentItems, step, steps, paymentMethods);
-
-                        if (!String.IsNullOrWhiteSpace(errorMessage))
-                        {
-                            confirmationHtml = confirmationHtml.Replace("{loadOrderError}", await languagesService.GetTranslationAsync(errorMessage));
-                        }
-                        
+                        confirmationHtml = confirmationHtml.Replace("{loadOrderError}", await languagesService.GetTranslationAsync(errorMessage));
                         groupsBuilder.AppendLine(confirmationHtml);
 
                         // Empty the shopping basket.

--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -21,6 +21,7 @@ using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.MeasurementProtocol.Interfaces;
@@ -434,7 +435,9 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                         break;
                     case OrderProcessStepTypes.OrderConfirmation:
                     case OrderProcessStepTypes.OrderPending:
-                        var confirmationHtml = ReplaceEntityDataInTemplate(shoppingBasket, currentItems, step, steps, paymentMethods);
+                        var orderId = Convert.ToUInt64(httpContextAccessor.HttpContext.Request.Query["order"].ToString().Decrypt());
+                        var order = await wiserItemsService.GetItemDetailsAsync(orderId,  entityType: Constants.OrderEntityType, skipPermissionsCheck: true);
+                        var confirmationHtml = ReplaceEntityDataInTemplate(order, currentItems, step, steps, paymentMethods);
                         groupsBuilder.AppendLine(confirmationHtml);
 
                         // Empty the shopping basket.

--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -23,6 +23,7 @@ using GeeksCoreLibrary.Modules.Communication.Interfaces;
 using GeeksCoreLibrary.Modules.Communication.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.GclConverters.Interfaces;
+using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.MeasurementProtocol.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
@@ -855,6 +856,10 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
 
                     orderId = conceptOrderId;
                 }
+                // Add order ID to the URLs for later reference.
+                var queryParameters = new Dictionary<string, string> {{"order", orderId.ToString().Encrypt()}};
+                paymentMethodSettings.PaymentServiceProvider.SuccessUrl = UriHelpers.AddToQueryString(paymentMethodSettings.PaymentServiceProvider.SuccessUrl, queryParameters);
+                paymentMethodSettings.PaymentServiceProvider.PendingUrl = UriHelpers.AddToQueryString(paymentMethodSettings.PaymentServiceProvider.PendingUrl, queryParameters);
 
                 // Generate invoice number.
                 var invoiceNumber = "";
@@ -935,12 +940,6 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
 
                 if (convertConceptOrderToOrder)
                 {
-                    foreach (var (main, _) in conceptOrders)
-                    {
-                        await shoppingBasketsService.ConvertConceptOrderToOrderAsync(main, basketSettings);
-                        // TODO: Call "TransactionFinished" site function.
-                    }
-                    
                     await HandlePaymentStatusUpdateAsync(orderProcessesService, orderProcessSettings, conceptOrders, "Success", true, convertConceptOrderToOrder);
 
                     return new PaymentRequestResult

--- a/GeeksCoreLibrary/Core/Helpers/StringHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/StringHelpers.cs
@@ -49,7 +49,7 @@ namespace GeeksCoreLibrary.Core.Helpers
 
             if (!regex.IsMatch(ean))
             {
-                throw new ArgumentException($"Value '{ean}' is an invalid EAN. The EAN must consist of 12 numerical values",ean);
+                throw new ArgumentException($"Value '{ean}' is an invalid EAN. The EAN must consist of 12 numerical values", ean);
             }
 
             var calculationSum = 0;
@@ -79,7 +79,7 @@ namespace GeeksCoreLibrary.Core.Helpers
         public static string HashValue(string value, HashSettingsModel hashSettings)
         {
             HashAlgorithm hashAlgorithm;
-            
+
             switch (hashSettings.Algorithm)
             {
                 case HashAlgorithms.MD5:
@@ -97,10 +97,10 @@ namespace GeeksCoreLibrary.Core.Helpers
                 default:
                     throw new ArgumentOutOfRangeException(nameof(hashSettings.Algorithm), hashSettings.Algorithm, null);
             }
-            
+
             var bytes = Encoding.ASCII.GetBytes(value);
             var hashBytes = hashAlgorithm.ComputeHash(bytes);
-            
+
             hashAlgorithm.Dispose();
 
             switch (hashSettings.Representation)

--- a/GeeksCoreLibrary/Core/Helpers/UriHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/UriHelpers.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web;
+using GeeksCoreLibrary.Core.Extensions;
+
+namespace GeeksCoreLibrary.Core.Helpers;
+
+public class UriHelpers
+{
+    /// <summary>
+    /// Add parameters to the query string of an URL.
+    /// </summary>
+    /// <param name="url">The URL to add the parameters to.</param>
+    /// <param name="parameters">The parameters to add.</param>
+    /// <returns>The finished URL.</returns>
+    public static string AddToQueryString(string url, IDictionary<string, string> parameters)
+    {
+        var uri = new Uri(url);
+        return AddToQueryString(uri, parameters);
+    }
+    
+    /// <summary>
+    /// Add parameters to the query string of an URL.
+    /// </summary>
+    /// <param name="uri">The URI to add the parameters to.</param>
+    /// <param name="parameters">The parameters to add.</param>
+    /// <returns>The finished URL.</returns>
+    public static string AddToQueryString(Uri uri, IDictionary<string, string> parameters)
+    {
+        var uriBuilder = new UriBuilder(uri);
+        var queryString = HttpUtility.ParseQueryString(uriBuilder.Query);
+
+        foreach (var parameter in parameters)
+        {
+            queryString.Add(parameter.Key, parameter.Value);
+        }
+
+        uriBuilder.Query = queryString.ToQueryString();
+        return uriBuilder.ToString();
+    }
+}


### PR DESCRIPTION
Concept orders were converted twice to an order. This causes the "AfterConvertToOrder" to be called twice.

On summary the basket information was available for replacements instead of the order. The order is now added to the URL for the PSP to know for which order to load the information.

https://app.asana.com/0/1201763244049195/1203965426621542
https://app.asana.com/0/1201763244049195/1203965426621547