### PR TITLE
Fixed potential NRE in DoSessionReplacements

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -230,7 +230,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
         /// <inheritdoc />
         public string DoSessionReplacements(string input, bool forQuery = false)
         {
-            if (httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>() == null || !httpContextAccessor.HttpContext.Session.IsAvailable)
+            if (httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>()?.Session == null || !httpContextAccessor.HttpContext.Session.IsAvailable)
             {
                 return input;
             }


### PR DESCRIPTION
Fixed a potential `NullReferenceException` in the `DoSessionReplacements` method when the session feature is enabled, but the session itself being `null`.

There is no ticket for this PR.