### PR TITLE
Fix for adding and dropping MySQL table columns

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
@@ -119,8 +119,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 await databaseConnection.EnsureOpenConnectionForReadingAsync();
                 databaseName = databaseConnection.ConnectedDatabase;
             }
-            databaseConnection.AddParameter("columnName", columnName);
-            await databaseConnection.ExecuteAsync($"ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{tableName.ToMySqlSafeValue(false)}` DROP COLUMN ?columnName");
+            await databaseConnection.ExecuteAsync($"ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{tableName.ToMySqlSafeValue(false)}` DROP COLUMN `{columnName.ToMySqlSafeValue(false)}`");
         }
 
         /// <inheritdoc />
@@ -698,7 +697,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
             if (!String.IsNullOrWhiteSpace(settings.AddAfterColumnName))
             {
-                queryBuilder.Append($" AFTER `{settings.AddAfterColumnName}`");
+                queryBuilder.Append($" AFTER `{settings.AddAfterColumnName.ToMySqlSafeValue(false)}`");
             }
 
             return queryBuilder;

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
@@ -698,8 +698,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
             if (!String.IsNullOrWhiteSpace(settings.AddAfterColumnName))
             {
-                databaseConnection.AddParameter($"addAfterColumnName{parameterSuffix}", settings.AddAfterColumnName);
-                queryBuilder.Append($" AFTER ?addAfterColumnName{parameterSuffix}");
+                queryBuilder.Append($" AFTER `{settings.AddAfterColumnName}`");
             }
 
             return queryBuilder;


### PR DESCRIPTION
Some fixes for the `MySqlDatabaseHelpersService`:
* The `AddAfterColumnName` functionality didn't work due to the name being added as a parameter to the MySQL command, which would turn it into a string even though it's not supposed to be a string.
* The `DropColumnAsync` method didn't work due to using a parameter for the column name, which would turn it into a string, but that makes the query invalid.

Asana: https://app.asana.com/0/5038781037429/1203237258080996

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203237258080996