### PR TITLE
OrderProcess - Disable XSRF protection for payment updates

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Controllers/OrderProcessesController.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Controllers/OrderProcessesController.cs
@@ -13,7 +13,6 @@ using GeeksCoreLibrary.Modules.Templates.Enums;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Models;
 using GeeksCoreLibrary.Modules.Templates.Services;
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -85,6 +84,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Controllers
         }
 
         [Route(Constants.PaymentInPage)]
+        [IgnoreAntiforgeryToken]
         public async Task<IActionResult> PaymentInAsync()
         {
             var context = HttpContext;
@@ -100,6 +100,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Controllers
         }
 
         [Route(Constants.PaymentReturnPage)]
+        [IgnoreAntiforgeryToken]
         public async Task<IActionResult> PaymentReturnAsync()
         {
             var context = HttpContext;


### PR DESCRIPTION
The `PaymentInAsync` and `PaymentReturnAsync` endpoints are usually called by external systems which would be blocked by the anti-XSRF protection. The `IgnoreAntiforgeryToken` attribute will allow these endpoints to be called without having to disable the protection for the entire website.