### PR TITLE
Added async modifier to methods returning a Task

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
@@ -60,18 +60,18 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         public string ConnectedDatabaseForWriting => databaseConnection.ConnectedDatabaseForWriting;
 
         /// <inheritdoc />
-        public Task<DbDataReader> GetReaderAsync(string query)
+        public async Task<DbDataReader> GetReaderAsync(string query)
         {
-            return databaseConnection.GetReaderAsync(query);
+            return await databaseConnection.GetReaderAsync(query);
         }
 
         /// <inheritdoc />
-        public Task<DataTable> GetAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
+        public async Task<DataTable> GetAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
         {
             // TODO: This skipCache parameter is temporary, and will be removed once a better solution is found to skip cache.
             if (skipCache)
             {
-                return databaseConnection.GetAsync(query, cleanUp: cleanUp, useWritingConnectionIfAvailable: useWritingConnectionIfAvailable);
+                return await databaseConnection.GetAsync(query, cleanUp: cleanUp, useWritingConnectionIfAvailable: useWritingConnectionIfAvailable);
             }
 
             var currentUri = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext);
@@ -88,7 +88,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 cacheName.Append($"{key}={value}");
             }
 
-            return cache.GetOrAddAsync(cacheName.ToString(),
+            return await cache.GetOrAddAsync(cacheName.ToString(),
                 async cacheEntry =>
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;
@@ -97,12 +97,12 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         }
 
         /// <inheritdoc />
-        public Task<string> GetAsJsonAsync(string query, bool formatResult = false, bool skipCache = false)
+        public async Task<string> GetAsJsonAsync(string query, bool formatResult = false, bool skipCache = false)
         {
             // TODO: This skipCache parameter is temporary, and will be removed once a better solution is found to skip cache.
             if (skipCache)
             {
-                return databaseConnection.GetAsJsonAsync(query, formatResult);
+                return await databaseConnection.GetAsJsonAsync(query, formatResult);
             }
 
             var cacheName = new StringBuilder("GCL_QUERY_");
@@ -118,7 +118,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 cacheName.Append($"{key}={value}");
             }
 
-            return cache.GetOrAddAsync(cacheName.ToString(),
+            return await cache.GetOrAddAsync(cacheName.ToString(),
                 async cacheEntry =>
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;
@@ -127,39 +127,39 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         }
 
         /// <inheritdoc />
-        public Task<int> ExecuteAsync(string query, bool useWritingConnectionIfAvailable = true, bool cleanUp = true)
+        public async Task<int> ExecuteAsync(string query, bool useWritingConnectionIfAvailable = true, bool cleanUp = true)
         {
-            return databaseConnection.ExecuteAsync(query, useWritingConnectionIfAvailable);
+            return await databaseConnection.ExecuteAsync(query, useWritingConnectionIfAvailable);
         }
 
         /// <inheritdoc />
-        public Task<T> InsertOrUpdateRecordBasedOnParametersAsync<T>(string tableName, T id = default, string idColumnName = "id", bool ignoreErrors = false, bool useWritingConnectionIfAvailable = true)
+        public async Task<T> InsertOrUpdateRecordBasedOnParametersAsync<T>(string tableName, T id = default, string idColumnName = "id", bool ignoreErrors = false, bool useWritingConnectionIfAvailable = true)
         {
-            return databaseConnection.InsertOrUpdateRecordBasedOnParametersAsync(tableName, id, idColumnName, ignoreErrors, useWritingConnectionIfAvailable);
+            return await databaseConnection.InsertOrUpdateRecordBasedOnParametersAsync(tableName, id, idColumnName, ignoreErrors, useWritingConnectionIfAvailable);
         }
 
         /// <inheritdoc />
-        public Task<long> InsertRecordAsync(string query, bool useWritingConnectionIfAvailable = true)
+        public async Task<long> InsertRecordAsync(string query, bool useWritingConnectionIfAvailable = true)
         {
-            return databaseConnection.InsertRecordAsync(query, useWritingConnectionIfAvailable);
+            return await databaseConnection.InsertRecordAsync(query, useWritingConnectionIfAvailable);
         }
 
         /// <inheritdoc />
-        public Task<IDbTransaction> BeginTransactionAsync(bool forceNewTransaction = false)
+        public async Task<IDbTransaction> BeginTransactionAsync(bool forceNewTransaction = false)
         {
-            return databaseConnection.BeginTransactionAsync(forceNewTransaction);
+            return await databaseConnection.BeginTransactionAsync(forceNewTransaction);
         }
 
         /// <inheritdoc />
-        public Task CommitTransactionAsync(bool throwErrorIfNoActiveTransaction = true)
+        public async Task CommitTransactionAsync(bool throwErrorIfNoActiveTransaction = true)
         {
-            return databaseConnection.CommitTransactionAsync(throwErrorIfNoActiveTransaction);
+            await databaseConnection.CommitTransactionAsync(throwErrorIfNoActiveTransaction);
         }
 
         /// <inheritdoc />
-        public Task RollbackTransactionAsync(bool throwErrorIfNoActiveTransaction = true)
+        public async Task RollbackTransactionAsync(bool throwErrorIfNoActiveTransaction = true)
         {
-            return databaseConnection.RollbackTransactionAsync(throwErrorIfNoActiveTransaction);
+            await databaseConnection.RollbackTransactionAsync(throwErrorIfNoActiveTransaction);
         }
 
         /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseHelpersService.cs
@@ -117,10 +117,10 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         }
 
         /// <inheritdoc />
-        public Task<bool> DatabaseExistsAsync(string databaseName)
+        public async Task<bool> DatabaseExistsAsync(string databaseName)
         {
             var cacheName = $"CachedDatabaseHelpersService_DatabaseExistsAsync_{databaseName}";
-            return cache.GetOrAddAsync(cacheName,
+            return await cache.GetOrAddAsync(cacheName,
                 async cacheEntry =>
                 {                    
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;


### PR DESCRIPTION
Various methods in the "CachedDatabaseConnection" and "CachedDatabaseHelpersService" that returned a Task didn't have the "async" modifier, and could potentially cause race conditions as the method could finish executing before the Tasks actually finished. These methods now all have the "async" modifier and use "await" for all function calls that are async.

Asana: https://app.asana.com/0/1200923549887805/1204012695375381