### PR TITLE
Fixed error in shopping basket save function

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -520,7 +520,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     lineIds.Add(line.Id);
                 }
 
-                await wiserItemsService.RemoveLinkedItemsAsync(shoppingBasket.Id, Constants.BasketLineToBasketLinkType, lineIds, entityType: Constants.BasketLineEntityType, createNewTransaction: !createNewTransaction, skipPermissionsCheck: true);
+                await wiserItemsService.RemoveLinkedItemsAsync(shoppingBasket.Id, Constants.BasketLineToBasketLinkType, lineIds, entityType: Constants.BasketLineEntityType, createNewTransaction: false, skipPermissionsCheck: true);
 
                 if (newBasket)
                 {
@@ -1831,8 +1831,10 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
 
                 if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
             }
-            catch
+            catch (Exception exception)
             {
+                logger.LogError(exception, "An error occured while trying to add one or more lines to the shopping basket.");
+
                 if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
                 throw;
             }


### PR DESCRIPTION
The save function of the `ShoppingBasketsService` would generate an error when trying to remove linked items if `createNewTransaction` was set to false, but a transaction was already started prior to calling the save function. The function would try to start a second transaction (which is not possible).