### PR TITLE
Include port in "Hostname" variable

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -26,17 +26,38 @@ namespace GeeksCoreLibrary.Core.Helpers
         };
 
         /// <summary>
-        /// Get the hostname, for example:
-        /// www.[testdomain] returns testdomain
-        /// domain.nl returns domain.nl
-        /// www.domain.nl returns domain.nl
-        /// domain.[testdomain] returns domain
-        /// domain.nl.[testdomain] returns domain.nl
+        /// Get the hostname from the current request. Some examples:
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Domain</term>
+        ///         <description>Result</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>www.[testdomain]</term>
+        ///         <description>testdomain</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>domain.nl</term>
+        ///         <description>domain.nl</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>www.domain.nl</term>
+        ///         <description>domain.nl</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>domain.[testdomain]</term>
+        ///         <description>domain</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>domain.nl.[testdomain]</term>
+        ///         <description>domain.nl</description>
+        ///     </item>
+        /// </list>
         /// </summary>
-        /// <param name="httpContext"></param>
-        /// <param name="testDomains"></param>
-        /// <param name="includingTestWww"></param>
-        /// <returns></returns>
+        /// <param name="httpContext">The <see cref="HttpContext"/> object whose request should be handled.</param>
+        /// <param name="testDomains">Optional: Which domains should be considered as test domains. These domain names will be stripped from the hostname.</param>
+        /// <param name="includingTestWww">Optional: Whether "www." and "test." should be added to the result.</param>
+        /// <returns>The hostname as a string.</returns>
         public static string GetHostName(HttpContext httpContext, List<string> testDomains = null, bool includingTestWww = false)
         {
             if (httpContext == null)
@@ -76,7 +97,10 @@ namespace GeeksCoreLibrary.Core.Helpers
                 return hostname.Remove(0, 4);
             }
 
-            return hostname;
+            // Will only return a port if the request URL contains a port (e.g.: "site.com:1234").
+            var port = httpContext.Request.Host.Port;
+
+            return port.HasValue ? $"{hostname}:{port}" : hostname;
         }
 
         /// <summary>


### PR DESCRIPTION
The `Hostname` default replacement variable will now include the port of the request URL if one was added. Note that port 80 and port 443 will not be added unless they're explicitly added in the URL.

Asana: https://app.asana.com/0/1200923549887805/1204077971372781