### PR TITLE
Support for URL regex for CSS and JS templates

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -591,9 +591,11 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 return;
             }
 
-            if (!String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex))
+            if (!template.Type.InList(TemplateTypes.Css, TemplateTypes.Scss, TemplateTypes.Js) && !String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex))
             {
                 // Skip this template if it has an URL regex and that regex does not match the current URL.
+                // This is skipped for CSS, SCSS and JS templates, otherwise they might exclude themselves when the
+                // request URL is for the CSS/JS templates (e.g.: "/css/gclcss_123.css").
                 return;
             }
 
@@ -1267,6 +1269,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         public async Task<TemplateDataModel> GetTemplateDataAsync(ITemplatesService templatesService, int id = 0, string name = "", int parentId = 0, string parentName = "")
         {
             var template = await templatesService.GetTemplateAsync(id, name, TemplateTypes.Html, parentId, parentName);
+            var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext).ToString();
 
             var cssStringBuilder = new StringBuilder();
             var jsStringBuilder = new StringBuilder();
@@ -1275,6 +1278,13 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             foreach (var templateId in template.CssTemplates.Concat(template.JavascriptTemplates))
             {
                 var linkedTemplate = await templatesService.GetTemplateAsync(templateId);
+
+                // Validate the template regex, if it has one.
+                if (!String.IsNullOrWhiteSpace(linkedTemplate.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, linkedTemplate.UrlRegex))
+                {
+                    continue;
+                }
+
                 (linkedTemplate.Type == TemplateTypes.Css ? cssStringBuilder : jsStringBuilder).Append(linkedTemplate.Content);
                 (linkedTemplate.Type == TemplateTypes.Css ? externalCssFilesList : externalJavaScriptFilesList).AddRange(linkedTemplate.ExternalFiles);
             }

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -591,7 +591,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 return;
             }
 
-            if (!template.Type.InList(TemplateTypes.Css, TemplateTypes.Scss, TemplateTypes.Js) && !String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex))
+            if (!template.Type.InList(TemplateTypes.Css, TemplateTypes.Scss, TemplateTypes.Js) && !String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
             {
                 // Skip this template if it has an URL regex and that regex does not match the current URL.
                 // This is skipped for CSS, SCSS and JS templates, otherwise they might exclude themselves when the
@@ -1280,7 +1280,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 var linkedTemplate = await templatesService.GetTemplateAsync(templateId);
 
                 // Validate the template regex, if it has one.
-                if (!String.IsNullOrWhiteSpace(linkedTemplate.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, linkedTemplate.UrlRegex))
+                if (!String.IsNullOrWhiteSpace(linkedTemplate.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, linkedTemplate.UrlRegex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
                 {
                     continue;
                 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -93,7 +93,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 foreach (DataRow globalHeaderDataRow in globalHeaders.Rows)
                 {
                     headerRegexCheck = globalHeaderDataRow.Field<string>("default_header_footer_regex");
-                    if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck))
+                    if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
                     {
                         continue;
                     }
@@ -114,7 +114,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             headerRegexCheck = await objectsService.FindSystemObjectByDomainNameAsync("headerregexcheck");
-            if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck))
+            if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
             {
                 return "";
             }
@@ -161,7 +161,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 foreach (DataRow globalFooterDataRow in globalFooters.Rows)
                 {
                     headerRegexCheck = globalFooterDataRow.Field<string>("default_header_footer_regex");
-                    if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck))
+                    if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
                     {
                         continue;
                     }
@@ -182,7 +182,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             headerRegexCheck = await objectsService.FindSystemObjectByDomainNameAsync("footerregexcheck");
-            if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck))
+            if (!String.IsNullOrWhiteSpace(url) && !String.IsNullOrWhiteSpace(headerRegexCheck) && !Regex.IsMatch(url, headerRegexCheck, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
             {
                 return "";
             }
@@ -250,7 +250,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     }
 
                     // Validate the template regex, if it has one.
-                    if (!String.IsNullOrWhiteSpace(template.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, template.UrlRegex))
+                    if (!String.IsNullOrWhiteSpace(template.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, template.UrlRegex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
                     {
                         continue;
                     }

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -198,6 +198,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         public async Task<PageViewModel> CreatePageViewModelAsync(List<string> externalCss, List<int> cssTemplates, List<string> externalJavascript, List<int> javascriptTemplates, string bodyHtml, int templateId = 0)
         {
             var viewModel = new PageViewModel();
+            var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext).ToString();
 
             // Add Google reCAPTCHAv3 if setup.
             await AddGoogleReCaptchaToViewModelAsync(viewModel);
@@ -244,6 +245,12 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                     externalCss.AddRange(template.ExternalFiles);
 
                     if (String.IsNullOrWhiteSpace(template.Content))
+                    {
+                        continue;
+                    }
+
+                    // Validate the template regex, if it has one.
+                    if (!String.IsNullOrWhiteSpace(template.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, template.UrlRegex))
                     {
                         continue;
                     }

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -627,7 +627,7 @@ ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, paren
                 return;
             }
 
-            if (!template.Type.InList(TemplateTypes.Css, TemplateTypes.Scss, TemplateTypes.Js) && !String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex))
+            if (!template.Type.InList(TemplateTypes.Css, TemplateTypes.Scss, TemplateTypes.Js) && !String.IsNullOrWhiteSpace(template.UrlRegex) && !Regex.IsMatch(currentUrl, template.UrlRegex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
             {
                 // Skip this template if it has an URL regex and that regex does not match the current URL.
                 // This is skipped for CSS, SCSS and JS templates, otherwise they might exclude themselves when the
@@ -1232,7 +1232,7 @@ ORDER BY id ASC");
                 query = query.ReplaceCaseInsensitive("{filters}", (await filtersService.GetFilterQueryPartAsync()).JoinPart);
             }
 
-            var pusherRegex = new Regex(@"PUSHER<channel\((.*?)\),event\((.*?)\),message\(((?s:.)*?)\)>", RegexOptions.Compiled);
+            var pusherRegex = new Regex(@"PUSHER<channel\((.*?)\),event\((.*?)\),message\(((?s:.)*?)\)>", RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
             var pusherMatches = pusherRegex.Matches(query);
             foreach (Match match in pusherMatches)
             {
@@ -1298,7 +1298,7 @@ ORDER BY ORDINAL_POSITION ASC";
                 var linkedTemplate = await templatesService.GetTemplateAsync(templateId);
 
                 // Validate the template regex, if it has one.
-                if (!String.IsNullOrWhiteSpace(linkedTemplate.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, linkedTemplate.UrlRegex))
+                if (!String.IsNullOrWhiteSpace(linkedTemplate.UrlRegex) && !String.IsNullOrWhiteSpace(currentUrl) && !Regex.IsMatch(currentUrl, linkedTemplate.UrlRegex, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(200)))
                 {
                     continue;
                 }


### PR DESCRIPTION
JavaScript and stylesheet templates are now excluded when they have a URL regex set and the URL doesn't match that regex.

Asana: https://app.asana.com/0/1200923549887805/1204096541331925