### PR TITLE
Ignore port for (system) objects

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -57,8 +57,9 @@ namespace GeeksCoreLibrary.Core.Helpers
         /// <param name="httpContext">The <see cref="HttpContext"/> object whose request should be handled.</param>
         /// <param name="testDomains">Optional: Which domains should be considered as test domains. These domain names will be stripped from the hostname.</param>
         /// <param name="includingTestWww">Optional: Whether "www." and "test." should be added to the result.</param>
+        /// <param name="includePort">Optional: Whether to also return the port number in the URL (but only if it's a custom port, not with 80 and 443). Default is true.</param>
         /// <returns>The hostname as a string.</returns>
-        public static string GetHostName(HttpContext httpContext, List<string> testDomains = null, bool includingTestWww = false)
+        public static string GetHostName(HttpContext httpContext, List<string> testDomains = null, bool includingTestWww = false, bool includePort = true)
         {
             if (httpContext == null)
             {
@@ -100,7 +101,7 @@ namespace GeeksCoreLibrary.Core.Helpers
             // Will only return a port if the request URL contains a port (e.g.: "site.com:1234").
             var port = httpContext.Request.Host.Port;
 
-            return port.HasValue ? $"{hostname}:{port}" : hostname;
+            return port.HasValue && includePort ? $"{hostname}:{port}" : hostname;
         }
 
         /// <summary>

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -166,7 +166,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                     dataDictionary.Clear();
 
                     // Try to get the type number by host name.
-                    if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync(HttpContextHelpers.GetHostName(httpContextAccessor.HttpContext)), out var objectsTypeNumber) || objectsTypeNumber == 0)
+                    if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync(HttpContextHelpers.GetHostName(httpContextAccessor.HttpContext, includePort: false)), out var objectsTypeNumber) || objectsTypeNumber == 0)
                     {
                         // Revert to -100 if the parsing failed or if it returned 0. This is a special value that will look through all objects, ignoring the type number completely.
                         objectsTypeNumber = -100;

--- a/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
+++ b/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
@@ -45,8 +45,8 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
             this.cacheService = cacheService;
             this.gclSettings = gclSettings.Value;
 
-            hostName = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext);
-            hostNameIncludingTestWww = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true);
+            hostName = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false);
+            hostNameIncludingTestWww = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true, includePort: false);
             urlPrefix = HttpContextHelpers.GetUrlPrefix(httpContextAccessor?.HttpContext);
         }
 

--- a/GeeksCoreLibrary/Modules/Objects/Services/ObjectsService.cs
+++ b/GeeksCoreLibrary/Modules/Objects/Services/ObjectsService.cs
@@ -35,17 +35,17 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
             var domain = overrideDomain;
             if (String.IsNullOrEmpty(domain))
             {
-                domain = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext);
+                domain = HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false);
             }
 
             if (searchFromSpecificToGeneral)
             {
                 // By passing an empty list to the testDomains parameters, no test domains will be checked.
-                finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, new List<string>(), true)}");
+                finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, new List<string>(), true, includePort: false)}");
 
                 if (String.IsNullOrEmpty(finalResult))
                 {
-                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true)}");
+                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true, includePort: false)}");
                 }
 
                 if (String.IsNullOrEmpty(finalResult))
@@ -62,13 +62,13 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
                     }
                     else if (!String.IsNullOrEmpty(overrideDomain) && String.IsNullOrEmpty(finalResult))
                     {
-                        finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext)}");
+                        finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false)}");
                     }
                 }
 
                 if (String.IsNullOrEmpty(finalResult))
                 {
-                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext).Split('.')[0]}");
+                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false).Split('.')[0]}");
                 }
                 if (String.IsNullOrEmpty(finalResult))
                 {
@@ -88,7 +88,7 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
                 }
                 if (String.IsNullOrEmpty(finalResult))
                 {
-                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext).Split('.')[0]}");
+                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false).Split('.')[0]}");
                 }
                 if (String.IsNullOrEmpty(finalResult))
                 {
@@ -104,19 +104,19 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
                     }
                     else if (!String.IsNullOrEmpty(overrideDomain) && String.IsNullOrEmpty(finalResult))
                     {
-                        finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext)}");
+                        finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includePort: false)}");
                     }
                 }
 
                 if (String.IsNullOrEmpty(finalResult))
                 {
-                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true)}");
+                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, includingTestWww: true, includePort: false)}");
                 }
 
                 if (String.IsNullOrEmpty(finalResult))
                 {
                     // By passing an empty list to the testDomains parameters, no test domains will be checked.
-                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, new List<string>(), true)}");
+                    finalResult = await GetSystemObjectValueAsync($"{objectKey}_{HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext, new List<string>(), true, includePort: false)}");
                 }
             }
 


### PR DESCRIPTION
Because the port was added to the hostname any (system) object for an URL that uses a custom port (like localhost) failed to be replaced.