### PR TITLE
MySQL virtual columns

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Enums/VirtualTypes.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Enums/VirtualTypes.cs
@@ -1,0 +1,7 @@
+﻿namespace GeeksCoreLibrary.Modules.Databases.Enums;
+
+public enum VirtualTypes
+{
+    Virtual,
+    Stored
+}

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -49,6 +49,63 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
                 }
             },
 
+            // wiser_itemdetail
+            new WiserTableDefinitionModel
+            {
+                Name = WiserTableNames.WiserItemDetail,
+                LastUpdate = new DateTime(2023, 3, 29),
+                Columns = new List<ColumnSettingsModel>
+                {
+                    new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
+                    new("language_code", MySqlDbType.VarChar, 5, notNull: true, defaultValue: "", comment: "leeg betekent beschikbaar voor alle talen"),
+                    new("item_id", MySqlDbType.UInt64, notNull: true, defaultValue: "0"),
+                    new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: "", comment: "optionele groepering van items, zoals een 'specs' tabel"),
+                    new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
+                    new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
+                    new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
+                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
+                    new("long_value", MySqlDbType.MediumText, comment: "Voor waardes die niet in 'value' passen, zoals van HTMLeditors")
+                },
+                Indexes = new List<IndexSettingsModel>
+                {
+                    new(WiserTableNames.WiserItemDetail, "item_key", IndexTypes.Unique, new List<string> { "item_id", "key", "language_code" }, "voor opbouwen productoverzicht"),
+                    new(WiserTableNames.WiserItemDetail, "key_value", IndexTypes.Normal, new List<string> { "key(50)", "value(100)" }, "filteren van items"),
+                    new(WiserTableNames.WiserItemDetail, "key_int_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemDetail, "key_decimal_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_decimal" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value(40)" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_int_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_decimal_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value_as_decimal" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_group", IndexTypes.Normal, new List<string> { "item_id", "groupname", "key(40)" })
+                }
+            },
+
+            // wiser_itemlinkdetail
+            new WiserTableDefinitionModel
+            {
+                Name = WiserTableNames.WiserItemLinkDetail,
+                LastUpdate = new DateTime(2023, 3, 29),
+                Columns = new List<ColumnSettingsModel>
+                {
+                    new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
+                    new("language_code", MySqlDbType.VarChar, 5, notNull: true, defaultValue: "", comment: "leeg betekent beschikbaar voor alle talen"),
+                    new("itemlink_id", MySqlDbType.UInt64, notNull: true, defaultValue: "0"),
+                    new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: "", comment: "optionele groepering van items, zoals een 'specs' tabel"),
+                    new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
+                    new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
+                    new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
+                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
+                    new("long_value", MySqlDbType.MediumText, comment: "Voor waardes die niet in 'value' passen, zoals van HTMLeditors")
+                },
+                Indexes = new List<IndexSettingsModel>
+                {
+                    new(WiserTableNames.WiserItemLinkDetail, "itemlink_key", IndexTypes.Unique, new List<string> { "itemlink_id", "key", "language_code" }, "voor opbouwen productoverzicht"),
+                    new(WiserTableNames.WiserItemLinkDetail, "itemlink_id", IndexTypes.Normal, new List<string> { "itemlink_id" }, "voor zoeken waardes van 1 item"),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_value", IndexTypes.Normal, new List<string> { "key(50)", "value(100)" }, "filteren van items"),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_int_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_decimal_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_decimal" })
+                }
+            },
+
             // wiser_grant_store
             new WiserTableDefinitionModel
             {

--- a/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
@@ -113,5 +113,22 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         /// Gets or sets whether this column should be part of the primary key.
         /// </summary>
         public bool IsPrimaryKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this column is a virtual column.
+        /// </summary>
+        public bool IsVirtual { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of virtual column.
+        /// This is only used if <see cref="IsVirtual"/> is set to <see langword="true"/>.
+        /// </summary>
+        public VirtualTypes VirtualType { get; set; } = VirtualTypes.Virtual;
+
+        /// <summary>
+        /// Gets or sets the expression for a virtual column.
+        /// This is only used if <see cref="IsVirtual"/> is set to <see langword="true"/>.
+        /// </summary>
+        public string VirtualExpression { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
@@ -13,7 +13,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         {
         }
 
-        public ColumnSettingsModel(string name, MySqlDbType type, int length = 0, int decimals = 2, string defaultValue = null, bool notNull = false, bool addIndex = false, IndexTypes indexType = IndexTypes.Normal, bool autoIncrement = false, IList<string> enumValues = null, string comment = null, string addAfterColumnName = null, bool updateTimeStampOnChange = false, string characterSet = "utf8mb4", string collation = "utf8mb4_general_ci", bool isPrimaryKey = false)
+        public ColumnSettingsModel(string name, MySqlDbType type, int length = 0, int decimals = 2, string defaultValue = null, bool notNull = false, bool addIndex = false, IndexTypes indexType = IndexTypes.Normal, bool autoIncrement = false, IList<string> enumValues = null, string comment = null, string addAfterColumnName = null, bool updateTimeStampOnChange = false, string characterSet = "utf8mb4", string collation = "utf8mb4_general_ci", bool isPrimaryKey = false, bool isVirtual = false, VirtualTypes? virtualType = null, string virtualExpression = null)
         {
             Name = name;
             Type = type;
@@ -31,6 +31,9 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
             CharacterSet = characterSet;
             Collation = collation;
             IsPrimaryKey = isPrimaryKey;
+            IsVirtual = isVirtual;
+            VirtualType = virtualType ?? VirtualTypes.Virtual;
+            VirtualExpression = virtualExpression;
         }
 
         /// <summary>

--- a/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
@@ -9,12 +9,13 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         {
         }
 
-        public IndexSettingsModel(string tableName , string name, IndexTypes type = IndexTypes.Normal, List<string> fields = null)
+        public IndexSettingsModel(string tableName , string name, IndexTypes type = IndexTypes.Normal, List<string> fields = null, string comment = null)
         {
             Name = name;
             Type = type;
             TableName = tableName;
             Fields = fields ?? new List<string>();
+            Comment = comment;
         }
 
         /// <summary>
@@ -36,5 +37,10 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         /// Gets or sets the fields that are part of this index.
         /// </summary>
         public List<string> Fields { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the comment describing the index.
+        /// </summary>
+        public string Comment { get; set; }
     }
 }


### PR DESCRIPTION
The table definitions can now also describe virtual columns. The `wiser_itemdetail` and `wiser_itemlinkdetail` tables now have 2 additional value columns: `value_as_int` and `value_as_decimal`. These values automatically convert the value to either an int or decimal so manual conversion is not necessary. It also adds indexes for these columns.

Related Wiser pull request: https://github.com/happy-geeks/wiser/pull/247

Asana:
https://app.asana.com/0/29553867016121/1203457154031219
https://app.asana.com/0/29553867016121/1202994198179349