### PR TITLE
Add the executed query to thrown exceptions.

### DIFF
--- a/GeeksCoreLibrary/Core/Exceptions/GclQueryException.cs
+++ b/GeeksCoreLibrary/Core/Exceptions/GclQueryException.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace GeeksCoreLibrary.Core.Exceptions;
+
+/// <summary>
+/// Custom exception for queries executed by the GCL.
+/// </summary>
+public class GclQueryException : Exception
+{
+    /// <summary>
+    /// Gets or sets the query that was being executed when the exception was thrown.
+    /// </summary>
+    public string Query { get; }
+    
+    /// <summary>
+    /// Create a new <see cref="GclQueryException"/> with only a message and the executed query.
+    /// </summary>
+    /// <param name="message">The message of the error.</param>
+    /// <param name="query">The query that was executed when the exception was thrown.</param>
+    public GclQueryException(string message, string query) : base(message)
+    {
+        Query = query;
+    }
+    
+    /// <summary>
+    /// Create a new <see cref="GclQueryException"/> with a message, the executed query and an inner exception to include an existing exception.
+    /// </summary>
+    /// <param name="message">The message of the error.</param>
+    /// <param name="query">The query that was executed when the exception was thrown.</param>
+    /// <param name="innerException">The inner exception to be included.</param>
+    public GclQueryException(string message, string query, Exception innerException) : base(message, innerException)
+    {
+        Query = query;
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return $"{base.ToString()}{Environment.NewLine}{Environment.NewLine}Failed during execution of query:{Environment.NewLine}{Query}";
+    }
+}

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
+using GeeksCoreLibrary.Core.Exceptions;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
@@ -141,7 +142,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 if (retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                    throw;
+                    throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
                 switch (mySqlException.Number)
@@ -157,7 +158,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                         return await GetAsync(query, retryCount + 1);
                     default:
                         logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                        throw;
+                        throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
             }
             finally
@@ -215,7 +216,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 if (retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                    throw;
+                    throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
                 switch (mySqlException.Number)
@@ -230,7 +231,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                         return await ExecuteAsync(query, retryCount + 1);
                     default:
                         logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                        throw;
+                        throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
             }
             finally


### PR DESCRIPTION
If an exception was thrown for example an invalid query it would only show a small part of the query. If the invalid syntax is at the end there is no information.

The full query is added to the exception to indicate where it goes wrong.

https://app.asana.com/0/1200346761113317/1203601476439864