### PR TITLE
Some improvements to handling of deadlocks

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Account.cs
+++ b/GeeksCoreLibrary/Components/Account/Account.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using GeeksCoreLibrary.Components.Account.Interfaces;
@@ -18,6 +19,7 @@ using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Communication.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.Databases.Services;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
@@ -32,6 +34,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using MySql.Data.MySqlClient;
 using Newtonsoft.Json;
 using Constants = GeeksCoreLibrary.Components.Account.Models.Constants;
 
@@ -841,22 +844,48 @@ namespace GeeksCoreLibrary.Components.Account
 
                     if (changePasswordResult == ResetOrChangePasswordResults.Success)
                     {
-                        await DatabaseConnection.BeginTransactionAsync();
-                        createOrUpdateAccountResult = await CreateOrUpdateAccountAsync(userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreateAccountId(), availableFields, useTransaction: false);
+                        var retries = 0;
+                        var transactionCompleted = false;
 
-                        if (createOrUpdateAccountResult.UserId > 0 && userData.UserId == 0)
+                        while (!transactionCompleted)
                         {
-                            // If we just created an account, save the password now, otherwise the password was already changed.
-                            changePasswordResult = await ChangePasswordAsync(createOrUpdateAccountResult.UserId, true);
-                            if (changePasswordResult != ResetOrChangePasswordResults.Success)
+                            try
                             {
-                                createOrUpdateAccountResult.ErrorTemplate = Settings.TemplateError;
-                                createOrUpdateAccountResult.SuccessTemplate = "";
-                                await DatabaseConnection.RollbackTransactionAsync();
+                                await DatabaseConnection.BeginTransactionAsync();
+                                createOrUpdateAccountResult = await CreateOrUpdateAccountAsync(userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreateAccountId(), availableFields, useTransaction: false);
+
+                                if (createOrUpdateAccountResult.UserId > 0 && userData.UserId == 0)
+                                {
+                                    // If we just created an account, save the password now, otherwise the password was already changed.
+                                    changePasswordResult = await ChangePasswordAsync(createOrUpdateAccountResult.UserId, true);
+                                    if (changePasswordResult != ResetOrChangePasswordResults.Success)
+                                    {
+                                        createOrUpdateAccountResult.ErrorTemplate = Settings.TemplateError;
+                                        createOrUpdateAccountResult.SuccessTemplate = "";
+                                        await DatabaseConnection.RollbackTransactionAsync();
+                                    }
+                                }
+
+                                await DatabaseConnection.CommitTransactionAsync(false);
+                                transactionCompleted = true;
+                            }
+                            catch (MySqlException mySqlException)
+                            {
+                                await DatabaseConnection.RollbackTransactionAsync(false);
+
+                                if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                                {
+                                    // Exception is a deadlock or something similar, retry the transaction.
+                                    retries++;
+                                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                                }
+                                else
+                                {
+                                    // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                                    throw;
+                                }
                             }
                         }
-
-                        await DatabaseConnection.CommitTransactionAsync(false);
                     }
 
                     if (createOrUpdateAccountResult.Result == CreateOrUpdateAccountResults.Success
@@ -1234,214 +1263,246 @@ namespace GeeksCoreLibrary.Components.Account
             }
 
             var request = httpContext.Request;
+            var retries = 0;
+            var transactionCompleted = false;
+            string userRole = null;
 
-            try
+            while (!transactionCompleted)
             {
-
-                if (useTransaction)
+                try
                 {
-                    await DatabaseConnection.BeginTransactionAsync();
-                }
-
-                var result = CreateOrUpdateAccountResults.Success;
-                var createdNewAccount = false;
-
-                // If we have no available fields from the main query, just add everything. The developer has been warned in the documentation about this.
-                if (!availableFields.Any())
-                {
-                    foreach (var formKey in request.Form.Keys.Where(k => !k.StartsWith("_")))
+                    if (useTransaction)
                     {
-                        availableFields.Add(formKey);
-                    }
-                }
-
-                var passwordFields = new List<string> { Settings.PasswordFieldName, Settings.NewPasswordFieldName, Settings.NewPasswordConfirmationFieldName };
-                availableFields = availableFields.Where(f => !passwordFields.Contains(f)).ToList();
-
-                // Check if the user already exists.
-                var emailAddress = request.Form[Settings.EmailAddressFieldName];
-                var loginValue = request.Form[Settings.LoginFieldName];
-                var userRole = request.Form[Settings.RoleFieldName];
-                var query = SetupAccountQuery(Settings.CheckIfAccountExistsQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue);
-                foreach (var field in availableFields)
-                {
-                    var formValue = GetFormValue(field);
-                    if (formValue == null)
-                    {
-                        continue;
+                        await DatabaseConnection.BeginTransactionAsync();
                     }
 
-                    var parameterName = DatabaseHelpers.CreateValidParameterName(field);
-                    DatabaseConnection.AddParameter(parameterName, formValue);
-                    query = query.ReplaceCaseInsensitive($"'{{{parameterName}}}'", $"?{parameterName}").ReplaceCaseInsensitive($"{{{parameterName}}}", $"?{parameterName}");
-                }
+                    var result = CreateOrUpdateAccountResults.Success;
+                    var createdNewAccount = false;
 
-                var dataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
-
-                if (dataTable.Rows.Count > 0)
-                {
-                    result = CreateOrUpdateAccountResults.UserAlreadyExists;
-                    var errorTemplate = await StringReplacementsService.DoAllReplacementsAsync(Settings.TemplateError, dataTable.Rows[0], Settings.HandleRequest, Settings.EvaluateIfElseInTemplates, Settings.RemoveUnknownVariables);
-                    return (result, errorTemplate, SuccessTemplate: "", UserId: 0, SubAccountId: 0, Role: "");
-                }
-
-                if ((Settings.ComponentMode == ComponentModes.SubAccountsManagement && subAccountId > 0) || (Settings.ComponentMode != ComponentModes.SubAccountsManagement && userId > 0))
-                {
-                    query = SetupAccountQuery(Settings.UpdateAccountQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue, role: userRole);
-                }
-                else
-                {
-                    query = SetupAccountQuery(Settings.CreateAccountQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue, role: userRole);
-                }
-
-                // Add fields to main query, for creating or updating an account.
-                foreach (var field in availableFields)
-                {
-                    var formValue = GetFormValue(field);
-                    if (formValue == null)
+                    // If we have no available fields from the main query, just add everything. The developer has been warned in the documentation about this.
+                    if (!availableFields.Any())
                     {
-                        continue;
+                        foreach (var formKey in request.Form.Keys.Where(k => !k.StartsWith("_")))
+                        {
+                            availableFields.Add(formKey);
+                        }
                     }
 
-                    var parameterName = DatabaseHelpers.CreateValidParameterName(field);
-                    DatabaseConnection.AddParameter(parameterName, formValue);
-                    query = query.ReplaceCaseInsensitive($"'{{{parameterName}}}'", $"?{parameterName}").ReplaceCaseInsensitive($"{{{parameterName}}}", $"?{parameterName}");
-                }
+                    var passwordFields = new List<string> {Settings.PasswordFieldName, Settings.NewPasswordFieldName, Settings.NewPasswordConfirmationFieldName};
+                    availableFields = availableFields.Where(f => !passwordFields.Contains(f)).ToList();
 
-                // Add / update the account.
-                dataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
-
-                // Get the user ID, if a new account was created. This will throw an exception if the CreateAccountQuery did not return a new ID, so that the changes will be rolled back and it's a developer mistake, not a user mistake.
-                if (userId <= 0)
-                {
-                    if (Settings.ComponentMode == ComponentModes.SubAccountsManagement)
-                    {
-                        throw new Exception("Trying to update or create a sub account, but we have no valid user Id!");
-                    }
-
-                    if (dataTable.Rows.Count == 0 || dataTable.Rows[0].IsNull(Constants.UserIdColumn))
-                    {
-                        throw new Exception("Account was created, but query did not return a valid user ID, rolling back changes...");
-                    }
-
-                    userId = Convert.ToUInt64(dataTable.Rows[0][Constants.UserIdColumn]);
-                    createdNewAccount = true;
-                    if (userId <= 0)
-                    {
-                        throw new Exception("Account was created, but query did not return a valid user ID, rolling back changes...");
-                    }
-                }
-
-                if (Settings.ComponentMode == ComponentModes.SubAccountsManagement && subAccountId <= 0)
-                {
-                    if (dataTable.Rows.Count == 0 || dataTable.Rows[0].IsNull(Constants.UserIdColumn))
-                    {
-                        throw new Exception("Sub account was created, but query did not return a valid user ID, rolling back changes...");
-                    }
-
-                    subAccountId = Convert.ToUInt64(dataTable.Rows[0][Constants.UserIdColumn]);
-                    if (subAccountId <= 0)
-                    {
-                        throw new Exception("Sub account was created, but query did not return a valid user ID, rolling back changes...");
-                    }
-                }
-
-                // Save the fields / entity properties, if a query is entered for that.
-                if (!String.IsNullOrWhiteSpace(Settings.SetValueInWiserEntityPropertyQuery))
-                {
-                    DatabaseConnection.AddParameter("userId", userId);
-                    DatabaseConnection.AddParameter("subAccountId", subAccountId);
-                    query = Settings.SetValueInWiserEntityPropertyQuery.ReplaceCaseInsensitive("'{name}'", "?name").ReplaceCaseInsensitive("{name}", "?name").ReplaceCaseInsensitive("'{value}'", "?value").ReplaceCaseInsensitive("{value}", "?value");
-
+                    // Check if the user already exists.
+                    var emailAddress = request.Form[Settings.EmailAddressFieldName];
+                    var loginValue = request.Form[Settings.LoginFieldName];
+                    userRole = request.Form[Settings.RoleFieldName];
+                    var query = SetupAccountQuery(Settings.CheckIfAccountExistsQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue);
                     foreach (var field in availableFields)
                     {
                         var formValue = GetFormValue(field);
-                        if (Settings.IgnoreEmptyValues && String.IsNullOrWhiteSpace(formValue))
+                        if (formValue == null)
                         {
                             continue;
                         }
 
-                        DatabaseConnection.AddParameter("name", field);
-                        DatabaseConnection.AddParameter("value", formValue);
-                        await RenderAndExecuteQueryAsync(query, skipCache: true);
+                        var parameterName = DatabaseHelpers.CreateValidParameterName(field);
+                        DatabaseConnection.AddParameter(parameterName, formValue);
+                        query = query.ReplaceCaseInsensitive($"'{{{parameterName}}}'", $"?{parameterName}").ReplaceCaseInsensitive($"{{{parameterName}}}", $"?{parameterName}");
                     }
-                }
 
-                // Update roles for the user.
-                if (!String.IsNullOrWhiteSpace(Settings.AccountRolesQuery))
-                {
-                    DatabaseConnection.AddParameter("userId", userId);
-                    DatabaseConnection.AddParameter("subAccountId", subAccountId);
-                    query = Settings.AccountRolesQuery;
+                    var dataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
 
-                    var rolesDataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
-                    if (rolesDataTable.Columns.Contains(Constants.RoleIdColumn))
+                    if (dataTable.Rows.Count > 0)
                     {
-                        if (rolesDataTable.Rows.Count == 0)
+                        result = CreateOrUpdateAccountResults.UserAlreadyExists;
+                        var errorTemplate = await StringReplacementsService.DoAllReplacementsAsync(Settings.TemplateError, dataTable.Rows[0], Settings.HandleRequest, Settings.EvaluateIfElseInTemplates, Settings.RemoveUnknownVariables);
+                        return (result, errorTemplate, SuccessTemplate: "", UserId: 0, SubAccountId: 0, Role: "");
+                    }
+
+                    if ((Settings.ComponentMode == ComponentModes.SubAccountsManagement && subAccountId > 0) || (Settings.ComponentMode != ComponentModes.SubAccountsManagement && userId > 0))
+                    {
+                        query = SetupAccountQuery(Settings.UpdateAccountQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue, role: userRole);
+                    }
+                    else
+                    {
+                        query = SetupAccountQuery(Settings.CreateAccountQuery, userId, subAccountId: subAccountId, emailAddress: emailAddress, loginValue: loginValue, role: userRole);
+                    }
+
+                    // Add fields to main query, for creating or updating an account.
+                    foreach (var field in availableFields)
+                    {
+                        var formValue = GetFormValue(field);
+                        if (formValue == null)
                         {
-                            // No roles for this user; remove all roles.
-                            await DatabaseConnection.ExecuteAsync($"DELETE FROM `{WiserTableNames.WiserUserRoles}` WHERE user_id = ?userId");
+                            continue;
                         }
-                        else
+
+                        var parameterName = DatabaseHelpers.CreateValidParameterName(field);
+                        DatabaseConnection.AddParameter(parameterName, formValue);
+                        query = query.ReplaceCaseInsensitive($"'{{{parameterName}}}'", $"?{parameterName}").ReplaceCaseInsensitive($"{{{parameterName}}}", $"?{parameterName}");
+                    }
+
+                    // Add / update the account.
+                    dataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
+
+                    // Get the user ID, if a new account was created. This will throw an exception if the CreateAccountQuery did not return a new ID, so that the changes will be rolled back and it's a developer mistake, not a user mistake.
+                    if (userId <= 0)
+                    {
+                        if (Settings.ComponentMode == ComponentModes.SubAccountsManagement)
                         {
-                            var newRoleIds = rolesDataTable.Rows.Cast<DataRow>().Select(dr => Convert.ToInt32(dr[Constants.RoleIdColumn])).ToArray();
+                            throw new Exception("Trying to update or create a sub account, but we have no valid user Id!");
+                        }
 
-                            // First determine which roles the user currently has.
-                            var currentRoleIds = (await AccountsService.GetUserRolesAsync(userId)).Select(role => role.Id).ToArray();
+                        if (dataTable.Rows.Count == 0 || dataTable.Rows[0].IsNull(Constants.UserIdColumn))
+                        {
+                            throw new Exception("Account was created, but query did not return a valid user ID, rolling back changes...");
+                        }
 
-                            // Roles to remove should be the roles that the user currently has, but are not present in the roles the user is supposed to have.
-                            var rolesToRemove = currentRoleIds.Except(newRoleIds).ToArray();
-                            // Roles to add should only be roles that the user doesn't already have.
-                            var rolesToAdd = newRoleIds.Except(currentRoleIds).ToArray();
+                        userId = Convert.ToUInt64(dataTable.Rows[0][Constants.UserIdColumn]);
+                        createdNewAccount = true;
+                        if (userId <= 0)
+                        {
+                            throw new Exception("Account was created, but query did not return a valid user ID, rolling back changes...");
+                        }
+                    }
 
-                            // Execute query to remove roles the user isn't supposed to have anymore.
-                            if (rolesToRemove.Length > 0)
+                    if (Settings.ComponentMode == ComponentModes.SubAccountsManagement && subAccountId <= 0)
+                    {
+                        if (dataTable.Rows.Count == 0 || dataTable.Rows[0].IsNull(Constants.UserIdColumn))
+                        {
+                            throw new Exception("Sub account was created, but query did not return a valid user ID, rolling back changes...");
+                        }
+
+                        subAccountId = Convert.ToUInt64(dataTable.Rows[0][Constants.UserIdColumn]);
+                        if (subAccountId <= 0)
+                        {
+                            throw new Exception("Sub account was created, but query did not return a valid user ID, rolling back changes...");
+                        }
+                    }
+
+                    // Save the fields / entity properties, if a query is entered for that.
+                    if (!String.IsNullOrWhiteSpace(Settings.SetValueInWiserEntityPropertyQuery))
+                    {
+                        DatabaseConnection.AddParameter("userId", userId);
+                        DatabaseConnection.AddParameter("subAccountId", subAccountId);
+                        query = Settings.SetValueInWiserEntityPropertyQuery.ReplaceCaseInsensitive("'{name}'", "?name").ReplaceCaseInsensitive("{name}", "?name").ReplaceCaseInsensitive("'{value}'", "?value").ReplaceCaseInsensitive("{value}", "?value");
+
+                        foreach (var field in availableFields)
+                        {
+                            var formValue = GetFormValue(field);
+                            if (Settings.IgnoreEmptyValues && String.IsNullOrWhiteSpace(formValue))
                             {
-                                var inStatement = new List<string>();
-                                for (var i = 0; i < rolesToRemove.Length; i++)
-                                {
-                                    DatabaseConnection.AddParameter($"removeRoleId{i}", rolesToRemove[i]);
-                                    inStatement.Add($"?removeRoleId{i}");
-                                }
-                                await DatabaseConnection.ExecuteAsync($"DELETE FROM `{WiserTableNames.WiserUserRoles}` WHERE user_id = ?userId AND role_id IN ({String.Join(",", inStatement)})");
+                                continue;
                             }
 
-                            // Execute query to add new roles to the user.
-                            if (rolesToAdd.Length > 0)
+                            DatabaseConnection.AddParameter("name", field);
+                            DatabaseConnection.AddParameter("value", formValue);
+                            await RenderAndExecuteQueryAsync(query, skipCache: true);
+                        }
+                    }
+
+                    // Update roles for the user.
+                    if (!String.IsNullOrWhiteSpace(Settings.AccountRolesQuery))
+                    {
+                        DatabaseConnection.AddParameter("userId", userId);
+                        DatabaseConnection.AddParameter("subAccountId", subAccountId);
+                        query = Settings.AccountRolesQuery;
+
+                        var rolesDataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
+                        if (rolesDataTable.Columns.Contains(Constants.RoleIdColumn))
+                        {
+                            if (rolesDataTable.Rows.Count == 0)
                             {
-                                var values = new List<string>();
-                                for (var i = 0; i < rolesToAdd.Length; i++)
+                                // No roles for this user; remove all roles.
+                                await DatabaseConnection.ExecuteAsync($"DELETE FROM `{WiserTableNames.WiserUserRoles}` WHERE user_id = ?userId");
+                            }
+                            else
+                            {
+                                var newRoleIds = rolesDataTable.Rows.Cast<DataRow>().Select(dr => Convert.ToInt32(dr[Constants.RoleIdColumn])).ToArray();
+
+                                // First determine which roles the user currently has.
+                                var currentRoleIds = (await AccountsService.GetUserRolesAsync(userId)).Select(role => role.Id).ToArray();
+
+                                // Roles to remove should be the roles that the user currently has, but are not present in the roles the user is supposed to have.
+                                var rolesToRemove = currentRoleIds.Except(newRoleIds).ToArray();
+                                // Roles to add should only be roles that the user doesn't already have.
+                                var rolesToAdd = newRoleIds.Except(currentRoleIds).ToArray();
+
+                                // Execute query to remove roles the user isn't supposed to have anymore.
+                                if (rolesToRemove.Length > 0)
                                 {
-                                    DatabaseConnection.AddParameter($"addRoleId{i}", rolesToAdd[i]);
-                                    values.Add($"(?userId, ?addRoleId{i})");
+                                    var inStatement = new List<string>();
+                                    for (var i = 0; i < rolesToRemove.Length; i++)
+                                    {
+                                        DatabaseConnection.AddParameter($"removeRoleId{i}", rolesToRemove[i]);
+                                        inStatement.Add($"?removeRoleId{i}");
+                                    }
+
+                                    await DatabaseConnection.ExecuteAsync($"DELETE FROM `{WiserTableNames.WiserUserRoles}` WHERE user_id = ?userId AND role_id IN ({String.Join(",", inStatement)})");
                                 }
-                                await DatabaseConnection.ExecuteAsync($@"INSERT IGNORE INTO `{WiserTableNames.WiserUserRoles}` (user_id, role_id) VALUES {String.Join(",", values)}");
+
+                                // Execute query to add new roles to the user.
+                                if (rolesToAdd.Length > 0)
+                                {
+                                    var values = new List<string>();
+                                    for (var i = 0; i < rolesToAdd.Length; i++)
+                                    {
+                                        DatabaseConnection.AddParameter($"addRoleId{i}", rolesToAdd[i]);
+                                        values.Add($"(?userId, ?addRoleId{i})");
+                                    }
+
+                                    await DatabaseConnection.ExecuteAsync($@"INSERT IGNORE INTO `{WiserTableNames.WiserUserRoles}` (user_id, role_id) VALUES {String.Join(",", values)}");
+                                }
                             }
                         }
                     }
-                }
 
-                if (createdNewAccount && Settings.SendNotificationsForNewAccounts)
+                    if (createdNewAccount && Settings.SendNotificationsForNewAccounts)
+                    {
+                        await SendNewAccountNotificationAsync(userId);
+                    }
+
+                    // Save the Google Analytics client ID. Make sure to always save it, even if the required settings don't contain a value.
+                    await SaveGoogleClientIdAsync(createdNewAccount ? userId : (await AccountsService.GetUserDataFromCookieAsync()).UserId);
+
+                    if (useTransaction)
+                    {
+                        // Everything succeeded, commit transaction and return the result
+                        await DatabaseConnection.CommitTransactionAsync();
+                    }
+
+                    transactionCompleted = true;
+                    return (result, ErrorTemplate: "", SuccessTemplate: Settings.TemplateSuccess, userId, subAccountId, Role: userRole);
+                }
+                catch (MySqlException mySqlException)
                 {
-                    await SendNewAccountNotificationAsync(userId);
+                    if (!useTransaction)
+                    {
+                        // We're not using transactions, rethrow the exception.
+                        throw;
+                    }
+
+                    await DatabaseConnection.RollbackTransactionAsync(false);
+
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    {
+                        // Exception is a deadlock or something similar, retry the transaction.
+                        retries++;
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                    }
+                    else
+                    {
+                        // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                        throw;
+                    }
                 }
-
-                // Save the Google Analytics client ID. Make sure to always save it, even if the required settings don't contain a value.
-                await SaveGoogleClientIdAsync(createdNewAccount ? userId : (await AccountsService.GetUserDataFromCookieAsync()).UserId);
-
-                if (useTransaction)
+                catch
                 {
-                    // Everything succeeded, commit transaction and return the result
-                    await DatabaseConnection.CommitTransactionAsync();
+                    await DatabaseConnection.RollbackTransactionAsync(false);
+                    throw;
                 }
+            }
 
-                return (result, ErrorTemplate: "", SuccessTemplate: Settings.TemplateSuccess, userId, subAccountId, Role: userRole);
-            }
-            catch
-            {
-                await DatabaseConnection.RollbackTransactionAsync(false);
-                throw;
-            }
+            return (CreateOrUpdateAccountResults.Success, ErrorTemplate: "", SuccessTemplate: Settings.TemplateSuccess, userId, subAccountId, Role: userRole);
         }
 
         /// <summary>

--- a/GeeksCoreLibrary/Components/Account/Account.cs
+++ b/GeeksCoreLibrary/Components/Account/Account.cs
@@ -796,7 +796,7 @@ namespace GeeksCoreLibrary.Components.Account
                 }
 
                 var userData = await AccountsService.GetUserDataFromCookieAsync();
-                var query = SetupAccountQuery(Settings.MainQuery, userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreateAccountId());
+                var query = SetupAccountQuery(Settings.MainQuery, userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreatedAccountId());
                 var accountDataTable = await RenderAndExecuteQueryAsync(query, skipCache: true);
                 var availableFields = new List<string>();
 
@@ -852,7 +852,7 @@ namespace GeeksCoreLibrary.Components.Account
                             try
                             {
                                 await DatabaseConnection.BeginTransactionAsync();
-                                createOrUpdateAccountResult = await CreateOrUpdateAccountAsync(userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreateAccountId(), availableFields, useTransaction: false);
+                                createOrUpdateAccountResult = await CreateOrUpdateAccountAsync(userData.UserId > 0 ? userData.UserId : AccountsService.GetRecentlyCreatedAccountId(), availableFields, useTransaction: false);
 
                                 if (createOrUpdateAccountResult.UserId > 0 && userData.UserId == 0)
                                 {

--- a/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
@@ -20,7 +20,7 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// So we still create an account for the user, but without a password. We then save this ID encrypted in a cookie to be used later. This function gets and decrypts that ID.
         /// </summary>
         /// <returns>The decrypted user ID if a user was recently created in this session. Otherwise it returns 0.</returns>
-        ulong GetRecentlyCreateAccountId();
+        ulong GetRecentlyCreatedAccountId();
 
         /// <summary>
         /// Generates a new cookie for a logged in user.
@@ -32,7 +32,7 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// <param name="userEntityType">The entity type for sub accounts.</param>
         /// <returns>The value that should be saved in the cookie.</returns>
         Task<string> GenerateNewCookieTokenAsync(ulong userId, ulong mainUserId, int amountOfDaysToRememberCookie, string mainUserEntityType = "relatie", string userEntityType = "account");
-        
+
         /// <summary>
         /// Deletes a cookie token from the database, so that the user cannot login with it anymore, even if it still has a cookie with that token.
         /// </summary>
@@ -55,7 +55,7 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// <param name="entityType">The entity type of the user account in wiser_item.</param>
         /// <returns></returns>
         Task<string> Get2FactorAuthenticationKeyAsync(ulong userId, string entityType = Constants.DefaultEntityType);
-        
+
         /// <summary>
         /// Attempts to log off the user. This will delete the user's cookie from their browser and our database.
         /// </summary>

--- a/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
@@ -200,7 +200,7 @@ namespace GeeksCoreLibrary.Components.Account.Services
         }
 
         /// <inheritdoc />
-        public ulong GetRecentlyCreateAccountId()
+        public ulong GetRecentlyCreatedAccountId()
         {
             var httpContext = httpContextAccessor?.HttpContext;
             if (httpContext == null)

--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -21,6 +21,7 @@ using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.Databases.Services;
 using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
@@ -29,6 +30,8 @@ using GeeksCoreLibrary.Modules.Payments.Enums;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
 using Constants = GeeksCoreLibrary.Components.OrderProcess.Models.Constants;
 
 namespace GeeksCoreLibrary.Components.OrderProcess
@@ -36,6 +39,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
     [ViewComponent(Name = "OrderProcess")]
     public class OrderProcess : CmsComponent<OrderProcessCmsSettingsModel, OrderProcess.ComponentModes>
     {
+        private readonly GclSettings gclSettings;
         private readonly ILanguagesService languagesService;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly IOrderProcessesService orderProcessesService;
@@ -63,7 +67,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
             /// For handling web hooks from PSPs and updating orders with the correct status based on what the PSP sends us.
             /// </summary>
             PaymentIn,
-            
+
             /// <summary>
             /// For PSPs that always send the user to the same page, no matter the result of their payment.
             /// From this page, we can then send the user to the correct page based on the result of the payment.
@@ -75,7 +79,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess
 
         #region Constructor
 
-        public OrderProcess(ILogger<OrderProcess> logger,
+        public OrderProcess(IOptions<GclSettings> gclSettings,
+            ILogger<OrderProcess> logger,
             IStringReplacementsService stringReplacementsService,
             ILanguagesService languagesService,
             IDatabaseConnection databaseConnection,
@@ -87,6 +92,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
             IMeasurementProtocolService measurementProtocolService,
             IHttpContextAccessor httpContextAccessor = null)
         {
+            this.gclSettings = gclSettings.Value;
             this.languagesService = languagesService;
             this.httpContextAccessor = httpContextAccessor;
             this.orderProcessesService = orderProcessesService;
@@ -104,9 +110,9 @@ namespace GeeksCoreLibrary.Components.OrderProcess
         }
 
         #endregion
-        
+
         #region Handling settings
-        
+
         /// <inheritdoc />
         public override void ParseSettingsJson(string settingsJson, int? forcedComponentMode = null)
         {
@@ -118,7 +124,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
 
             HandleDefaultSettingsFromComponentMode();
         }
-        
+
         /// <inheritdoc />
         public override string GetSettingsJson()
         {
@@ -126,7 +132,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
         }
 
         #endregion
-        
+
         #region Rendering
 
         /// <inheritdoc />
@@ -179,14 +185,14 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                 ComponentModes.PaymentReturn => await HandlePaymentReturnModeAsync(),
                 _ => throw new ArgumentOutOfRangeException(nameof(Settings.ComponentMode), Settings.ComponentMode.ToString())
             };
-            
+
             return new HtmlString(html);
         }
 
         #endregion
 
         #region Handling different component modes
-        
+
         /// <summary>
         /// Handles the checkout component mode and outputs the HTML for this mode.
         /// </summary>
@@ -213,7 +219,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                     HttpContextHelpers.Return404(httpContextAccessor?.HttpContext);
                     return "";
                 }
-                
+
                 // If we have no confirmation page and/or no payment methods, then the order process has not been fully configured and we want to throw an error.
                 if (steps.All(step => step.Type != OrderProcessStepTypes.OrderConfirmation))
                 {
@@ -277,7 +283,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                     await shoppingBasketsService.SaveAsync(shoppingBasket, shoppingBasketLines, shoppingBasketSettings);
                     await measurementProtocolService.BeginCheckoutEventAsync(orderProcessSettings, shoppingBasket, shoppingBasketLines, shoppingBasketSettings);
                 }
-                
+
                 // Generate the URL for the next step, we'll need this for a few things.
                 var nextStep = ActiveStep + 1;
                 UriBuilder nextStepUri;
@@ -306,39 +312,70 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                 // Do all validation and saving first, so that we don't have to render the entire HTML of this step, if we are going to to send someone to the next step anyway.
                 if (isPostBack)
                 {
-                    await DatabaseConnection.BeginTransactionAsync();
+                    var retries = 0;
+                    var transactionCompleted = false;
 
-                    // If we have no user ID yet, create it here because the ValidatePostBackAndSaveValuesAsync method will need a user ID to link items that might be created there. 
-                    if (userData.Id == 0)
+                    while (!transactionCompleted)
                     {
-                        userData = await wiserItemsService.CreateAsync(userData, createNewTransaction: false, skipPermissionsCheck: true);
-                    }
-
-                    fieldErrorsOccurred = await ValidatePostBackAndSaveValuesAsync(orderProcessSettings, step, loggedInUser, request, shoppingBasket, shoppingBasketLines, shoppingBasketSettings, paymentMethods, currentItems);
-
-                    // Save values to database if all validation succeeded.
-                    if (!fieldErrorsOccurred)
-                    {
-                        // Save basket to database.
-                        shoppingBasket = await shoppingBasketsService.SaveAsync(shoppingBasket, shoppingBasketLines, shoppingBasketSettings, createNewTransaction: false);
-                        
-                        // Save all other items to database.
-                        foreach (var item in currentItems)
+                        try
                         {
-                            await wiserItemsService.SaveAsync(item.Item, userId: userData.Id, createNewTransaction: false, skipPermissionsCheck: true);
+                            await DatabaseConnection.BeginTransactionAsync();
+
+                            // If we have no user ID yet, create it here because the ValidatePostBackAndSaveValuesAsync method will need a user ID to link items that might be created there.
+                            if (userData.Id == 0)
+                            {
+                                userData = await wiserItemsService.CreateAsync(userData, createNewTransaction: false, skipPermissionsCheck: true);
+                            }
+
+                            fieldErrorsOccurred = await ValidatePostBackAndSaveValuesAsync(orderProcessSettings, step, loggedInUser, request, shoppingBasket, shoppingBasketLines, shoppingBasketSettings, paymentMethods, currentItems);
+
+                            // Save values to database if all validation succeeded.
+                            if (fieldErrorsOccurred)
+                            {
+                                await DatabaseConnection.RollbackTransactionAsync();
+                            }
+                            else
+                            {
+                                // Save basket to database.
+                                shoppingBasket = await shoppingBasketsService.SaveAsync(shoppingBasket, shoppingBasketLines, shoppingBasketSettings, createNewTransaction: false);
+
+                                // Save all other items to database.
+                                foreach (var item in currentItems)
+                                {
+                                    await wiserItemsService.SaveAsync(item.Item, userId: userData.Id, createNewTransaction: false, skipPermissionsCheck: true);
+                                }
+
+                                // Link basket to active user, if it's not linked to someone else yet.
+                                await shoppingBasketsService.LinkBasketToUserAsync(shoppingBasketSettings, userData.Id, shoppingBasket);
+
+                                await DatabaseConnection.CommitTransactionAsync();
+
+                                response.Redirect(nextStepUri.ToString());
+
+                                return null;
+                            }
+
+                            transactionCompleted = true;
                         }
-                        
-                        // Link basket to active user, if it's not linked to someone else yet.
-                        await shoppingBasketsService.LinkBasketToUserAsync(shoppingBasketSettings, userData.Id, shoppingBasket);
+                        catch (MySqlException mySqlException)
+                        {
+                            await DatabaseConnection.RollbackTransactionAsync(false);
 
-                        await DatabaseConnection.CommitTransactionAsync();
-
-                        response.Redirect(nextStepUri.ToString());
-
-                        return null;
+                            if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                            {
+                                // Exception is a deadlock or something similar, retry the transaction.
+                                retries++;
+                                Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                            }
+                            else
+                            {
+                                // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                                throw;
+                            }
+                        }
                     }
                 }
-                
+
                 // Redirect the user if needed.
                 if (!String.IsNullOrWhiteSpace(step.StepRedirectUrl) && response != null)
                 {
@@ -366,7 +403,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                 }
 
                 previousStepUri.Query = previousStepQueryString.ToString() ?? String.Empty;
-                
+
                 // Build the steps HTML.
                 var replaceData = new Dictionary<string, object>
                 {
@@ -419,7 +456,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
 
                                 continue;
                             }
-                            
+
                             var groupHtml = await RenderGroupAsync(group, loggedInUser, shoppingBasket, currentItems, paymentMethods, fieldErrorsOccurred);
                             if (groupHtml == null)
                             {
@@ -610,7 +647,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                     {
                         value = field.Values[value];
                     }
-                
+
                     replaceData.Add($"{item.EntityType}.{itemDetail.Key}_{linkSettings.Type}", value);
                     replaceData[$"{item.EntityType}.{itemDetail.Key}"] = value;
                 }
@@ -629,7 +666,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
             {
                 return "HttpContext not available.";
             }
-            
+
             var paymentRequestResult = await orderProcessesService.HandlePaymentRequestAsync(Settings.OrderProcessId);
 
             switch (paymentRequestResult.Action)
@@ -680,13 +717,13 @@ namespace GeeksCoreLibrary.Components.OrderProcess
             {
                 return "HttpContext not available.";
             }
-            
+
             var paymentMethodFromRequest = HttpContextHelpers.GetRequestValue(httpContextAccessor.HttpContext, Constants.SelectedPaymentMethodRequestKey);
             if (!UInt64.TryParse(paymentMethodFromRequest, out var paymentMethodId) || paymentMethodId == 0)
             {
                 throw new Exception($"Invalid payment method ID: {paymentMethodFromRequest}");
             }
-            
+
             var result = await orderProcessesService.HandlePaymentReturnAsync(Settings.OrderProcessId, paymentMethodId);
 
             switch (result.Action)
@@ -878,7 +915,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                                 }
                             }
                         }
-                        
+
                         if (!String.IsNullOrWhiteSpace(fieldValue))
                         {
                             break;
@@ -1128,7 +1165,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                                 passwordFields.First().IsValid = false;
                                 passwordFields.Last().IsValid = false;
                                 fieldErrorsOccurred = true;
-                                
+
                                 var errorMessage = await languagesService.GetTranslationAsync("orderProcess_passwords_not_the_same_errorMessage", defaultValue: "");
                                 if (!String.IsNullOrEmpty(errorMessage))
                                 {
@@ -1193,7 +1230,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess
                 };
             }).ToList();
         }
-        
+
         /// <summary>
         /// Method to add an error to the result.
         /// If a variable '{error}' exists in the result HTML, then that variable will be replaced with the error.

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Components.Account.Interfaces;
 using GeeksCoreLibrary.Components.OrderProcess.Enums;
@@ -16,6 +17,7 @@ using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.Databases.Services;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
@@ -25,6 +27,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MySql.Data.MySqlClient;
 
 namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
 {
@@ -499,51 +502,79 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                 newBasket = true;
             }
 
-            if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
-            try
+            var retries = 0;
+            var transactionCompleted = false;
+
+            while (!transactionCompleted)
             {
-                shoppingBasket = await wiserItemsService.SaveAsync(shoppingBasket, alwaysSaveValues: true, saveHistory: false, createNewTransaction: false, skipPermissionsCheck: true);
-
-                var lineIds = new List<ulong>();
-
-                foreach (var line in basketLines)
+                try
                 {
-                    if (String.IsNullOrWhiteSpace(line.EntityType) || line.Id == 0UL)
+                    if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
+                    shoppingBasket = await wiserItemsService.SaveAsync(shoppingBasket, alwaysSaveValues: true, saveHistory: false, createNewTransaction: false, skipPermissionsCheck: true);
+
+                    var lineIds = new List<ulong>();
+
+                    foreach (var line in basketLines)
                     {
-                        line.EntityType = Constants.BasketLineEntityType;
-                        line.AddedBy = "GCL";
+                        if (String.IsNullOrWhiteSpace(line.EntityType) || line.Id == 0UL)
+                        {
+                            line.EntityType = Constants.BasketLineEntityType;
+                            line.AddedBy = "GCL";
+                        }
+
+                        var lineSaveResult = await wiserItemsService.SaveAsync(line, shoppingBasket.Id, Constants.BasketLineToBasketLinkType, alwaysSaveValues: true, saveHistory: false, createNewTransaction: false, skipPermissionsCheck: true);
+                        line.Id = lineSaveResult.Id;
+
+                        lineIds.Add(line.Id);
                     }
 
-                    var lineSaveResult = await wiserItemsService.SaveAsync(line, shoppingBasket.Id, Constants.BasketLineToBasketLinkType, alwaysSaveValues: true, saveHistory: false, createNewTransaction: false, skipPermissionsCheck: true);
-                    line.Id = lineSaveResult.Id;
+                    await wiserItemsService.RemoveLinkedItemsAsync(shoppingBasket.Id, Constants.BasketLineToBasketLinkType, lineIds, entityType: Constants.BasketLineEntityType, createNewTransaction: false, skipPermissionsCheck: true);
 
-                    lineIds.Add(line.Id);
-                }
-
-                await wiserItemsService.RemoveLinkedItemsAsync(shoppingBasket.Id, Constants.BasketLineToBasketLinkType, lineIds, entityType: Constants.BasketLineEntityType, createNewTransaction: false, skipPermissionsCheck: true);
-
-                if (newBasket)
-                {
-                    if (user is { MainUserId: > 0 })
+                    if (newBasket)
                     {
-                        await wiserItemsService.AddItemLinkAsync(shoppingBasket.Id, user.MainUserId, Constants.BasketToUserLinkType, skipPermissionsCheck: true);
+                        if (user is {MainUserId: > 0})
+                        {
+                            await wiserItemsService.AddItemLinkAsync(shoppingBasket.Id, user.MainUserId, Constants.BasketToUserLinkType, skipPermissionsCheck: true);
+                        }
+                        else
+                        {
+                            var newlyCreatedAccount = accountsService.GetRecentlyCreateAccountId();
+                            if (newlyCreatedAccount > 0)
+                            {
+                                await wiserItemsService.AddItemLinkAsync(shoppingBasket.Id, newlyCreatedAccount, Constants.BasketToUserLinkType, skipPermissionsCheck: true);
+                            }
+                        }
+                    }
+
+                    if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
+                    transactionCompleted = true;
+                }
+                catch (MySqlException mySqlException)
+                {
+                    if (!createNewTransaction)
+                    {
+                        throw;
+                    }
+
+                    await databaseConnection.RollbackTransactionAsync(false);
+
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    {
+                        // Exception is a deadlock or something similar, retry the transaction.
+                        retries++;
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     }
                     else
                     {
-                        var newlyCreatedAccount = accountsService.GetRecentlyCreateAccountId();
-                        if (newlyCreatedAccount > 0)
-                        {
-                            await wiserItemsService.AddItemLinkAsync(shoppingBasket.Id, newlyCreatedAccount, Constants.BasketToUserLinkType, skipPermissionsCheck: true);
-                        }
+                        // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                        throw;
                     }
                 }
-
-                if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
-            }
-            catch
-            {
-                if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
-                throw;
+                catch
+                {
+                    if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
+                    throw;
+                }
             }
 
             // Write basket item ID to cookie.
@@ -772,36 +803,59 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
         /// <inheritdoc />
         public async Task ConvertConceptOrderToOrderAsync(WiserItemModel conceptOrder, ShoppingBasketCmsSettingsModel settings)
         {
-            try
+            var retries = 0;
+            var transactionCompleted = false;
+
+            while (!transactionCompleted)
             {
-                await databaseConnection.BeginTransactionAsync();
-
-                await wiserItemsService.ChangeEntityTypeAsync(conceptOrder.Id, OrderProcess.Models.Constants.ConceptOrderEntityType, OrderProcess.Models.Constants.OrderEntityType, skipPermissionsCheck: true, resetAddedOnDate: true);
-
-                // Check if there is a AfterCreateConceptOrder query in the templates module and execute this query if present.
-                var afterConvertToOrderQuery = (await templatesService.GetTemplateAsync(0, "AfterConvertToOrder", TemplateTypes.Query)).Content;
-                if (!String.IsNullOrWhiteSpace(afterConvertToOrderQuery))
+                try
                 {
-                    var query = stringReplacementsService.DoSessionReplacements(afterConvertToOrderQuery, true);
+                    await databaseConnection.BeginTransactionAsync();
 
-                    var replacementData = new Dictionary<string, object> { { "orderId", conceptOrder.Id } };
+                    await wiserItemsService.ChangeEntityTypeAsync(conceptOrder.Id, OrderProcess.Models.Constants.ConceptOrderEntityType, OrderProcess.Models.Constants.OrderEntityType, skipPermissionsCheck: true, resetAddedOnDate: true);
 
-                    var orderLineToOrderLinkType = await wiserItemsService.GetLinkTypeAsync(OrderProcess.Models.Constants.OrderEntityType, OrderProcess.Models.Constants.OrderLineEntityType);
-                    var orderLines = await wiserItemsService.GetLinkedItemDetailsAsync(conceptOrder.Id, orderLineToOrderLinkType, OrderProcess.Models.Constants.OrderLineEntityType, itemIdEntityType: OrderProcess.Models.Constants.OrderEntityType, skipPermissionsCheck: true);
+                    // Check if there is a AfterCreateConceptOrder query in the templates module and execute this query if present.
+                    var afterConvertToOrderQuery = (await templatesService.GetTemplateAsync(0, "AfterConvertToOrder", TemplateTypes.Query)).Content;
+                    if (!String.IsNullOrWhiteSpace(afterConvertToOrderQuery))
+                    {
+                        var query = stringReplacementsService.DoSessionReplacements(afterConvertToOrderQuery, true);
 
-                    query = stringReplacementsService.DoReplacements(query, replacementData, forQuery: true);
-                    query = await ReplaceBasketInTemplateAsync(conceptOrder, orderLines, settings, query, forQuery: true);
-                    query = stringReplacementsService.DoHttpRequestReplacements(query, true);
+                        var replacementData = new Dictionary<string, object> {{"orderId", conceptOrder.Id}};
 
-                    await databaseConnection.ExecuteAsync(query);
+                        var orderLineToOrderLinkType = await wiserItemsService.GetLinkTypeAsync(OrderProcess.Models.Constants.OrderEntityType, OrderProcess.Models.Constants.OrderLineEntityType);
+                        var orderLines = await wiserItemsService.GetLinkedItemDetailsAsync(conceptOrder.Id, orderLineToOrderLinkType, OrderProcess.Models.Constants.OrderLineEntityType, itemIdEntityType: OrderProcess.Models.Constants.OrderEntityType, skipPermissionsCheck: true);
+
+                        query = stringReplacementsService.DoReplacements(query, replacementData, forQuery: true);
+                        query = await ReplaceBasketInTemplateAsync(conceptOrder, orderLines, settings, query, forQuery: true);
+                        query = stringReplacementsService.DoHttpRequestReplacements(query, true);
+
+                        await databaseConnection.ExecuteAsync(query);
+                    }
+
+                    await databaseConnection.CommitTransactionAsync();
+                    transactionCompleted = true;
                 }
+                catch (MySqlException mySqlException)
+                {
+                    await databaseConnection.RollbackTransactionAsync(false);
 
-                await databaseConnection.CommitTransactionAsync();
-            }
-            catch
-            {
-                await databaseConnection.RollbackTransactionAsync();
-                throw;
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    {
+                        // Exception is a deadlock or something similar, retry the transaction.
+                        retries++;
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                    }
+                    else
+                    {
+                        // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                        throw;
+                    }
+                }
+                catch
+                {
+                    await databaseConnection.RollbackTransactionAsync(false);
+                    throw;
+                }
             }
         }
 
@@ -1689,67 +1743,95 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
         /// <inheritdoc />
         public async Task AddLineAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string uniqueId = null, ulong itemId = 0UL, int quantity = 1, string type = "product", IDictionary<string, string> lineDetails = null, bool createNewTransaction = true)
         {
-            if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
-            try
+            var retries = 0;
+            var transactionCompleted = false;
+
+            while (!transactionCompleted)
             {
-                if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
+                try
                 {
-                    var sqlQuery = settings.SqlQuery;
-                    sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
-                    sqlQuery = sqlQuery.Replace("{itemid}", itemId.ToString());
-                    sqlQuery = sqlQuery.Replace("{quantity}", quantity.ToString(CultureInfo.InvariantCulture));
-
-                    sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
-
-                    var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
-                    if (getItemDetailsResult.Rows.Count > 0)
+                    if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
+                    if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
                     {
-                        var details = getItemDetailsResult.Columns.Cast<DataColumn>().Where(dataColumn => dataColumn.ColumnName != "id").ToDictionary(dataColumn => dataColumn.ColumnName, dataColumn => Convert.ToString(getItemDetailsResult.Rows[0][dataColumn]));
+                        var sqlQuery = settings.SqlQuery;
+                        sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
+                        sqlQuery = sqlQuery.Replace("{itemid}", itemId.ToString());
+                        sqlQuery = sqlQuery.Replace("{quantity}", quantity.ToString(CultureInfo.InvariantCulture));
 
-                        lineDetails ??= new Dictionary<string, string>();
-                        foreach (var (key, value) in details)
+                        sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
+
+                        var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
+                        if (getItemDetailsResult.Rows.Count > 0)
                         {
-                            lineDetails[key] = value;
+                            var details = getItemDetailsResult.Columns.Cast<DataColumn>().Where(dataColumn => dataColumn.ColumnName != "id").ToDictionary(dataColumn => dataColumn.ColumnName, dataColumn => Convert.ToString(getItemDetailsResult.Rows[0][dataColumn]));
+
+                            lineDetails ??= new Dictionary<string, string>();
+                            foreach (var (key, value) in details)
+                            {
+                                lineDetails[key] = value;
+                            }
                         }
                     }
-                }
 
-                var addItemLine = AddLineInternal(basketLines, settings, uniqueId, itemId, quantity, type, lineDetails);
+                    var addItemLine = AddLineInternal(basketLines, settings, uniqueId, itemId, quantity, type, lineDetails);
 
-                // Write changes to database.
-                await SaveAsync(shoppingBasket, basketLines, settings, false);
+                    // Write changes to database.
+                    await SaveAsync(shoppingBasket, basketLines, settings, false);
 
-                var alsoCreateItemLink = (await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_AlsoCreateItemLinkBetweenBasketLineAndProduct")).Equals("true", StringComparison.OrdinalIgnoreCase);
-                if (alsoCreateItemLink)
-                {
-                    if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_LinkTypeProductToOrderLine", Constants.ProductToOrderLineLinkType.ToString()), out var productToBasketLinkType))
+                    var alsoCreateItemLink = (await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_AlsoCreateItemLinkBetweenBasketLineAndProduct")).Equals("true", StringComparison.OrdinalIgnoreCase);
+                    if (alsoCreateItemLink)
                     {
-                        productToBasketLinkType = Constants.ProductToOrderLineLinkType;
+                        if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_LinkTypeProductToOrderLine", Constants.ProductToOrderLineLinkType.ToString()), out var productToBasketLinkType))
+                        {
+                            productToBasketLinkType = Constants.ProductToOrderLineLinkType;
+                        }
+
+                        var productId = addItemLine.GetDetailValue<ulong>(Constants.ConnectedItemIdProperty);
+                        if (productId > 0)
+                        {
+                            await wiserItemsService.AddItemLinkAsync(productId, addItemLine.Id, productToBasketLinkType, skipPermissionsCheck: true);
+                        }
                     }
 
-                    var productId = addItemLine.GetDetailValue<ulong>(Constants.ConnectedItemIdProperty);
-                    if (productId > 0)
+                    await ExecuteAddToBasketQuery(shoppingBasket, basketLines, settings);
+
+                    // Reload basket (for getting item details of added item).
+                    if (!String.IsNullOrEmpty(settings.ExtraMainFieldsQuery) || !String.IsNullOrEmpty(settings.ExtraLineFieldsQuery))
                     {
-                        await wiserItemsService.AddItemLinkAsync(productId, addItemLine.Id, productToBasketLinkType, skipPermissionsCheck: true);
+                        (shoppingBasket, basketLines, _, _) = await LoadAsync(settings, shoppingBasket.Id);
+                    }
+
+                    await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, type, false);
+
+                    if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
+                    transactionCompleted = true;
+                }
+                catch (MySqlException mySqlException)
+                {
+                    if (!createNewTransaction)
+                    {
+                        throw;
+                    }
+
+                    await databaseConnection.RollbackTransactionAsync(false);
+
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    {
+                        // Exception is a deadlock or something similar, retry the transaction.
+                        retries++;
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                    }
+                    else
+                    {
+                        // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                        throw;
                     }
                 }
-
-                await ExecuteAddToBasketQuery(shoppingBasket, basketLines, settings);
-
-                // Reload basket (for getting item details of added item).
-                if (!String.IsNullOrEmpty(settings.ExtraMainFieldsQuery) || !String.IsNullOrEmpty(settings.ExtraLineFieldsQuery))
+                catch
                 {
-                    (shoppingBasket, basketLines, _, _) = await LoadAsync(settings, shoppingBasket.Id);
+                    if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
+                    throw;
                 }
-
-                await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, type, false);
-
-                if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
-            }
-            catch
-            {
-                if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
-                throw;
             }
         }
 
@@ -1761,82 +1843,111 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                 return;
             }
 
-            if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
-            try
+            var retries = 0;
+            var transactionCompleted = false;
+
+            while (!transactionCompleted)
             {
-                var createLinksFor = new List<WiserItemModel>();
-                foreach (var item in items)
+                try
                 {
-                    if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
+                    if (createNewTransaction) await databaseConnection.BeginTransactionAsync();
+                    var createLinksFor = new List<WiserItemModel>();
+                    foreach (var item in items)
                     {
-                        var sqlQuery = settings.SqlQuery;
-                        sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
-                        sqlQuery = sqlQuery.Replace("{itemid}", item.ItemId.ToString());
-                        sqlQuery = sqlQuery.Replace("{quantity}", item.Quantity.ToString(CultureInfo.InvariantCulture));
-
-                        sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
-
-                        var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
-                        if (getItemDetailsResult.Rows.Count > 0)
+                        if (!String.IsNullOrWhiteSpace(settings.SqlQuery))
                         {
-                            var details = getItemDetailsResult.Columns.Cast<DataColumn>().Where(dataColumn => dataColumn.ColumnName != "id").ToDictionary(dataColumn => dataColumn.ColumnName, dataColumn => Convert.ToString(getItemDetailsResult.Rows[0][dataColumn]));
+                            var sqlQuery = settings.SqlQuery;
+                            sqlQuery = await templatesService.HandleIncludesAsync(sqlQuery, false, null, false, true);
+                            sqlQuery = sqlQuery.Replace("{itemid}", item.ItemId.ToString());
+                            sqlQuery = sqlQuery.Replace("{quantity}", item.Quantity.ToString(CultureInfo.InvariantCulture));
 
-                            item.LineDetails ??= new Dictionary<string, string>();
-                            foreach (var (key, value) in details)
+                            sqlQuery = await stringReplacementsService.DoAllReplacementsAsync(sqlQuery, null, true, true, false, true);
+
+                            var getItemDetailsResult = await databaseConnection.GetAsync(sqlQuery, true);
+                            if (getItemDetailsResult.Rows.Count > 0)
                             {
-                                item.LineDetails[key] = value;
+                                var details = getItemDetailsResult.Columns.Cast<DataColumn>().Where(dataColumn => dataColumn.ColumnName != "id").ToDictionary(dataColumn => dataColumn.ColumnName, dataColumn => Convert.ToString(getItemDetailsResult.Rows[0][dataColumn]));
+
+                                item.LineDetails ??= new Dictionary<string, string>();
+                                foreach (var (key, value) in details)
+                                {
+                                    item.LineDetails[key] = value;
+                                }
+                            }
+                        }
+
+                        var addItemLine = AddLineInternal(basketLines, settings, item.UniqueId, item.ItemId, item.Quantity, item.Type, item.LineDetails);
+                        createLinksFor.Add(addItemLine);
+                    }
+
+                    // Write changes to database.
+                    await SaveAsync(shoppingBasket, basketLines, settings, false);
+
+                    if (createLinksFor.Count > 0)
+                    {
+                        var alsoCreateItemLink = (await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_AlsoCreateItemLinkBetweenBasketLineAndProduct")).Equals("true", StringComparison.OrdinalIgnoreCase);
+                        if (alsoCreateItemLink)
+                        {
+                            if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_LinkTypeProductToOrderLine", Constants.ProductToOrderLineLinkType.ToString()), out var productToBasketLinkType))
+                            {
+                                productToBasketLinkType = Constants.ProductToOrderLineLinkType;
+                            }
+
+                            foreach (var item in createLinksFor)
+                            {
+                                var productId = item.GetDetailValue<ulong>(Constants.ConnectedItemIdProperty);
+                                if (productId <= 0)
+                                {
+                                    continue;
+                                }
+
+                                await wiserItemsService.AddItemLinkAsync(productId, item.Id, productToBasketLinkType, skipPermissionsCheck: true);
                             }
                         }
                     }
 
-                    var addItemLine = AddLineInternal(basketLines, settings, item.UniqueId, item.ItemId, item.Quantity, item.Type, item.LineDetails);
-                    createLinksFor.Add(addItemLine);
-                }
+                    await ExecuteAddToBasketQuery(shoppingBasket, basketLines, settings);
 
-                // Write changes to database.
-                await SaveAsync(shoppingBasket, basketLines, settings, false);
-
-                if (createLinksFor.Count > 0)
-                {
-                    var alsoCreateItemLink = (await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_AlsoCreateItemLinkBetweenBasketLineAndProduct")).Equals("true", StringComparison.OrdinalIgnoreCase);
-                    if (alsoCreateItemLink)
+                    if (!String.IsNullOrEmpty(settings.ExtraMainFieldsQuery) || !String.IsNullOrEmpty(settings.ExtraLineFieldsQuery))
                     {
-                        if (!Int32.TryParse(await objectsService.FindSystemObjectByDomainNameAsync("W2CHECKOUT_LinkTypeProductToOrderLine", Constants.ProductToOrderLineLinkType.ToString()), out var productToBasketLinkType))
-                        {
-                            productToBasketLinkType = Constants.ProductToOrderLineLinkType;
-                        }
+                        (shoppingBasket, basketLines, _, _) = await LoadAsync(settings, shoppingBasket.Id);
+                    }
 
-                        foreach (var item in createLinksFor)
-                        {
-                            var productId = item.GetDetailValue<ulong>(Constants.ConnectedItemIdProperty);
-                            if (productId <= 0)
-                            {
-                                continue;
-                            }
+                    // Recalculate shipping costs, coupons etc. after getting the extra fields (price can be selected with extra fields query).
+                    await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, items.First().Type, false);
 
-                            await wiserItemsService.AddItemLinkAsync(productId, item.Id, productToBasketLinkType, skipPermissionsCheck: true);
-                        }
+                    if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
+                    transactionCompleted = true;
+                }
+                catch (MySqlException mySqlException)
+                {
+                    if (!createNewTransaction)
+                    {
+                        throw;
+                    }
+
+                    await databaseConnection.RollbackTransactionAsync(false);
+
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    {
+                        // Exception is a deadlock or something similar, retry the transaction.
+                        retries++;
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                    }
+                    else
+                    {
+                        // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
+                        logger.LogError(mySqlException, "An error occured while trying to add one or more lines to the shopping basket.");
+                        throw;
                     }
                 }
-
-                await ExecuteAddToBasketQuery(shoppingBasket, basketLines, settings);
-
-                if (!String.IsNullOrEmpty(settings.ExtraMainFieldsQuery) || !String.IsNullOrEmpty(settings.ExtraLineFieldsQuery))
+                catch (Exception exception)
                 {
-                    (shoppingBasket, basketLines, _, _) = await LoadAsync(settings, shoppingBasket.Id);
+                    logger.LogError(exception, "An error occured while trying to add one or more lines to the shopping basket.");
+
+                    if (createNewTransaction) await databaseConnection.RollbackTransactionAsync(false);
+                    throw;
                 }
-
-                // Recalculate shipping costs, coupons etc. after getting the extra fields (price can be selected with extra fields query).
-                await RecalculateVariablesAsync(shoppingBasket, basketLines, settings, items.First().Type, false);
-
-                if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
-            }
-            catch (Exception exception)
-            {
-                logger.LogError(exception, "An error occured while trying to add one or more lines to the shopping basket.");
-
-                if (createNewTransaction) await databaseConnection.RollbackTransactionAsync();
-                throw;
             }
         }
 

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -451,7 +451,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                             var userId = user.MainUserId;
                             if (userId == 0)
                             {
-                                userId = accountsService.GetRecentlyCreateAccountId();
+                                userId = accountsService.GetRecentlyCreatedAccountId();
                             }
 
                             if (userId > 0 && !settings.MultipleBasketsPossible && shoppingBasket.EntityType == Constants.BasketEntityType)
@@ -538,7 +538,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                         }
                         else
                         {
-                            var newlyCreatedAccount = accountsService.GetRecentlyCreateAccountId();
+                            var newlyCreatedAccount = accountsService.GetRecentlyCreatedAccountId();
                             if (newlyCreatedAccount > 0)
                             {
                                 await wiserItemsService.AddItemLinkAsync(shoppingBasket.Id, newlyCreatedAccount, Constants.BasketToUserLinkType, skipPermissionsCheck: true);
@@ -622,7 +622,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
 
             if (userId == 0UL)
             {
-                userId = accountsService.GetRecentlyCreateAccountId();
+                userId = accountsService.GetRecentlyCreatedAccountId();
                 if (userId == 0UL)
                 {
                     userId = (await wiserItemsService.GetLinkedItemIdsAsync(shoppingBasket.Id, Constants.BasketToUserLinkType, reverse: true, skipPermissionsCheck: true)).FirstOrDefault();
@@ -1165,7 +1165,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                         }
                         else
                         {
-                            var userId = accountsService.GetRecentlyCreateAccountId();
+                            var userId = accountsService.GetRecentlyCreatedAccountId();
                             if (userId == 0)
                             {
                                 var userEntityType = await objectsService.FindSystemObjectByDomainNameAsync("userEntityType", "relatie");

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -53,9 +53,18 @@ namespace GeeksCoreLibrary.Core.Models
         ///         <term>1040</term>
         ///         <description>Too many connections</description>
         ///     </item>
+        ///     <item>
+        ///         <term>1412</term>
+        ///         <description>Table definition changed.</description>
+        ///     </item>
         /// </list>
         /// </summary>
         public int MaximumRetryCountForQueries { get; set; } = 5;
+
+        /// <summary>
+        /// Gets or sets the amount of time to wait before retrying a query when a deadlock or similar exception occurs.
+        /// </summary>
+        public int TimeToWaitBeforeRetryingQueryInMilliseconds { get; set; } = 200;
 
         /// <summary>
         /// The current environment.
@@ -209,11 +218,11 @@ namespace GeeksCoreLibrary.Core.Models
         /// A list of domain names that are considered to be test domains. E.g.: my-test-domain.com
         /// </summary>
         public string[] TestDomains { get; set; } = Array.Empty<string>();
-        
+
         /// <summary>
         /// Whether to log whenever a database connection gets opened and closed.
         /// These logs will be saved in the table "gcl_database_connection_log".
-        /// That table will be automatically created if it doesn't exist yet. 
+        /// That table will be automatically created if it doesn't exist yet.
         /// </summary>
         public bool LogOpeningAndClosingOfConnections { get; set; }
     }

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -4288,11 +4288,11 @@ WHERE id = ?saveDetailId";
                 {
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < MySqlDatabaseConnection.MaxRetriesAfterDeadlock)
+                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
-                        Thread.Sleep(200);
+                        Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     }
                     else
                     {

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -25,7 +25,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 {
     public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
     {
-        public const int MaxRetriesAfterDeadlock = 5;
         public static readonly List<int> MySqlErrorCodesToRetry = new()
         {
             (int) MySqlErrorCode.LockDeadlock,
@@ -151,7 +150,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // If we're not in a transaction, retry the query if it's a deadlock.
                 if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    Thread.Sleep(200);
+                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
                 }
 
@@ -223,7 +222,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // If we're not in a transaction, retry the query if it's a deadlock.
                 if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    Thread.Sleep(100);
+                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);
                 }
 
@@ -341,7 +340,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // If we're not in a transaction, retry the query if it's a deadlock.
                 if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    Thread.Sleep(100);
+                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
                     return await InsertRecordAsync(query, retryCount + 1, useWritingConnectionIfAvailable);
                 }
 

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -35,7 +35,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             (int) MySqlErrorCode.ConnectionCountError,
             (int) MySqlErrorCode.TableDefinitionChanged
         };
-        
+
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly ILogger<MySqlDatabaseConnection> logger;
         private readonly IBranchesService branchesService;
@@ -139,32 +139,30 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (MySqlException mySqlException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries)
+                // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
+                // so retrying a single query in a transaction is not very useful on most/all cases.
+                // Also, if we've reached the maximum number of retries, don't retry anymore.
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
-                switch (mySqlException.Number)
+                // If we're not in a transaction, retry the query if it's a deadlock.
+                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    case (int)MySqlErrorCode.LockDeadlock:
-                    case (int)MySqlErrorCode.LockWaitTimeout:
-                        Thread.Sleep(100);
-                        return await GetAsync(query, retryCount + 1);
-                    case (int)MySqlErrorCode.UnableToConnectToHost:
-                    case (int)MySqlErrorCode.TooManyUserConnections:
-                    case (int)MySqlErrorCode.ConnectionCountError:
-                        Thread.Sleep(1000);
-                        return await GetAsync(query, retryCount + 1);
-                    default:
-                        logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                        throw new GclQueryException("Error trying to run query", query, mySqlException);
+                    Thread.Sleep(100);
+                    return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
                 }
+
+                // For any other errors, just throw the exception.
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
             {
-                // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets committed or rollbacked.
-                if (transaction == null && cleanUp)
+                // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets committed or roll backed.
+                if (!HasActiveTransaction() && cleanUp)
                 {
                     await CleanUpAsync();
                 }
@@ -213,26 +211,25 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (MySqlException mySqlException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries)
+                // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
+                // so retrying a single query in a transaction is not very useful on most/all cases.
+                // Also, if we've reached the maximum number of retries, don't retry anymore.
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
-                switch (mySqlException.Number)
+                // If we're not in a transaction, retry the query if it's a deadlock.
+                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    case (int)MySqlErrorCode.LockDeadlock:
-                    case (int)MySqlErrorCode.LockWaitTimeout:
-                        return await ExecuteAsync(query, retryCount + 1);
-                    case (int)MySqlErrorCode.UnableToConnectToHost:
-                    case (int)MySqlErrorCode.TooManyUserConnections:
-                    case (int)MySqlErrorCode.ConnectionCountError:
-                        Thread.Sleep(1000);
-                        return await ExecuteAsync(query, retryCount + 1);
-                    default:
-                        logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                        throw new GclQueryException("Error trying to run query", query, mySqlException);
+                    Thread.Sleep(100);
+                    return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);
                 }
+
+                // For any other errors, just throw the exception.
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
             {
@@ -263,7 +260,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             {
                 query.Append($"UPDATE {(ignoreErrors ? "IGNORE" : "")} `{tableName}` SET ");
             }
-            
+
             if (idIsDefaultValue)
             {
                 query.Append($"({String.Join(",", parameters.Select(p => $"`{(p.Key == "InsertOrUpdateRecord_Id" ? idColumnName : p.Key)}`"))}) VALUES ({String.Join(",", parameters.Select(p => $"?{p.Key}"))})");
@@ -332,24 +329,25 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (MySqlException mySqlException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries)
+                // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
+                // so retrying a single query in a transaction is not very useful on most/all cases.
+                // Also, if we've reached the maximum number of retries, don't retry anymore.
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    throw;
+                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                    throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
-                switch (mySqlException.Number)
+                // If we're not in a transaction, retry the query if it's a deadlock.
+                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    case (int)MySqlErrorCode.LockDeadlock:
-                    case (int)MySqlErrorCode.LockWaitTimeout:
-                        return await InsertRecordAsync(query, retryCount + 1);
-                    case (int)MySqlErrorCode.UnableToConnectToHost:
-                    case (int)MySqlErrorCode.TooManyUserConnections:
-                    case (int)MySqlErrorCode.ConnectionCountError:
-                        Thread.Sleep(1000);
-                        return await InsertRecordAsync(query, retryCount + 1);
-                    default:
-                        throw;
+                    Thread.Sleep(100);
+                    return await InsertRecordAsync(query, retryCount + 1, useWritingConnectionIfAvailable);
                 }
+
+                // For any other errors, just throw the exception.
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
             {
@@ -506,7 +504,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 CommandForReading = ConnectionForReading.CreateCommand();
                 createdNewConnection = true;
             }
-            
+
             CommandForReading ??= ConnectionForReading.CreateCommand();
 
             // Remember the database name that was connected to.
@@ -527,7 +525,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             {
                 return;
             }
-            
+
             await ConnectionForReading.OpenAsync();
 
             await SetTimezone(CommandForReading);
@@ -596,7 +594,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         {
             connectionStringForReading ??= new MySqlConnectionStringBuilder();
             connectionStringForWriting ??= new MySqlConnectionStringBuilder();
-            
+
             connectionStringForReading.ConnectionString = newConnectionStringForReading;
             connectionStringForWriting.ConnectionString = String.IsNullOrWhiteSpace(newConnectionStringForWriting) ? newConnectionStringForReading : newConnectionStringForWriting;
             await CleanUpAsync();
@@ -611,7 +609,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 await AddConnectionCloseLogAsync(true);
                 await ConnectionForWriting.CloseAsync();
             }
-            
+
             ConnectionForReading = null;
             ConnectionForWriting = null;
         }
@@ -623,7 +621,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             {
                 CommandForReading.CommandTimeout = value;
             }
-            
+
             if (CommandForWriting != null)
             {
                 CommandForWriting.CommandTimeout = value;
@@ -653,7 +651,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Not setting timezones when they are not available should not be logged as en error.
                 if (mySqlException.Number == 1298)
                 {
-                    logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}'");
+                    logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}', because that timezone is not available in the database.");
                 }
                 else
                 {
@@ -678,7 +676,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 {
                     return;
                 }
-                
+
                 var commandToUse = isWriteConnection && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? CommandForWriting : CommandForReading;
 
                 if (!logTableExists.HasValue)
@@ -721,7 +719,7 @@ VALUES (?gclConnectionOpened, ?gclConnectionUrl, ?gclConnectionHttpMethod, ?gclC
 SELECT LAST_INSERT_ID();";
                 await using var reader = await commandToUse.ExecuteReaderAsync();
                 var id = !await reader.ReadAsync() ? 0 : (Int32.TryParse(Convert.ToString(reader.GetValue(0)), out var tempId) ? tempId : 0);
-                
+
                 if (isWriteConnection)
                 {
                     writeConnectionLogId = id;
@@ -745,7 +743,7 @@ SELECT LAST_INSERT_ID();";
         private async Task AddConnectionCloseLogAsync(bool isWriteConnection, bool disposeConnection = false)
         {
             var commandToUse = isWriteConnection && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? CommandForWriting : CommandForReading;
-            
+
             try
             {
                 if (!gclSettings.LogOpeningAndClosingOfConnections && ((isWriteConnection && writeConnectionLogId == 0) || (!isWriteConnection && readConnectionLogId == 0)))

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -143,7 +143,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -155,7 +155,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
@@ -215,7 +215,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -227,7 +227,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
@@ -333,7 +333,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -345,7 +345,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -151,7 +151,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // If we're not in a transaction, retry the query if it's a deadlock.
                 if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
                 {
-                    Thread.Sleep(100);
+                    Thread.Sleep(200);
                     return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
                 }
 

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -144,7 +144,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -156,7 +156,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
@@ -216,7 +216,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -228,7 +228,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally
@@ -334,7 +334,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
                 if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
                 {
-                    logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                    logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
@@ -346,7 +346,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 }
 
                 // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                logger.LogError(mySqlException, $"Error trying to run this query: {query}", query);
                 throw new GclQueryException("Error trying to run query", query, mySqlException);
             }
             finally


### PR DESCRIPTION
* Changed functionality to no longer automatically retry single queries if that query is part of a transaction.
* Added setting for the time to wait before retrying a query or transaction in which a deadlock or similar error occurred.
* Fixed problem that logs did not actually show the query.
* Added automatic retries for deadlocks to all transactions.

Asana ticket: https://app.asana.com/0/1200346761113317/1203974810597720