### PR TITLE
Return the created communication ID.

### DIFF
--- a/GeeksCoreLibrary/Modules/Communication/Interfaces/ICommunicationsService.cs
+++ b/GeeksCoreLibrary/Modules/Communication/Interfaces/ICommunicationsService.cs
@@ -63,7 +63,7 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this e-mail should get sent. Leave null to send it right away.</param>
         /// <param name="attachments">Optional: A list of attachments to add to the e-mail. This should be IDs from the table "wiser_itemfile". Default is <see langowrd="null" />.</param>
-        Task SendEmailAsync(string receiver, string subject, string body, string receiverName = null, string cc = null, string bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null);
+        Task<int> SendEmailAsync(string receiver, string subject, string body, string receiverName = null, string cc = null, string bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null);
 
         /// <summary>
         /// Send an e-mail to someone.
@@ -79,7 +79,7 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this e-mail should get sent. Leave null to send it right away.</param>
         /// <param name="attachments">Optional: A list of attachments to add to the e-mail. This should be IDs from the table "wiser_itemfile". Default is <see langowrd="null" />.</param>
-        Task SendEmailAsync(IEnumerable<CommunicationReceiverModel> receivers, string subject, string body, IEnumerable<string> cc, IEnumerable<string> bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null);
+        Task<int> SendEmailAsync(IEnumerable<CommunicationReceiverModel> receivers, string subject, string body, IEnumerable<string> cc, IEnumerable<string> bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null);
 
         /// <summary>
         /// Send an e-mail to someone.
@@ -119,7 +119,7 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="sender">Optional: The sender of the message. Leave empty or <see langword="null"/> to use the default sender. Default is <see langowrd="null" />.</param>
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this SMS should get sent. Leave null to send it right away.</param>
-        Task SendSmsAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null);
+        Task<int> SendSmsAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null);
         
         /// <summary>
         /// Send an SMS to someone.
@@ -129,13 +129,13 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="sender">Optional: The sender of the message. Leave empty or <see langword="null"/> to use the default sender. Default is <see langowrd="null" />.</param>
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this SMS should get sent. Leave null to send it right away.</param>
-        Task SendSmsAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null);
+        Task<int> SendSmsAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null);
         
         /// <summary>
         /// Send an SMS to someone.
         /// </summary>
         /// <param name="communication">The <see cref="SingleCommunicationModel"/> with information for sending the SMS.</param>
-        Task SendSmsAsync(SingleCommunicationModel communication);
+        Task<int> SendSmsAsync(SingleCommunicationModel communication);
         
         /// <summary>
         /// Uses an SMS provider to send an SMS directly.
@@ -153,7 +153,7 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="sender">Optional: The sender of the message. Leave empty or <see langword="null"/> to use the default sender. Default is <see langowrd="null" />.</param>
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this SMS should get sent. Leave null to send it right away.</param>
-        Task SendWhatsAppAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null);
+        Task<int> SendWhatsAppAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null);
 
         /// <summary>
         /// Send a message using WhatsApp to someone.
@@ -163,13 +163,13 @@ namespace GeeksCoreLibrary.Modules.Communication.Interfaces
         /// <param name="sender">Optional: The sender of the message. Leave empty or <see langword="null"/> to use the default sender. Default is <see langowrd="null" />.</param>
         /// <param name="senderName">Optional: The sender name of the message. Leave empty or <see langword="null"/> to use the default sender name. Default is <see langowrd="null" />.</param>
         /// <param name="sendDate">Optional: The date and time that this SMS should get sent. Leave null to send it right away.</param>
-        Task SendWhatsAppAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null);
+        Task<int> SendWhatsAppAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null);
 
         /// <summary>
         /// Send a message using WhatsApp to someone.
         /// </summary>
         /// <param name="communication">The <see cref="SingleCommunicationModel"/> with information for sending the SMS.</param>
-        Task SendWhatsAppAsync(SingleCommunicationModel communication);
+        Task<int> SendWhatsAppAsync(SingleCommunicationModel communication);
 
         /// <summary>
         /// Uses an WhatsApp provider to send message directly.

--- a/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
+++ b/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
@@ -271,7 +271,7 @@ WHERE id = ?id";
         }
 
         /// <inheritdoc />
-        public async Task SendEmailAsync(string receiver, string subject, string body, string receiverName = null, string cc = null, string bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null)
+        public async Task<int> SendEmailAsync(string receiver, string subject, string body, string receiverName = null, string cc = null, string bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
             var receiverAddresses = receiver.Split(';');
@@ -299,13 +299,13 @@ WHERE id = ?id";
                 ccAddresses.AddRange(cc.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries));
             }
 
-            await SendEmailAsync(receivers, subject, body, ccAddresses, bccAddresses, replyTo, replyToName, sender, senderName, sendDate, attachments);
+            return await SendEmailAsync(receivers, subject, body, ccAddresses, bccAddresses, replyTo, replyToName, sender, senderName, sendDate, attachments);
         }
 
         /// <inheritdoc />
-        public async Task SendEmailAsync(IEnumerable<CommunicationReceiverModel> receivers, string subject, string body, IEnumerable<string> cc = null, IEnumerable<string> bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null)
+        public async Task<int> SendEmailAsync(IEnumerable<CommunicationReceiverModel> receivers, string subject, string body, IEnumerable<string> cc = null, IEnumerable<string> bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null)
         {
-            await SendEmailAsync(new SingleCommunicationModel
+            return await SendEmailAsync(new SingleCommunicationModel
             {
                 Receivers = receivers,
                 Subject = subject,
@@ -598,7 +598,7 @@ WHERE id = ?id";
         }
 
         /// <inheritdoc />
-        public async Task SendSmsAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null)
+        public async Task<int> SendSmsAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
             var receiverAddresses = receiver.Split(';');
@@ -608,13 +608,13 @@ WHERE id = ?id";
                 receivers.Add(receiverModel);
             }
 
-            await SendSmsAsync(receivers, body, sender, senderName, sendDate);
+            return await SendSmsAsync(receivers, body, sender, senderName, sendDate);
         }
 
         /// <inheritdoc />
-        public async Task SendSmsAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null)
+        public async Task<int> SendSmsAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null)
         {
-            await SendSmsAsync(new SingleCommunicationModel()
+            return await SendSmsAsync(new SingleCommunicationModel()
             {
                 Receivers = receivers,
                 Content = body,
@@ -625,12 +625,12 @@ WHERE id = ?id";
         }
 
         /// <inheritdoc />
-        public async Task SendSmsAsync(SingleCommunicationModel communication)
+        public async Task<int> SendSmsAsync(SingleCommunicationModel communication)
         {
             communication.Id = 0;
             communication.Type = CommunicationTypes.Sms;
             communication.Subject ??= "";
-            await AddOrUpdateSingleCommunicationAsync(communication);
+            return await AddOrUpdateSingleCommunicationAsync(communication);
         }
 
         /// <inheritdoc />
@@ -741,7 +741,7 @@ WHERE id = ?id";
         }
 
         /// <inheritdoc />
-        public async Task SendWhatsAppAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null)
+        public async Task<int> SendWhatsAppAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
             var receiverAddresses = receiver.Split(';');
@@ -751,13 +751,13 @@ WHERE id = ?id";
                 receivers.Add(receiverModel);
             }
 
-            await SendWhatsAppAsync(receivers, body, sender, senderName, sendDate, attachments);
+            return await SendWhatsAppAsync(receivers, body, sender, senderName, sendDate, attachments);
         }
 
         /// <inheritdoc />
-        public async Task SendWhatsAppAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null)
+        public async Task<int> SendWhatsAppAsync(IEnumerable<CommunicationReceiverModel> receivers, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null)
         {
-            await SendWhatsAppAsync(new SingleCommunicationModel()
+            return await SendWhatsAppAsync(new SingleCommunicationModel()
             {
                 Receivers = receivers,
                 Content = body,
@@ -770,12 +770,12 @@ WHERE id = ?id";
         }
 
         /// <inheritdoc />
-        public async Task SendWhatsAppAsync(SingleCommunicationModel communication)
+        public async Task<int> SendWhatsAppAsync(SingleCommunicationModel communication)
         {
             communication.Id = 0;
             communication.Type = CommunicationTypes.WhatsApp;
             communication.Subject ??= "";
-            await AddOrUpdateSingleCommunicationAsync(communication);
+            return await AddOrUpdateSingleCommunicationAsync(communication);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When creating a communication in the queue the ID of that communication was only returned in some cases. This change makes sure this value is always returned.

https://app.asana.com/0/7257459017111/1204050481956757