### PR TITLE
Fixed missing methods in StringReplacementsService

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
+using GeeksCoreLibrary.Modules.GclReplacements.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Linq;
@@ -137,4 +139,21 @@ public interface IReplacementsMediator
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be removed. Default value is "}".</param>
     /// <returns>The original string without variables.</returns>
     string RemoveTemplateVariables(string input, string prefix = "{", string suffix = "}");
+
+    /// <summary>
+    /// Checks for any replacement variables in a string and returns an array of <see cref="StringReplacementVariable"/>.
+    /// </summary>
+    /// <param name="input">The input string to check.</param>
+    /// <param name="prefix">The prefix of replacement variables. The default is '{'.</param>
+    /// <param name="suffix">The suffix of replacement variables. The default is '}'.</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+    /// <returns>An array of <see cref="StringReplacementVariable"/>.</returns>
+    StringReplacementVariable[] GetReplacementVariables(string input, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
+
+    /// <summary>
+    /// Attempts to find a formatter method (a method in <see cref="StringReplacementsExtensions"/>) to be used in a string replacement snippet.
+    /// </summary>
+    /// <param name="formatterString">The name of the formatter.</param>
+    /// <returns>A <see cref="StringReplacementMethod"/> object containing information about the method and variables.</returns>
+    StringReplacementMethod GetFormatterMethod(string formatterString);
 }

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -27,7 +27,6 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     private readonly Regex formatterRegex;
     private readonly MethodInfo[] formatters;
 
-
     private const string RawFormatterName = "Raw";
 
     /// <summary>
@@ -435,15 +434,8 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         return regex.Replace(input, "");
     }
 
-    /// <summary>
-    /// Checks for any replacement variables in a string and returns an array of <see cref="StringReplacementVariable"/>.
-    /// </summary>
-    /// <param name="input">The input string to check.</param>
-    /// <param name="prefix">The prefix of replacement variables. The default is '{'.</param>
-    /// <param name="suffix">The suffix of replacement variables. The default is '}'.</param>
-    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <returns>An array of <see cref="StringReplacementVariable"/>.</returns>
-    private static StringReplacementVariable[] GetReplacementVariables(string input, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
+    /// <inheritdoc />
+    public StringReplacementVariable[] GetReplacementVariables(string input, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (String.IsNullOrWhiteSpace(input))
         {
@@ -460,7 +452,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         {
             var fieldName = match.Groups["field"].Value;
             var originalFieldName = fieldName;
-            var formatters = "";
+            var variableFormatters = "";
             var defaultValue = "";
 
             // Checks for default values.
@@ -484,7 +476,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             if (fieldName.Contains(':') && !fieldName.Trim().EndsWith(':'))
             {
                 var lastColonIndex = fieldName.LastIndexOf(":", StringComparison.Ordinal);
-                formatters = fieldName[lastColonIndex..].TrimStart(':');
+                variableFormatters = fieldName[lastColonIndex..].TrimStart(':');
                 fieldName = fieldName[..lastColonIndex];
             }
 
@@ -497,10 +489,10 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             };
 
             // Now replace "~~COLON~~" with an actual colon again.
-            formatters = formatters.Replace("~~COLON~~", ":");
+            variableFormatters = variableFormatters.Replace("~~COLON~~", ":");
 
             // Add the formatters to the list.
-            variable.Formatters.AddRange(formatters.Split('|', StringSplitOptions.RemoveEmptyEntries));
+            variable.Formatters.AddRange(variableFormatters.Split('|', StringSplitOptions.RemoveEmptyEntries));
 
             // Add the default formatter, unless the raw formatter has been used.
             if (!String.IsNullOrWhiteSpace(defaultFormatter)
@@ -517,12 +509,8 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         return result.ToArray();
     }
 
-    /// <summary>
-    /// Attempts to find a formatter method (a method in <see cref="StringReplacementsExtensions"/>) to be used in a string replacement snippet.
-    /// </summary>
-    /// <param name="formatterString"></param>
-    /// <returns></returns>
-    private StringReplacementMethod GetFormatterMethod(string formatterString)
+    /// <inheritdoc />
+    public StringReplacementMethod GetFormatterMethod(string formatterString)
     {
         var match = formatterRegex.Match(formatterString);
 

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -138,10 +138,10 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                         }
 
                         // Check if there are any valid formatter functions used in the variable and if so, use the variable name without the formatter as translation.
-                        var replacementVariables = GetReplacementVariables($"{{{value}}}");
+                        var replacementVariables = replacementsMediator.GetReplacementVariables($"{{{value}}}");
                         foreach (var variable in replacementVariables)
                         {
-                            if (variable.Formatters.All(f => GetFormatterMethod(f) != null))
+                            if (variable.Formatters.All(f => replacementsMediator.GetFormatterMethod(f) != null))
                             {
                                 value = variable.VariableName;
                             }
@@ -175,10 +175,10 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
                         }
 
                         // Check if there are any valid formatter functions used in the variable and if so, use the variable name without the formatter as object name.
-                        var replacementVariables = GetReplacementVariables($"{{{value}}}");
+                        var replacementVariables = replacementsMediator.GetReplacementVariables($"{{{value}}}");
                         foreach (var variable in replacementVariables)
                         {
-                            if (variable.Formatters.All(f => GetFormatterMethod(f) != null))
+                            if (variable.Formatters.All(f => replacementsMediator.GetFormatterMethod(f) != null))
                             {
                                 value = variable.VariableName;
                             }


### PR DESCRIPTION
Some methods that were moved to the `ReplacementsMediator` were still being called in the `StringReplacementsService`. The methods are now public methods that are defined in the `IReplacementsMediator` interface.

Asana: https://app.asana.com/0/1200346761113317/1204125836006082