### PR TITLE
Configurator Vue mode update

### DIFF
--- a/GeeksCoreLibrary/Components/Configurator/Configurator.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Configurator.cs
@@ -1683,7 +1683,7 @@ namespace GeeksCoreLibrary.Components.Configurator
                 }
 
                 // Retrieve extra data from the step's item details.
-                var extraData = stepData.ExtraData ?? new Dictionary<string, JToken>();
+                stepData.ExtraData ??= new Dictionary<string, JToken>();
 
                 // Run extra data query if one is available.
                 var extraDataQuery = stepData.ExtraDataQuery;
@@ -1713,11 +1713,11 @@ namespace GeeksCoreLibrary.Components.Configurator
                                 value = new JValue(extraDataDataTable.Rows[0].Field<object>(column));
                             }
 
-                            extraData.Add(column.ColumnName, value);
+                            stepData.ExtraData[column.ColumnName] = value;
                         }
 
                         // Check if a property named "available" exists and if so, parse it to a boolean.
-                        if (extraData.TryGetValue("available", out var availableValue))
+                        if (stepData.ExtraData.TryGetValue("available", out var availableValue))
                         {
                             bool stepAvailable;
                             var stringValue = availableValue.Value<string>();
@@ -1727,6 +1727,7 @@ namespace GeeksCoreLibrary.Components.Configurator
                             }
                             else if (stringValue == "1" || !Boolean.TryParse(stringValue, out stepAvailable))
                             {
+                                // If the value cannot be parsed to a boolean, the value is also considered true (this is to prevent bad data from making the step unavailable).
                                 stepAvailable = true;
                             }
 
@@ -1734,8 +1735,6 @@ namespace GeeksCoreLibrary.Components.Configurator
                         }
                     }
                 }
-
-                stepData.ExtraData = extraData;
 
                 // Dependencies are valid, load options.
                 var stepOptionsQuery = stepData.StepOptionsQuery;

--- a/GeeksCoreLibrary/Components/Configurator/Models/VueStepDataModel.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Models/VueStepDataModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -123,6 +122,24 @@ public class VueStepDataModel
     /// </summary>
     [JsonProperty("valueDisplayName")]
     public string CurrentValueDisplayName { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the step's options should open a modal when selected.
+    /// </summary>
+    [JsonProperty("optionsOpenModal")]
+    public bool OptionsOpenModal { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content (HTML) of the modal.
+    /// </summary>
+    [JsonProperty("modalContent")]
+    public string ModalContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the query selector for the modal container.
+    /// </summary>
+    [JsonProperty("modalContainerSelector")]
+    public string ModalContainerSelector { get; set; }
 
     /// <summary>
     /// Gets or sets extra data which are retrieved from the database.

--- a/GeeksCoreLibrary/Components/Configurator/Models/VueStepDataModel.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Models/VueStepDataModel.cs
@@ -41,7 +41,7 @@ public class VueStepDataModel
     /// Gets or sets the step's options. While it can contain any number of properties, the following are required: "id", "value", "name".
     /// </summary>
     [JsonProperty("options")]
-    public IEnumerable<Dictionary<string, object>> Options { get; set; }
+    public IEnumerable<VueStepOptionDataModel> Options { get; set; }
 
     /// <summary>
     /// Gets or sets the step's dependencies. The dependencies determine the step's visibility.

--- a/GeeksCoreLibrary/Components/Configurator/Models/VueStepOptionDataModel.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Models/VueStepOptionDataModel.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GeeksCoreLibrary.Components.Configurator.Models;
+
+public class VueStepOptionDataModel
+{
+    /// <summary>
+    /// Gets or sets the option's unique ID.
+    /// </summary>
+    [JsonProperty("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the option's value.
+    /// </summary>
+    [JsonProperty("value")]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the option's display name.
+    /// </summary>
+    [JsonProperty("name")]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the option is the default option.
+    /// </summary>
+    [JsonProperty("isDefaultOption")]
+    public bool IsDefaultOption { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object> AdditionalData { get; set; }
+}

--- a/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
@@ -459,18 +459,18 @@ WHERE configurator.entity_type = '{Constants.ConfiguratorEntityType}' AND config
         validationRegexErrorMessage.`value` AS validationRegexErrorMessage,
         IF(
             templatesFromStepId.id IS NOT NULL AND templatesFromStepId.`value` NOT IN ('', '0'),
-            (SELECT CONCAT_WS('', `value`, long_value) FROM wiser_itemdetail WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'step_template'),
+            (SELECT CONCAT_WS('', `value`, long_value) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'step_template'),
             CONCAT_WS('', stepTemplate.`value`, stepTemplate.long_value)
         ) AS stepTemplate,
         IF(
             templatesFromStepId.id IS NOT NULL AND templatesFromStepId.`value` NOT IN ('', '0'),
-            (SELECT CONCAT_WS('', `value`, long_value) FROM wiser_itemdetail WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'values_template'),
+            (SELECT CONCAT_WS('', `value`, long_value) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'values_template'),
             CONCAT_WS('', stepOptionTemplate.`value`, stepOptionTemplate.long_value)
         ) AS stepOptionTemplate,
         CONCAT_WS('', stepOptionsQuery.`value`, stepOptionsQuery.long_value) AS stepOptionsQuery,
         CONCAT_WS('', extraDataQuery.`value`, extraDataQuery.long_value) AS extraDataQuery,
         urlRegex.`value` AS urlRegex,
-        (SELECT JSON_OBJECTAGG(`key`, CONCAT_WS('', `value`, long_value)) FROM wiser_itemdetail WHERE item_id = step.id AND groupname = 'extra_data') AS extraData,
+        (SELECT JSON_OBJECTAGG(`key`, CONCAT_WS('', `value`, long_value)) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = step.id AND groupname = 'extra_data') AS extraData,
 
         IFNULL(optionsOpenModal.`value`, '0') = '1' AS optionsOpenModal,
         CONCAT_WS('', modalTemplate.`value`, stepOptionsQuery.long_value) AS modalTemplate,
@@ -533,18 +533,18 @@ WHERE configurator.entity_type = '{Constants.ConfiguratorEntityType}' AND config
         # Layout properties.
         IF(
             templatesFromStepId.id IS NOT NULL AND templatesFromStepId.`value` NOT IN ('', '0'),
-            (SELECT CONCAT_WS('', `value`, long_value) FROM wiser_itemdetail WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'step_template'),
+            (SELECT CONCAT_WS('', `value`, long_value) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'step_template'),
             CONCAT_WS('', stepTemplate.`value`, stepTemplate.long_value)
         ) AS stepTemplate,
         IF(
             templatesFromStepId.id IS NOT NULL AND templatesFromStepId.`value` NOT IN ('', '0'),
-            (SELECT CONCAT_WS('', `value`, long_value) FROM wiser_itemdetail WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'values_template'),
+            (SELECT CONCAT_WS('', `value`, long_value) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = CONVERT(templatesFromStepId.`value`, UNSIGNED) AND `key` = 'values_template'),
             CONCAT_WS('', stepOptionTemplate.`value`, stepOptionTemplate.long_value)
         ) AS stepOptionTemplate,
         CONCAT_WS('', stepOptionsQuery.`value`, stepOptionsQuery.long_value) AS stepOptionsQuery,
         CONCAT_WS('', extraDataQuery.`value`, extraDataQuery.long_value) AS extraDataQuery,
         urlRegex.`value` AS urlRegex,
-        (SELECT JSON_OBJECTAGG(`key`, CONCAT_WS('', `value`, long_value)) FROM wiser_itemdetail WHERE item_id = step.id AND groupname = 'extra_data') AS extraData,
+        (SELECT JSON_OBJECTAGG(`key`, CONCAT_WS('', `value`, long_value)) FROM {WiserTableNames.WiserItemDetail} WHERE item_id = step.id AND groupname = 'extra_data') AS extraData,
 
         IFNULL(optionsOpenModal.`value`, '0') = '1' AS optionsOpenModal,
         CONCAT_WS('', modalTemplate.`value`, stepOptionsQuery.long_value) AS modalTemplate,

--- a/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Services/ConfiguratorsService.cs
@@ -687,6 +687,19 @@ ORDER BY parentStepId, ordering";
                 var extraDataJson = dataRow.Field<string>("extraData");
                 var extraData = !String.IsNullOrWhiteSpace(extraDataJson) ? Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, JToken>>(extraDataJson) : null;
 
+                // Perform string replacements on the values of the extra data.
+                if (extraData is { Count: > 0 })
+                {
+                    foreach (var key in extraData.Keys)
+                    {
+                        // Make sure the value is a string.
+                        if (extraData[key] is JValue { Type: JTokenType.String } jValue)
+                        {
+                            jValue.Value = await stringReplacementsService.DoAllReplacementsAsync(jValue.Value<string>());
+                        }
+                    }
+                }
+
                 var step = new VueStepDataModel
                 {
                     StepId = Convert.ToUInt64(dataRow["stepId"]),

--- a/GeeksCoreLibrary/GeeksCoreLibrary.csproj
+++ b/GeeksCoreLibrary/GeeksCoreLibrary.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="Mollie.Api" Version="2.2.0.4" />
     <PackageReference Include="MultiSafepay" Version="0.8.7" />
     <PackageReference Include="MySql.Data" Version="8.0.32.1" />
+    <PackageReference Include="ObjectCloner" Version="2.2.2" />
     <PackageReference Include="OmniKassa_Rabobank" Version="1.4.0" />
     <PackageReference Include="RestSharp" Version="109.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
- Fixed caching issue;
- Static extra data is loaded through initial query instead of one query per step (this improves performance);
- Extra data from the extra data query can now overwrite static extra data values;
- Support for steps that open modal when clicking on option instead of making a selection.

Asana ticket for the caching issue fix: https://app.asana.com/0/1200923549887805/1204833966511650