### PR TITLE
Added save call for order in order process service

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -1195,6 +1195,9 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                 }
 
                 main.SetDetail(Constants.PaymentHistoryProperty, $"{DateTime.Now:yyyyMMddHHmmss} - {newStatus}", true);
+                main.SetDetail("user_mail_body", emailContent);
+                main.SetDetail("user_mail_subject", emailSubject);
+                await shoppingBasketsService.SaveAsync(main, lines, basketSettings);
 
                 // If order is not finished yet and the payment was successful.
                 if (!hasAlreadyBeenConvertedToOrderBefore && isSuccessfulStatus && convertConceptOrderToOrder)
@@ -1211,8 +1214,6 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
 
                 if (!String.IsNullOrWhiteSpace(userEmailAddress) && !String.IsNullOrWhiteSpace(emailContent))
                 {
-                    main.SetDetail("user_mail_body", emailContent);
-                    main.SetDetail("user_mail_subject", emailSubject);
                     mailsToSendToUser.Add(new SingleCommunicationModel
                     {
                         Content = emailContent,


### PR DESCRIPTION
Some properties would never get saved if an order used "NOPSP" payment method. This fixes that by adding an additional save call. Also moved setting the email body and subject details on the order to a different place.

https://app.asana.com/0/1201394730777422/1204619084110932