### PR TITLE
Check changes to wiser_entity table on launch of the GCL project.

### DIFF
--- a/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
@@ -137,14 +137,15 @@ namespace GeeksCoreLibrary.Core.Extensions
             {
                 // During startup, make sure that the log table exists, but only if the logging is enabled.
                 using var scope = builder.ApplicationServices.CreateScope();
+                var databaseHelpersService = scope.ServiceProvider.GetRequiredService<IDatabaseHelpersService>();
+                
                 var gclSettings = scope.ServiceProvider.GetRequiredService<IOptions<GclSettings>>();
                 if (!gclSettings.Value.LogOpeningAndClosingOfConnections)
                 {
+                    await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserEntity});
                     return;
                 }
-
-                var databaseHelpersService = scope.ServiceProvider.GetRequiredService<IDatabaseHelpersService>();
-                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {Modules.Databases.Models.Constants.DatabaseConnectionLogTableName});
+                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {Modules.Databases.Models.Constants.DatabaseConnectionLogTableName, WiserTableNames.WiserEntity});
             });
 
             return builder;


### PR DESCRIPTION
The table was never checked for changes. Since the table always need to e updated the check is done on launch of a project using the GCL.

https://app.asana.com/0/1200346761113317/1204986264877999