### PR TITLE
Reuse responses if the expected result is the same.

### DIFF
--- a/GeeksCoreLibrary/Components/Configurator/Configurator.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Configurator.cs
@@ -10,7 +10,6 @@ using GeeksCoreLibrary.Components.Configurator.Interfaces;
 using GeeksCoreLibrary.Components.Configurator.Models;
 using GeeksCoreLibrary.Core.Cms;
 using GeeksCoreLibrary.Core.Cms.Attributes;
-using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
@@ -1633,6 +1632,9 @@ namespace GeeksCoreLibrary.Components.Configurator
                 stepsToRemove.AddRange(result.StepsData.Select(stepData => stepData.StepName).Except(stepsToProcess));
             }
 
+            // Data retrieved from APIs is cached in this dictionary to reuse the response for multiple steps.
+            var apiData = new Dictionary<string, JToken>();
+
             // Update options.
             foreach (var step in stepsToProcess)
             {
@@ -1742,7 +1744,7 @@ namespace GeeksCoreLibrary.Components.Configurator
                         await configuratorsService.SetVueStepOptionsWithQueryAsync(stepData, options, configuration);
                         break;
                     case "api":
-                        await configuratorsService.SetVueStepOptionsWithApiAsync(stepData, options, configuration);
+                        await configuratorsService.SetVueStepOptionsWithApiAsync(stepData, options, configuration, apiData);
                         break;
                 }
             }

--- a/GeeksCoreLibrary/Components/Configurator/Interfaces/IConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Interfaces/IConfiguratorsService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Components.Configurator.Models;
+using Newtonsoft.Json.Linq;
 
 namespace GeeksCoreLibrary.Components.Configurator.Interfaces;
 
@@ -38,8 +39,9 @@ public interface IConfiguratorsService
     /// <param name="stepData">The <see cref="VueStepDataModel"/> containing the information of the step to set the values for.</param>
     /// <param name="options">The options to use when no results are provided.</param>
     /// <param name="configuration">The <see cref="VueConfigurationsModel"/> to use for replacements.</param>
+    /// <param name="apiData">Previous responses from an API during the current loading of steps. The key is a hash from the URL and body.</param>
     /// <returns></returns>
-    Task SetVueStepOptionsWithApiAsync(VueStepDataModel stepData, List<VueStepOptionDataModel> options, VueConfigurationsModel configuration);
+    Task SetVueStepOptionsWithApiAsync(VueStepDataModel stepData, List<VueStepOptionDataModel> options, VueConfigurationsModel configuration, Dictionary<string, JToken> apiData);
 
     /// <summary>
     /// save configuration to database

--- a/GeeksCoreLibrary/Components/Configurator/Services/CachedConfiguratorsService.cs
+++ b/GeeksCoreLibrary/Components/Configurator/Services/CachedConfiguratorsService.cs
@@ -14,6 +14,7 @@ using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using LazyCache;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 
 namespace GeeksCoreLibrary.Components.Configurator.Services
 {
@@ -102,9 +103,9 @@ namespace GeeksCoreLibrary.Components.Configurator.Services
         }
 
         /// <inheritdoc />
-        public async Task SetVueStepOptionsWithApiAsync(VueStepDataModel stepData, List<VueStepOptionDataModel> options, VueConfigurationsModel configuration)
+        public async Task SetVueStepOptionsWithApiAsync(VueStepDataModel stepData, List<VueStepOptionDataModel> options, VueConfigurationsModel configuration, Dictionary<string, JToken> apiData)
         {
-            await configuratorsService.SetVueStepOptionsWithApiAsync(stepData, options, configuration);
+            await configuratorsService.SetVueStepOptionsWithApiAsync(stepData, options, configuration, apiData);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
When the endpoint and body are the same during the loading of multiple steps the responses will be reused. This way less calls need to be made to an external API. Since the data hasn't changed during loading the response should be the same if the endpoint and body are the same.

https://app.asana.com/0/1200923549887805/1205082123491891