### PR TITLE
Fixed a potential String.Replace error

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -200,7 +200,10 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                     var regex = new Regex(@"<svg(?:[^>]*)>(?:\s*)<use(?:[^>]*)xlink:href=""([^>""]*)#(?:[^>""]*)""(?:[^>]*)>", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
                     foreach (Match match in regex.Matches(newBodyHtml))
                     {
-                        newBodyHtml = newBodyHtml.Replace(match.Groups[1].Value, "");
+                        if (!String.IsNullOrEmpty(match.Groups[1].Value))
+                        {
+                            newBodyHtml = newBodyHtml.Replace(match.Groups[1].Value, "");
+                        }
                     }
                 }
 


### PR DESCRIPTION
The `removeSvgUrlsFromIcons` option that would remove part of the href in SVG icons would return an error if the regex match would return an empty string. This change fixes that.