### PR TITLE
Return NoPsp provider settings in NoPspService settings getter function

### DIFF
--- a/GeeksCoreLibrary/Modules/Payments/Services/NoPspService.cs
+++ b/GeeksCoreLibrary/Modules/Payments/Services/NoPspService.cs
@@ -50,7 +50,11 @@ namespace GeeksCoreLibrary.Modules.Payments.Services
         /// <inheritdoc />
         public Task<PaymentServiceProviderSettingsModel> GetProviderSettingsAsync(PaymentServiceProviderSettingsModel paymentServiceProviderSettings)
         {
-            return Task.FromResult(new PaymentServiceProviderSettingsModel());
+            return Task.FromResult(new PaymentServiceProviderSettingsModel()
+            {
+                Type = PaymentServiceProviders.NoPsp,
+                Title = "NoPsp",
+            });
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
https://app.asana.com/0/1201394730777422/1205142033930599/f

Return NoPsp provider settings in NoPspService settings getter function to fix the following problem: 

When calling the GetProviderSettingsAsync in the NoPspService returned an empty PaymentServiceProviderSettingsModel. This caused the type to be Unknown and Title to be null.
This then goes wrong in de OrderProcessesService where the result is used to get the right PaymentServiceProviderService.
