### PR TITLE
Added "defaultFormatter" to replacement functions

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
@@ -24,8 +24,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>An IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been performed.</returns>
-    IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs all replacements on a string using all data from a <see cref="DataTable"/>.
@@ -37,8 +38,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>An IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.</returns>
-    IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs all replacements on a string using the data from a DataRow.
@@ -49,8 +51,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.
@@ -62,8 +65,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, StringValues&gt;&gt; interface.
@@ -75,8 +79,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the ISession interface.
@@ -88,8 +93,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs replacements on a string using a JToken. This function is the most generic function, and all other replacement functions also use this function.
@@ -100,8 +106,9 @@ public interface IReplacementsMediator
     /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+    string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Performs replacements on a string using a dictionary of some type. This function is the most generic function, and all other replacement functions also use this function.
@@ -111,8 +118,9 @@ public interface IReplacementsMediator
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false);
+    string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode");
 
     /// <summary>
     /// Evaluates logic snippets in a string. These are simple if/else statements that can be used to conditionally include or exclude parts of a template.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
@@ -18,149 +18,161 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Interfaces
         /// <param name="evaluateLogicSnippets"></param>
         /// <param name="removeUnknownVariables"></param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
         /// <returns></returns>
-        Task<string> DoAllReplacementsAsync(string input, DataRow dataRow = null, bool handleRequest = true, bool evaluateLogicSnippets = true, bool removeUnknownVariables = true, bool forQuery = false);
+        Task<string> DoAllReplacementsAsync(string input, DataRow dataRow = null, bool handleRequest = true, bool evaluateLogicSnippets = true, bool removeUnknownVariables = true, bool forQuery = false, string defaultFormatter = "HtmlEncode");
 
         /// <summary>
         /// Performs replacements based on data available in the HTTP request, such as query and form values.
         /// </summary>
         /// <param name="input"></param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
         /// <returns></returns>
-        string DoHttpRequestReplacements(string input, bool forQuery = false);
+        string DoHttpRequestReplacements(string input, bool forQuery = false, string defaultFormatter = "HtmlEncode");
 
         /// <summary>
         /// Performs replacements based on data available in the session.
         /// </summary>
         /// <param name="input"></param>
         /// <param name="forQuery">Optional: Set to <see langword="true"/> to make all replaced values safe against SQL injection.</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
         /// <returns></returns>
-        string DoSessionReplacements(string input, bool forQuery = false);
-    /// <summary>
-    /// Performs all replacements on a string using all data from a <see cref="DataSet"/>.
-    /// This will return an IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been done.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>An IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been performed.</returns>
-    IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        string DoSessionReplacements(string input, bool forQuery = false, string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs all replacements on a string using all data from a <see cref="DataTable"/>.
-    /// This will return an IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>An IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.</returns>
-    IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using all data from a <see cref="DataSet"/>.
+        /// This will return an IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been done.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>An IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been performed.</returns>
+        IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs all replacements on a string using the data from a DataRow.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using all data from a <see cref="DataTable"/>.
+        /// This will return an IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>An IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.</returns>
+        IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.
-    /// This function will typically be used to replace Query and Form replacements from the http context.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using the data from a DataRow.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, StringValues&gt;&gt; interface.
-    /// This function will typically be used to replace Query and Form replacements from the http context.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.
+        /// This function will typically be used to replace Query and Form replacements from the http context.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs all replacements on a string using data that implements the ISession interface.
-    /// This function will typically be used to replace Session replacements from the http context.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, StringValues&gt;&gt; interface.
+        /// This function will typically be used to replace Query and Form replacements from the http context.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs replacements on a string using a JToken. This function is the most generic function, and all other replacement functions also use this function.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Performs all replacements on a string using data that implements the ISession interface.
+        /// This function will typically be used to replace Session replacements from the http context.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Performs replacements on a string using a dictionary of some type. This function is the most generic function, and all other replacement functions also use this function.
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false);
+        /// <summary>
+        /// Performs replacements on a string using a JToken. This function is the most generic function, and all other replacement functions also use this function.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Evaluates logic snippets in a string. These are simple if/else statements that can be used to conditionally include or exclude parts of a template.
-    /// The syntax looks like this: [if({variable}=x)]...[else]...[endif].
-    /// </summary>
-    /// <param name="input">The string to do replacements on.</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string EvaluateTemplate(string input);
+        /// <summary>
+        /// Performs replacements on a string using a dictionary of some type. This function is the most generic function, and all other replacement functions also use this function.
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+        /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode");
 
-    /// <summary>
-    /// Searches input string for variables with default values and replaces them with those default values.
-    /// </summary>
-    /// <param name="input">The input string.</param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
-    /// <returns>The original string with all replacements done.</returns>
-    string HandleVariablesDefaultValues(string input, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Evaluates logic snippets in a string. These are simple if/else statements that can be used to conditionally include or exclude parts of a template.
+        /// The syntax looks like this: [if({variable}=x)]...[else]...[endif].
+        /// </summary>
+        /// <param name="input">The string to do replacements on.</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string EvaluateTemplate(string input);
 
-    /// <summary>
-    /// Removes any template variables that are present in the input string.
-    /// </summary>
-    /// <param name="input"></param>
-    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be removed. Default value is "{".</param>
-    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be removed. Default value is "}".</param>
-    /// <returns>The original string without variables.</returns>
-    string RemoveTemplateVariables(string input, string prefix = "{", string suffix = "}");
+        /// <summary>
+        /// Searches input string for variables with default values and replaces them with those default values.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+        /// <returns>The original string with all replacements done.</returns>
+        string HandleVariablesDefaultValues(string input, string prefix = "{", string suffix = "}");
+
+        /// <summary>
+        /// Removes any template variables that are present in the input string.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be removed. Default value is "{".</param>
+        /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be removed. Default value is "}".</param>
+        /// <returns>The original string without variables.</returns>
+        string RemoveTemplateVariables(string input, string prefix = "{", string suffix = "}");
 
         /// <summary>
         /// Replace variables in a string based on JSON data.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -44,7 +44,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     }
 
     /// <inheritdoc />
-    public IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null || replaceData.Tables.Count == 0)
         {
@@ -53,12 +53,12 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
         foreach (DataTable dataTable in replaceData.Tables)
         {
-            yield return DoReplacements(input, dataTable, forQuery, caseSensitive, prefix, suffix);
+            yield return DoReplacements(input, dataTable, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
         }
     }
 
     /// <inheritdoc />
-    public IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null || replaceData.Rows.Count == 0)
         {
@@ -67,12 +67,12 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
         foreach (DataRow dataRow in replaceData.Rows)
         {
-            yield return DoReplacements(input, dataRow, forQuery, caseSensitive, prefix, suffix);
+            yield return DoReplacements(input, dataRow, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
         }
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null)
         {
@@ -85,11 +85,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(column.ColumnName, replaceData[column]);
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null)
         {
@@ -102,11 +102,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(key, value);
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null)
         {
@@ -119,11 +119,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(key, value.ToString());
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}")
+    public string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         var dataDictionary = new Dictionary<string, object>(caseSensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         foreach (var item in replaceData.Keys)
@@ -136,11 +136,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(item, Encoding.UTF8.GetString(rawValue));
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}")
+    public string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null)
         {
@@ -162,7 +162,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         }
 
         // Do the replacements for the current level.
-        output = DoReplacements(output, dataDictionary, prefix, suffix, forQuery);
+        output = DoReplacements(output, dataDictionary, prefix, suffix, forQuery, defaultFormatter);
 
         // Repeat the process for each object in the current level until the bottom is reached.
         foreach (var jToken in replaceData)
@@ -175,7 +175,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             switch (item.Value.Type)
             {
                 case JTokenType.Object:
-                    output = DoReplacements(output, item.Value, forQuery, caseSensitive, prefix, suffix);
+                    output = DoReplacements(output, item.Value, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
                     break;
                 case JTokenType.Array:
                 {
@@ -186,7 +186,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                             continue;
                         }
 
-                        output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix);
+                        output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
                     }
 
                     break;
@@ -198,7 +198,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false)
+    public string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode")
     {
         if (replaceData == null || replaceData.Count == 0)
         {
@@ -206,7 +206,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         }
 
         // Find all replacement variables in the input string. Every replacement variable can also have multiple formatters.
-        var variables = forQuery ? GetReplacementVariables(input, prefix, suffix, null) : GetReplacementVariables(input, prefix, suffix);
+        var variables = forQuery ? GetReplacementVariables(input, prefix, suffix, null) : GetReplacementVariables(input, prefix, suffix, defaultFormatter);
         if (variables.Length == 0)
         {
             return input;


### PR DESCRIPTION
All variants of the `DoReplacements` function can now override the default formatter.