### PR TITLE
Fixed inconsistency in "Handle request" content option

### DIFF
--- a/GeeksCoreLibrary/Components/Pagination/Pagination.cs
+++ b/GeeksCoreLibrary/Components/Pagination/Pagination.cs
@@ -159,7 +159,7 @@ namespace GeeksCoreLibrary.Components.Pagination
                 }
 
                 // Perform replacements on the query.
-                parsedQuery = await TemplatesService.DoReplacesAsync(parsedQuery, handleRequest: Settings.HandleRequest, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables, forQuery: true);
+                parsedQuery = await TemplatesService.DoReplacesAsync(parsedQuery, evaluateLogicSnippets: Settings.EvaluateIfElseInTemplates, removeUnknownVariables: Settings.RemoveUnknownVariables, forQuery: true);
 
                 var getCountResult = await DatabaseConnection.GetAsync(parsedQuery);
                 if (getCountResult.Rows.Count > 0)


### PR DESCRIPTION
The "HandleRequest" setting for the repeater and pagination dynamic component mentions that it impacts the TEMPLATES of that component, however the pagination code also uses it for the QUERY of the component. The repeater query code does not. This change should fix that and make the setting consistent and comply with the actual description.