### PR TITLE
Remove caching of payment methods of order process

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/CachedOrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/CachedOrderProcessesService.cs
@@ -66,13 +66,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
         /// <inheritdoc />
         public override async Task<List<PaymentMethodSettingsModel>> GetPaymentMethodsAsync(ulong orderProcessId, UserCookieDataModel loggedInUser = null)
         {
-            var cacheName = $"OrderProcessGetPaymentMethods_{orderProcessId}_{(loggedInUser == null ? "all" : loggedInUser.UserId.ToString())}_{branchesService.GetDatabaseNameFromCookie()}";
-            return await cache.GetOrAddAsync(cacheName,
-                delegate(ICacheEntry cacheEntry)
-                {                    
-                    cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultOrderProcessCacheDuration;
-                    return orderProcessesService.GetPaymentMethodsAsync(orderProcessId, loggedInUser);
-                });
+            return await orderProcessesService.GetPaymentMethodsAsync(orderProcessId, loggedInUser);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
https://app.asana.com/0/1201394730777422/1204562312086552/f

Which payment methods get shown can be dependent on a multitude of different aspects like price, country, etc.
This means it shouldn't be cached.