### PR TITLE
Use MySqlConnector package instead of MySql.Data

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Account.cs
+++ b/GeeksCoreLibrary/Components/Account/Account.cs
@@ -25,7 +25,6 @@ using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Models;
 using Google.Authenticator;
-using Google.Protobuf;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
@@ -34,7 +33,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Newtonsoft.Json;
 using Constants = GeeksCoreLibrary.Components.Account.Models.Constants;
 

--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -31,7 +31,7 @@ using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Constants = GeeksCoreLibrary.Components.OrderProcess.Models.Constants;
 
 namespace GeeksCoreLibrary.Components.OrderProcess

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -27,7 +27,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
 {

--- a/GeeksCoreLibrary/Core/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/DbDataReaderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Core.Extensions
 {
@@ -16,7 +17,7 @@ namespace GeeksCoreLibrary.Core.Extensions
         {
             return reader.IsDBNull(columnIndex) ? String.Empty : reader.GetString(columnIndex);
         }
-        
+
         /// <summary>
         /// Gets a string value from a <see cref="DbDataReader"/> and returns an empty string if the value is <see langword="null"/>.
         /// </summary>
@@ -25,9 +26,14 @@ namespace GeeksCoreLibrary.Core.Extensions
         /// <returns>A <see langword="string"/> with the value.</returns>
         public static string GetStringHandleNull(this DbDataReader reader, string columnName)
         {
+            if (!reader.HasColumn(columnName))
+            {
+                return String.Empty;
+            }
+
             return reader.IsDBNull(reader.GetOrdinal(columnName)) ? String.Empty : reader.GetString(columnName);
         }
-        
+
         /// <summary>
         /// Checks if a columns exists in a data reader.
         /// </summary>

--- a/GeeksCoreLibrary/Core/Extensions/StringExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/StringExtensions.cs
@@ -188,7 +188,7 @@ namespace GeeksCoreLibrary.Core.Extensions
                 return null;
             }
 
-            var result = MySql.Data.MySqlClient.MySqlHelper.EscapeString(input);
+            var result = MySqlConnector.MySqlHelper.EscapeString(input);
             return encloseInQuotes ? $"'{result}'" : result;
         }
 

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -35,6 +35,20 @@ namespace GeeksCoreLibrary.Core.Models
         public string DatabaseTimeZone { get; set; } = "Europe/Amsterdam";
 
         /// <summary>
+        /// This will be used to set the correct character set for the database before executing any query. The MySqlConnector package normally
+        /// forces the character set to utf8mb4, but that might not be the correct character set for your database. This setting allows you to
+        /// set the character set to the correct value.
+        /// </summary>
+        public string DatabaseCharacterSet { get; set; } = "utf8mb4";
+
+        /// <summary>
+        /// This will be used to set the correct collation for the database before executing any query. The MySqlConnector package normally
+        /// forces the collation to the database standard, which is usually utf8mb4_0900_ai_ci for MySQL 8.x installations, but that might not be the
+        /// correct collation for your database. This setting allows you to set the collation to the correct value.
+        /// </summary>
+        public string DatabaseCollation { get; set; } = "utf8mb4_general_ci";
+
+        /// <summary>
         /// The maximum amount of times the GCL should retry executing a query.
         /// The GCL only does this for the following MySQL error codes, any other error will not cause another attempt:
         /// <list type="ErrorCodes">

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -24,7 +24,7 @@ using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Core.Services
 {

--- a/GeeksCoreLibrary/GeeksCoreLibrary.csproj
+++ b/GeeksCoreLibrary/GeeksCoreLibrary.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="MySql.Data" Version="8.2.0" />
+    <PackageReference Include="MySqlConnector" Version="2.3.1" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Enums;
 using GeeksCoreLibrary.Modules.Databases.Models;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Modules.Databases.Helpers
 {

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
@@ -2,7 +2,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Modules.Databases.Interfaces
 {

--- a/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using GeeksCoreLibrary.Modules.Databases.Enums;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Modules.Databases.Models
 {

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
@@ -13,7 +13,7 @@ using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Models;
 using Microsoft.Extensions.Logging;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace GeeksCoreLibrary.Modules.Databases.Services
 {

--- a/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
+++ b/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
@@ -68,18 +68,10 @@ namespace GeeksCoreLibrary.Modules.Objects.Services
 
                 var objects = new Dictionary<string, SettingObject>(StringComparer.OrdinalIgnoreCase);
 
-                var reader = await databaseConnection.GetReaderAsync(@"SELECT `key`, `value`, `description`, `typenr` FROM easy_objects WHERE active = 1");
-                try
+                await using var reader = await databaseConnection.GetReaderAsync(@"SELECT `key`, `value`, `description`, `typenr` FROM easy_objects WHERE active = 1");
+                while (await reader.ReadAsync())
                 {
-                    while (await reader.ReadAsync())
-                    {
-                        objects.Add($"{reader.GetStringHandleNull("key")}{reader.GetInt32(reader.GetOrdinal("typenr"))}", reader.ToObjectModel());
-                    }
-                }
-                finally
-                {
-                    await reader.CloseAsync();
-                    await reader.DisposeAsync();
+                    objects.Add($"{reader.GetString(reader.GetOrdinal("key"))}{reader.GetInt32(reader.GetOrdinal("typenr"))}", reader.ToObjectModel());
                 }
 
                 return objects;

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -13,7 +13,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
     {
         public static async Task<Template> ToTemplateModelAsync(this DbDataReader reader, TemplateTypes? type = null)
         {
-            if (!Enum.TryParse(typeof(TemplateTypes), reader.GetStringHandleNull("template_type"), true, out var templateType))
+            if (!Enum.TryParse(typeof(TemplateTypes), Convert.ToString(await reader.GetFieldValueAsync<int>("template_type")), true, out var templateType))
             {
                 if (!Enum.TryParse(typeof(TemplateTypes), reader.GetStringHandleNull("root_name"), true, out templateType))
                 {
@@ -21,7 +21,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Extensions
                 }
             }
 
-            if (!Enum.TryParse(typeof(ResourceInsertModes), reader.GetStringHandleNull("insert_mode"), true, out var insertMode))
+            if (!Enum.TryParse(typeof(ResourceInsertModes), Convert.ToString(reader.GetFieldValueAsync<int>("insert_mode")), true, out var insertMode))
             {
                 insertMode = ResourceInsertModes.Standard;
             }

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -207,15 +207,9 @@ GROUP BY template.template_id
 ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
 
             Template result;
-            var reader = await databaseConnection.GetReaderAsync(query);
-            try
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
             {
                 result = await reader.ReadAsync() ? await reader.ToTemplateModelAsync(type) : new Template();
-            }
-            finally
-            {
-                await reader.CloseAsync();
-                await reader.DisposeAsync();
             }
 
             // Check login requirement.
@@ -478,19 +472,11 @@ ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, paren
                         GROUP BY template.template_id
                         ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, parent2.ordering ASC, parent1.ordering ASC, template.ordering ASC";
 
-            var reader = await databaseConnection.GetReaderAsync(query);
-            try
+            await using var reader = await databaseConnection.GetReaderAsync(query);
+            while (await reader.ReadAsync())
             {
-                while (await reader.ReadAsync())
-                {
-                    var template = await reader.ToTemplateModelAsync();
-                    results.Add(template);
-                }
-            }
-            finally
-            {
-                await reader.CloseAsync();
-                await reader.DisposeAsync();
+                var template = await reader.ToTemplateModelAsync();
+                results.Add(template);
             }
 
             return results;
@@ -571,19 +557,13 @@ ORDER BY parent5.ordering ASC, parent4.ordering ASC, parent3.ordering ASC, paren
             var idsLoaded = new List<int>();
             var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext).ToString();
 
-            var reader = await databaseConnection.GetReaderAsync(query);
-            try
+            await using (var reader = await databaseConnection.GetReaderAsync(query))
             {
                 while (await reader.ReadAsync())
                 {
                     var template = await reader.ToTemplateModelAsync();
                     await AddTemplateToResponseAsync(idsLoaded, template, currentUrl, resultBuilder, result);
                 }
-            }
-            finally
-            {
-                await reader.CloseAsync();
-                await reader.DisposeAsync();
             }
 
             result.Content = resultBuilder.ToString();


### PR DESCRIPTION
This changes the package for the MySQL database connections to `MySqlConnector` instead of `MySql.Data`, and updates all code accordingly. Also updated some Reader usages to use `await` instead of `try..finally`. This is done because our logs show a lot of connection errors, and they mostly seem to be because of bugs in the `MySql.Data` package.

**Pros**
* This package fixes various bugs that the `MySql.Data` package still suffers from. A full list can be found here: https://mysqlconnector.net/tutorials/migrating-from-connector-net/#fixed-bugs
* This package has better performance than the `MySql.Data` package. A benchmark can be found here: https://mysqlconnector.net/#performance
* Pretty much all code still works exactly the same. There are a few differences (the code has been updated accordingly).
* It kind of forces developers to write better code. For example, the data reader method `GetString` will no longer work on columns that don't return strings, which is correct. The `MySql.Data` package allowed this [because it implicitly converts values](https://mysqlconnector.net/tutorials/migrating-from-connector-net/#implicit-conversions), which is bad practice and error-prone. The GCL used this in a few places, but they've all been updated to use better methods.
* It supports load balancing by setting multiple database names in the connection string. The official connector says it also supports this, but it doesn't work due to a bug in the code (which got fixed in this connector).

**Cons**
* This package normally forces the character set to `utf8mb4` with the server's default collation (which will most likely be `utf8mb4_0900_ai_ci`) even if the actual database uses a different character set and/or collation. To combat this, a query will be executed after opening the connection which forces the character set and collation to whatever is set in the app settings. This means that there are two extra settings in the app settings. This is unfortunately the only way to really get around this behavior.
* This package does not include the `MySqlX` namespace that is used for the document store, which means that the `MySql.Data` package is still required to make that work. This basically means that two separate connectors are installed.

[Asana ticket](https://app.asana.com/0/1205090868730163/1205884675321526)