### PR TITLE
Fix replacements that are dependent on the httpcontext.

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -318,6 +318,11 @@ namespace GeeksCoreLibrary.Core.Helpers
         /// <returns>The remote IP address of the client.</returns>
         public static string GetUserIpAddress(HttpContext httpContext)
         {
+            if (httpContext == null)
+            {
+                return String.Empty;
+            }
+            
             var result = GetHeaderValueAs<string>(httpContext, "CF_CONNECTING_IP"); // Cloud Flare IP address.
             if (String.IsNullOrWhiteSpace(result))
             {

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -81,7 +81,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
             dataDictionary.Add("Hostname", HttpContextHelpers.GetHostName(httpContextAccessor?.HttpContext));
             dataDictionary.Add("Environment", (int)gclSettings.Environment);
             dataDictionary.Add("IpAddress", HttpContextHelpers.GetUserIpAddress(httpContextAccessor?.HttpContext));
-            dataDictionary.Add("UserAgent", HttpContextHelpers.GetHeaderValueAs<string>(httpContextAccessor?.HttpContext, Microsoft.Net.Http.Headers.HeaderNames.UserAgent));
+            dataDictionary.Add("UserAgent", HttpContextHelpers.GetHeaderValueAs<string>(httpContextAccessor?.HttpContext, Microsoft.Net.Http.Headers.HeaderNames.UserAgent) ?? String.Empty);
             input = replacementsMediator.DoReplacements(input, dataDictionary, forQuery: forQuery, defaultFormatter: defaultFormatter);
 
             // System object replaces.


### PR DESCRIPTION
If an application that is not webbased uses the GCL it would crash during replacements because the httpcontext is null.

https://app.asana.com/0/1201027711166952/1206054275314309