### PR TITLE
Implement hybrid document store save

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -236,7 +236,8 @@ namespace GeeksCoreLibrary.Core.Services
                     databaseConnection.AddParameter("linkTypeNumber", linkTypeNumber);
                     databaseConnection.AddParameter("username", username);
                     databaseConnection.AddParameter("userId", userId);
-                    databaseConnection.AddParameter("publishedEnvironment", wiserItem.PublishedEnvironment ?? Environments.Live);
+                    databaseConnection.AddParameter("publishedEnvironment", 
+                                                    wiserItem.PublishedEnvironment ?? Environments.Live | Environments.Acceptance | Environments.Test | Environments.Development);
                     databaseConnection.AddParameter("saveHistoryGcl", saveHistory); // This is used in triggers.
                     var query = $@"SET @saveHistory = ?saveHistoryGcl;
 SET @_userId = ?userId;

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -103,7 +103,7 @@ namespace GeeksCoreLibrary.Core.Services
             var entitySettings = await wiserItemsService.GetEntityTypeSettingsAsync(wiserItem.EntityType);
             storeType ??= entitySettings.StoreType;
 
-            if (storeType is StoreType.DocumentStore or StoreType.Hybrid)
+            if (storeType is StoreType.DocumentStore)
             {
                 return (await documentStorageService.StoreItemAsync(wiserItem, entitySettings)).model;
             }
@@ -121,16 +121,26 @@ namespace GeeksCoreLibrary.Core.Services
                     {
                         wiserItem = await wiserItemsService.CreateAsync(wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, false, skipPermissionsCheck, storeTypeOverride);
 
+                        if (storeType == StoreType.Hybrid)
+                        {
+                            wiserItem = (await documentStorageService.StoreItemAsync(wiserItem, entitySettings)).model;
+                            if (createNewTransaction && !alreadyHadTransaction)
+                            {
+                                await databaseConnection.CommitTransactionAsync();
+                            }
+
+                            transactionCompleted = true;
+                            return wiserItem;
+                        }
                         // When a new item has been created the values always need to be saved. There is no use to check if they have been changed since they are all new.
                         alwaysSaveValues = true;
                     }
-
-                    var result = await wiserItemsService.UpdateAsync(wiserItem.Id, wiserItem, userId, username, encryptionKey, alwaysSaveValues, saveHistory, false, skipPermissionsCheck, isNewlyCreated, alwaysSaveReadOnly);
+                    wiserItem = await wiserItemsService.UpdateAsync(wiserItem.Id, wiserItem, userId, username, encryptionKey, alwaysSaveValues, saveHistory, false, skipPermissionsCheck, isNewlyCreated);
 
                     if (createNewTransaction && !alreadyHadTransaction) await databaseConnection.CommitTransactionAsync();
                     transactionCompleted = true;
 
-                    return result;
+                    return wiserItem;
                 }
                 catch (MySqlException mySqlException)
                 {
@@ -194,9 +204,13 @@ namespace GeeksCoreLibrary.Core.Services
             var entityTypeSettings = await wiserItemsService.GetEntityTypeSettingsAsync(wiserItem.EntityType);
             storeType ??= entityTypeSettings.StoreType;
 
-            if (storeType is StoreType.DocumentStore or StoreType.Hybrid)
+            switch (storeType)
             {
-                return (await documentStorageService.StoreItemAsync(wiserItem, entityTypeSettings)).model;
+                case StoreType.DocumentStore:
+                    return (await documentStorageService.StoreItemAsync(wiserItem, entityTypeSettings)).model;
+                case StoreType.Hybrid:
+                    wiserItem.PublishedEnvironment = 0;
+                    break;
             }
 
             var tablePrefix = wiserItemsService.GetTablePrefixForEntity(entityTypeSettings);
@@ -221,14 +235,14 @@ namespace GeeksCoreLibrary.Core.Services
                     databaseConnection.AddParameter("parentId", parentId);
                     databaseConnection.AddParameter("linkTypeNumber", linkTypeNumber);
                     databaseConnection.AddParameter("username", username);
-                    databaseConnection.AddParameter("username", username);
                     databaseConnection.AddParameter("userId", userId);
+                    databaseConnection.AddParameter("publishedEnvironment", wiserItem.PublishedEnvironment ?? Environments.Live);
                     databaseConnection.AddParameter("saveHistoryGcl", saveHistory); // This is used in triggers.
                     var query = $@"SET @saveHistory = ?saveHistoryGcl;
 SET @_userId = ?userId;
 SET @saveHistory = ?saveHistoryGcl;
-INSERT INTO {tablePrefix}{WiserTableNames.WiserItem} (moduleid, title, entity_type, added_by)
-VALUES (?moduleId, ?title, ?entityType, ?username);
+INSERT INTO {tablePrefix}{WiserTableNames.WiserItem} (moduleid, title, entity_type, added_by, published_environment)
+VALUES (?moduleId, ?title, ?entityType, ?username, ?publishedEnvironment);
 SELECT LAST_INSERT_ID() AS newId;";
                     var queryResult = await databaseConnection.GetAsync(query, true);
 

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDocumentStoreConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDocumentStoreConnection.cs
@@ -61,7 +61,7 @@ using MySqlX.XDevAPI.CRUD;
     /// <param name="item">The item that will be serialized.</param>
     /// <param name="id">The document ID. If the item doesn't exist yet, a new ID will be generated.</param>
     /// <returns>The <see cref="Result"/> object that contains data about the inserted/updated item.</returns>
-    Task<string> InsertOrUpdateDocumentAsync(string collectionName, object item, ulong id = 0);
+    Task<string> InsertOrUpdateDocumentAsync(string collectionName, object item, string id = null);
 
     /// <summary>
     /// Modifies a document by its internal id (the _id column). Note that it has to match the _id column exactly.

--- a/GeeksCoreLibrary/Modules/Databases/Services/DocumentStoreConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/DocumentStoreConnection.cs
@@ -194,21 +194,20 @@ public class DocumentStoreConnection : IDocumentStoreConnection, IScopedService
     }
 
     /// <inheritdoc />
-    public async Task<string> InsertOrUpdateDocumentAsync(string collectionName, object item, ulong id = 0)
+    public async Task<string> InsertOrUpdateDocumentAsync(string collectionName, object item, string id = null)
     {
         var collection = GetCollection(collectionName);
 
-        var itemString = JsonConvert.SerializeObject(item, jsonSerializerSettings);
-        if (id == 0UL)
+        if (String.IsNullOrWhiteSpace(id))
         {
-            // New item.
+            var itemString = JsonConvert.SerializeObject(item, jsonSerializerSettings);
             var result = await collection.Add(itemString).ExecuteAsync();
+            
             return result.GeneratedIds[0];
         }
         
-        await collection.Modify("id = :itemId").Patch(itemString).Bind("itemId", $"{id}").ExecuteAsync();
-
-        return null;
+        await ModifyDocumentByIdAsync(collectionName, id, item);
+        return id;
     }
 
     /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDocumentStorageService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDocumentStorageService.cs
@@ -71,7 +71,7 @@ public class MySqlDocumentStorageService : IDocumentStorageService, IScopedServi
         
         wiserItem.ChangedOn = DateTime.Now;
         
-        var id = await documentStorageConnection.InsertOrUpdateDocumentAsync($"{prefix}{WiserTableNames.WiserItemStore}", wiserItem, wiserItem.Id);
+        var id = await documentStorageConnection.InsertOrUpdateDocumentAsync($"{prefix}{WiserTableNames.WiserItemStore}", wiserItem, wiserItem.UniqueUuid);
 
         return (wiserItem, id);
     }


### PR DESCRIPTION
https://app.asana.com/0/1200923549887805/1203802664624132

When the store_type is set to hybrid, the item will be created in the table without any details with published_environment set to none and added to the document store with the details.
This way saving the item van be split up into multiple phases. 