### PR TITLE
Reverted document store connection change

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Services/DocumentStoreConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/DocumentStoreConnection.cs
@@ -200,8 +200,9 @@ public class DocumentStoreConnection : IDocumentStoreConnection, IScopedService
 
         if (String.IsNullOrWhiteSpace(id))
         {
-            var result = await collection.Add( JObject.FromObject(item)).ExecuteAsync();
-            
+            var itemString = JsonConvert.SerializeObject(item, jsonSerializerSettings);
+            var result = await collection.Add(itemString).ExecuteAsync();
+
             return result.GeneratedIds[0];
         }
         


### PR DESCRIPTION
This reverts a change made to the `DocumentStoreConnection`. The original change caused the code to skip the serialization part of the item that was to be added to the document store, but instead it caused no data to be stored at all.

[Asana ticket](https://app.asana.com/0/1200923549887805/1203802664624132)