### PR TITLE
Improvements to MySqlDatabaseconnection

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/QueryHelpers.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/QueryHelpers.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace GeeksCoreLibrary.Modules.Databases.Helpers;
+
+public static class QueryHelpers
+{
+    /// <summary>
+    /// Determines if the given query is a write query.
+    /// </summary>
+    /// <param name="query">The query to check.</param>
+    /// <returns>True if the query is a write query, otherwise false.</returns>
+    public static bool IsWriteQuery(string query)
+    {
+        if (String.IsNullOrWhiteSpace(query))
+        {
+            return false;
+        }
+
+        return query.Contains("INSERT", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("UPDATE", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("DELETE", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("ALTER", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("CREATE", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("DROP", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("TRUNCATE", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("OPTIMIZE", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("REPLACE INTO", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
@@ -28,9 +28,9 @@ namespace GeeksCoreLibrary.Modules.Databases.Interfaces
         /// Gets results from a query as a DataTable.
         /// </summary>
         /// <param name="query">The query to execute and get the results of.</param>
-        /// <param name="skipCache"></param>
-        /// <param name="cleanUp">Clean up after the query has been completed.</param>
-        /// <param name="useWritingConnectionIfAvailable">Use the writing connection to get information only available on the connection such as LAST_INSERT_ID.</param>
+        /// <param name="skipCache">Optional: Set to true to skip the query cache. Queries that get data, will get cached by default, based on a hash of the query and all parameters.</param>
+        /// <param name="cleanUp">Optional: Clean up after the query has been completed.</param>
+        /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
         Task<DataTable> GetAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false);
 
         /// <summary>
@@ -38,15 +38,16 @@ namespace GeeksCoreLibrary.Modules.Databases.Interfaces
         /// </summary>
         /// <param name="query">The query to execute and get the results of.</param>
         /// <param name="formatResult">Optional: Set to true to format the JSON to make is easy readable.</param>
+        /// <param name="skipCache">Optional: Set to true to skip the query cache. Queries that get data, will get cached by default, based on a hash of the query and all parameters.</param>
         Task<string> GetAsJsonAsync(string query, bool formatResult = false, bool skipCache = false);
 
         /// <summary>
         /// Executes a query and returns the amount of rows affected.
         /// </summary>
-        /// <param name="query"></param>
-        /// <param name="useWritingConnectionIfAvailable"></param>
-        /// <param name="cleanUp">Clean up after the query has been completed.</param>
-        /// <returns></returns>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
+        /// <param name="cleanUp">Optional: Clean up the connection and command after the query has been completed.</param>
+        /// <returns>The amount of affected rows.</returns>
         Task<int> ExecuteAsync(string query, bool useWritingConnectionIfAvailable = true, bool cleanUp = true);
 
         /// <summary>
@@ -65,8 +66,8 @@ namespace GeeksCoreLibrary.Modules.Databases.Interfaces
         /// Inserts a record using a query and returns the newly inserted ID.
         /// </summary>
         /// <param name="query">The query that should be executed, which should be an INSERT query.</param>
-        /// <param name="useWritingConnectionIfAvailable">Optional: If there is a separate connection for writing data, use that connection. Default is true.</param>
-        /// <returns></returns>
+        /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
+        /// <returns>The ID of the newly inserted record.</returns>
         Task<long> InsertRecordAsync(string query, bool useWritingConnectionIfAvailable = true);
 
         /// <summary>
@@ -119,12 +120,12 @@ namespace GeeksCoreLibrary.Modules.Databases.Interfaces
         /// <param name="writeDatabase">Optional: Set to <see langword="true"/> to get the database of the write connection (if applicable), otherwise get the database of the read connection. Default is <see langword="false"/>.</param>
         /// <returns>The key that you can use in caching.</returns>
         string GetDatabaseNameForCaching(bool writeDatabase = false);
-        
+
         /// <summary>
         /// If the connection is not open yet, open it.
         /// </summary>
         Task EnsureOpenConnectionForReadingAsync();
-        
+
         /// <summary>
         /// If the connection is not open yet, open it.
         /// </summary>

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -14,6 +14,7 @@ using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Branches.Interfaces;
+using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Models;
 using Microsoft.AspNetCore.Hosting;
@@ -121,7 +122,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             try
             {
                 MySqlCommand commandToUse;
-                if (useWritingConnectionIfAvailable && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
+                if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
                 {
                     await EnsureOpenConnectionForWritingAsync();
                     commandToUse = CommandForWriting;
@@ -198,7 +199,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             try
             {
                 MySqlCommand commandToUse;
-                if (useWritingConnectionIfAvailable && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
+                if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
                 {
                     await EnsureOpenConnectionForWritingAsync();
                     commandToUse = CommandForWriting;
@@ -301,7 +302,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             try
             {
                 MySqlCommand commandToUse;
-                if (useWritingConnectionIfAvailable && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
+                if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
                 {
                     await EnsureOpenConnectionForWritingAsync();
                     commandToUse = CommandForWriting;

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -47,8 +47,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
         private MySqlConnection ConnectionForReading { get; set; }
         private MySqlConnection ConnectionForWriting { get; set; }
-        private MySqlCommand CommandForReading { get; set; }
-        private MySqlCommand CommandForWriting { get; set; }
 
         private readonly GclSettings gclSettings;
 
@@ -59,6 +57,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         private int readConnectionLogId;
         private int writeConnectionLogId;
         private bool? logTableExists;
+        private int? commandTimeout;
 
         private readonly ConcurrentDictionary<string, object> parameters = new();
 
@@ -104,9 +103,9 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         {
             logger.LogTrace($"Called GetReaderAsync of MySqlDatabaseConnection with ID '{instanceId}' on URL {HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext)}");
             await EnsureOpenConnectionForReadingAsync();
-            CommandForReading.CommandText = query;
-
-            dataReader = await CommandForReading.ExecuteReaderAsync();
+            await using var command = new MySqlCommand(query, ConnectionForReading);
+            SetupMySqlCommand(command);
+            dataReader = await command.ExecuteReaderAsync();
 
             return dataReader;
         }
@@ -119,19 +118,21 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
         private async Task<DataTable> GetAsync(string query, int retryCount, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
         {
+            MySqlCommand commandToUse = null;
             try
             {
-                MySqlCommand commandToUse;
                 if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
                 {
                     await EnsureOpenConnectionForWritingAsync();
-                    commandToUse = CommandForWriting;
+                    commandToUse = new MySqlCommand(query, ConnectionForWriting);
                 }
                 else
                 {
                     await EnsureOpenConnectionForReadingAsync();
-                    commandToUse = CommandForReading;
+                    commandToUse = new MySqlCommand(query, ConnectionForReading);
                 }
+
+                SetupMySqlCommand(commandToUse);
 
                 var result = new DataTable();
                 commandToUse.CommandText = query;
@@ -166,6 +167,11 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             finally
             {
+                if (commandToUse != null)
+                {
+                    await commandToUse.DisposeAsync();
+                }
+
                 // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets committed or roll backed.
                 if (!HasActiveTransaction() && cleanUp)
                 {
@@ -196,19 +202,21 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         /// <returns></returns>
         private async Task<int> ExecuteAsync(string query, int retryCount, bool useWritingConnectionIfAvailable = true, bool cleanUp = true)
         {
+            MySqlCommand commandToUse = null;
             try
             {
-                MySqlCommand commandToUse;
                 if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
                 {
                     await EnsureOpenConnectionForWritingAsync();
-                    commandToUse = CommandForWriting;
+                    commandToUse = new MySqlCommand(query, ConnectionForWriting);
                 }
                 else
                 {
                     await EnsureOpenConnectionForReadingAsync();
-                    commandToUse = CommandForReading;
+                    commandToUse = new MySqlCommand(query, ConnectionForReading);
                 }
+
+                SetupMySqlCommand(commandToUse);
 
                 commandToUse.CommandText = query;
                 logger.LogDebug("Query: {query}", query);
@@ -238,6 +246,11 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             finally
             {
+                if (commandToUse != null)
+                {
+                    await commandToUse.DisposeAsync();
+                }
+
                 // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets comitted or rollbacked.
                 if (transaction == null && cleanUp)
                 {
@@ -299,20 +312,9 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 return 0L;
             }
 
+            MySqlCommand commandToUse = null;
             try
             {
-                MySqlCommand commandToUse;
-                if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
-                {
-                    await EnsureOpenConnectionForWritingAsync();
-                    commandToUse = CommandForWriting;
-                }
-                else
-                {
-                    await EnsureOpenConnectionForReadingAsync();
-                    commandToUse = CommandForReading;
-                }
-
                 var finalQuery = new StringBuilder(query.TrimEnd());
                 if (finalQuery[^1] != ';')
                 {
@@ -322,7 +324,18 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Add the query to retrieve the last inserted ID to the query that was passed to the function.
                 finalQuery.Append("SELECT LAST_INSERT_ID();");
 
-                commandToUse.CommandText = finalQuery.ToString();
+                if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
+                {
+                    await EnsureOpenConnectionForWritingAsync();
+                    commandToUse = new MySqlCommand(finalQuery.ToString(), ConnectionForWriting);
+                }
+                else
+                {
+                    await EnsureOpenConnectionForReadingAsync();
+                    commandToUse = new MySqlCommand(finalQuery.ToString(), ConnectionForReading);
+                }
+
+                SetupMySqlCommand(commandToUse);
 
                 await using var reader = await commandToUse.ExecuteReaderAsync();
                 if (!await reader.ReadAsync())
@@ -356,6 +369,11 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             finally
             {
+                if (commandToUse != null)
+                {
+                    await commandToUse.DisposeAsync();
+                }
+
                 // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets comitted or rollbacked.
                 if (transaction == null)
                 {
@@ -392,16 +410,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
             transaction = await connectionToUse.BeginTransactionAsync();
 
-            // MySqlConnector wants us to set the transaction on the command, so that it knows which transaction to use.
-            if (CommandForReading != null)
-            {
-                CommandForReading.Transaction = transaction;
-            }
-            if (CommandForWriting != null)
-            {
-                CommandForWriting.Transaction = transaction;
-            }
-
             return transaction;
         }
 
@@ -424,16 +432,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             await transaction.DisposeAsync();
             transaction = null;
 
-            // Also reset the Transaction property on the commands, so that they don't use the transaction anymore.
-            if (CommandForReading != null)
-            {
-                CommandForReading.Transaction = null;
-            }
-            if (CommandForWriting != null)
-            {
-                CommandForWriting.Transaction = null;
-            }
-
             await CleanUpAsync();
         }
 
@@ -455,16 +453,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             // Dispose and set to null, so that we know there is no more active transaction.
             await transaction.DisposeAsync();
             transaction = null;
-
-            // Also reset the Transaction property on the commands, so that they don't use the transaction anymore.
-            if (CommandForReading != null)
-            {
-                CommandForReading.Transaction = null;
-            }
-            if (CommandForWriting != null)
-            {
-                CommandForWriting.Transaction = null;
-            }
 
             await CleanUpAsync();
         }
@@ -496,10 +484,6 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         private async Task CleanUpAsync()
         {
             if (dataReader != null) await dataReader.DisposeAsync();
-            if (CommandForReading != null) await CommandForReading.DisposeAsync();
-            if (CommandForWriting != null) await CommandForWriting.DisposeAsync();
-            CommandForReading = null;
-            CommandForWriting = null;
             dataReader = null;
         }
 
@@ -541,25 +525,11 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             if (ConnectionForReading == null)
             {
                 ConnectionForReading = new MySqlConnection { ConnectionString = connectionStringForReading.ConnectionString };
-                CommandForReading = ConnectionForReading.CreateCommand();
                 createdNewConnection = true;
             }
 
-            CommandForReading ??= ConnectionForReading.CreateCommand();
-
             // Remember the database name that was connected to.
             ConnectedDatabase = ConnectionForReading.Database;
-
-            // Copy parameters.
-            foreach (var parameter in parameters)
-            {
-                if (CommandForReading.Parameters.Contains(parameter.Key))
-                {
-                    CommandForReading.Parameters.RemoveAt(parameter.Key);
-                }
-
-                CommandForReading.Parameters.AddWithValue(parameter.Key, parameter.Value);
-            }
 
             if (ConnectionForReading.State != ConnectionState.Closed)
             {
@@ -568,8 +538,8 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
             await ConnectionForReading.OpenAsync();
 
-            await SetTimezone(CommandForReading);
-            await SetCharacterSetAndCollationAsync(CommandForReading);
+            await SetTimezone(ConnectionForReading);
+            await SetCharacterSetAndCollationAsync(ConnectionForReading);
 
             if (createdNewConnection)
             {
@@ -594,25 +564,11 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             if (ConnectionForWriting == null)
             {
                 ConnectionForWriting = new MySqlConnection { ConnectionString = connectionStringForWriting.ConnectionString };
-                CommandForWriting = ConnectionForWriting.CreateCommand();
                 createdNewConnection = true;
             }
 
-            CommandForWriting ??= ConnectionForWriting.CreateCommand();
-
             // Remember the database name that was connected to.
             ConnectedDatabaseForWriting = ConnectionForWriting.Database;
-
-            // Copy parameters.
-            foreach (var parameter in parameters)
-            {
-                if (CommandForWriting.Parameters.Contains(parameter.Key))
-                {
-                    CommandForWriting.Parameters.RemoveAt(parameter.Key);
-                }
-
-                CommandForWriting.Parameters.AddWithValue(parameter.Key, parameter.Value);
-            }
 
             if (ConnectionForWriting.State != ConnectionState.Closed)
             {
@@ -621,8 +577,8 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 
             await ConnectionForWriting.OpenAsync();
 
-            await SetTimezone(CommandForWriting);
-            await SetCharacterSetAndCollationAsync(CommandForWriting);
+            await SetTimezone(ConnectionForWriting);
+            await SetCharacterSetAndCollationAsync(ConnectionForWriting);
 
             if (createdNewConnection)
             {
@@ -659,15 +615,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         /// <inheritdoc />
         public void SetCommandTimeout(int value)
         {
-            if (CommandForReading != null)
-            {
-                CommandForReading.CommandTimeout = value;
-            }
-
-            if (CommandForWriting != null)
-            {
-                CommandForWriting.CommandTimeout = value;
-            }
+            commandTimeout = value;
         }
 
         /// <inheritdoc />
@@ -732,14 +680,14 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             return true;
         }
 
-        private async Task SetTimezone(MySqlCommand command)
+        private async Task SetTimezone(MySqlConnection connection)
         {
             try
             {
                 // Make sure we always use the correct timezone.
                 if (!String.IsNullOrWhiteSpace(gclSettings.DatabaseTimeZone))
                 {
-                    command.CommandText = $"SET @@time_zone = {gclSettings.DatabaseTimeZone.ToMySqlSafeValue(true)};";
+                    await using var command = new MySqlCommand($"SET @@time_zone = {gclSettings.DatabaseTimeZone.ToMySqlSafeValue(true)};", connection);
                     await command.ExecuteNonQueryAsync();
                 }
             }
@@ -765,8 +713,8 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
         /// <summary>
         /// Sets the correct character set and collation for the database connection.
         /// </summary>
-        /// <param name="command">The <see cref="MySqlCommand"/> object that will execute the query.</param>
-        private async Task SetCharacterSetAndCollationAsync(MySqlCommand command)
+        /// <param name="connection">The <see cref="MySqlConnection"/> object that will execute the query.</param>
+        private async Task SetCharacterSetAndCollationAsync(MySqlConnection connection)
         {
             try
             {
@@ -776,7 +724,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Make sure we always use the correct timezone.
                 if (!String.IsNullOrWhiteSpace(gclSettings.DatabaseTimeZone))
                 {
-                    command.CommandText = $"SET NAMES {characterSet} COLLATE {collation};";
+                    await using var command = new MySqlCommand($"SET NAMES {characterSet} COLLATE {collation};", connection);
                     await command.ExecuteNonQueryAsync();
                 }
             }
@@ -803,7 +751,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                     return;
                 }
 
-                var commandToUse = isWriteConnection && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? CommandForWriting : CommandForReading;
+                await using var commandToUse = new MySqlCommand("", !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? ConnectionForWriting : ConnectionForReading);
 
                 logTableExists ??= await LogTableExistsAsync(commandToUse);
 
@@ -861,8 +809,6 @@ SELECT LAST_INSERT_ID();";
         /// <param name="disposeConnection">Set to true to dispose the connection at the end.</param>
         private async Task AddConnectionCloseLogAsync(bool isWriteConnection, bool disposeConnection = false)
         {
-            var commandToUse = isWriteConnection && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? CommandForWriting : CommandForReading;
-
             try
             {
                 if (!gclSettings.LogOpeningAndClosingOfConnections && ((isWriteConnection && writeConnectionLogId == 0) || (!isWriteConnection && readConnectionLogId == 0)))
@@ -877,17 +823,7 @@ SELECT LAST_INSERT_ID();";
                     return;
                 }
 
-                if (commandToUse == null)
-                {
-                    if (isWriteConnection && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
-                    {
-                        commandToUse = CommandForWriting ??= ConnectionForWriting.CreateCommand();
-                    }
-                    else
-                    {
-                        commandToUse = CommandForReading ??= ConnectionForReading.CreateCommand();
-                    }
-                }
+                await using var commandToUse = new MySqlCommand("", !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString) ? ConnectionForWriting : ConnectionForReading);
 
                 if (commandToUse.Connection is { State: ConnectionState.Closed })
                 {
@@ -908,17 +844,51 @@ SELECT LAST_INSERT_ID();";
             {
                 if (disposeConnection)
                 {
-                    if (commandToUse != null)
-                    {
-                        await commandToUse.DisposeAsync();
-                    }
-
                     var connection = (isWriteConnection ? ConnectionForWriting : ConnectionForReading);
                     if (connection != null)
                     {
                         await connection.DisposeAsync();
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Setups a <see cref="MySqlCommand"/> by doing the following things:
+        /// - Copy all current parameters to the given command.
+        /// - Set the transaction on the command.
+        /// - Set the command timeout.
+        /// - Wait until the connection is no longer in the state "Connecting".
+        /// </summary>
+        /// <param name="command">The <see cref="MySqlCommand"/> to copy the parameters to.</param>
+        private void SetupMySqlCommand(MySqlCommand command)
+        {
+            // Copy all current parameters to the given command.
+            foreach (var parameter in parameters)
+            {
+                if (command.Parameters.Contains(parameter.Key))
+                {
+                    command.Parameters.RemoveAt(parameter.Key);
+                }
+
+                command.Parameters.AddWithValue(parameter.Key, parameter.Value);
+            }
+
+            // MySqlConnector wants us to set the transaction on the command, so that it knows which transaction to use.
+            command.Transaction = transaction;
+
+            // Set the command timeout.
+            if (commandTimeout.HasValue)
+            {
+                command.CommandTimeout = commandTimeout.Value;
+            }
+
+            // Sometimes, the connection is in the state "Connecting", which causes exceptions if we then try to execute a query.
+            var counter = 0;
+            while (command.Connection?.State == ConnectionState.Connecting && counter < 100)
+            {
+                Thread.Sleep(10);
+                counter++;
             }
         }
     }


### PR DESCRIPTION
Made the following changes:
* Added better support for database clusters with read-only databases. The GCL will try to automatically detect if a query contains any kind of modification that does not work on a read-only node.
* Create a new MySqlCommand everytime we execute a query. This is done because I was getting random NullReferenceExceptions when executing queries; Sometimes the Commands that we saved in memory were null for some reason. These changes fix that. This also has the side effect that it improved the performance by a lot. On a site that I tested this on, the loading of the homepage went from 1.8 seconds to 0,8 seconds, that is more than 50% increase in performance.
* Added some missing documentation in code.

Asana ticket: https://app.asana.com/0/1151477971646641/1206380496687108