### PR TITLE
Option to set the SameSite mode for cookies.

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -224,7 +224,7 @@ namespace GeeksCoreLibrary.Core.Helpers
                 HttpOnly = httpOnly,
                 Secure = httpContext.Request.IsHttps,
                 IsEssential = isEssential,
-                SameSite = SameSiteMode.Lax
+                SameSite = GclSettings.Current.CookieSameSiteMode
             };
 
             httpContext.Response.Cookies.Append(key, value, newCookieOptions);

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -2,6 +2,7 @@
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Modules.Communication.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace GeeksCoreLibrary.Core.Models
 {
@@ -255,5 +256,10 @@ namespace GeeksCoreLibrary.Core.Models
         /// That table will be automatically created if it doesn't exist yet.
         /// </summary>
         public bool LogOpeningAndClosingOfConnections { get; set; }
+        
+        /// <summary>
+        /// The SameSite mode to use for cookies.
+        /// </summary>
+        public SameSiteMode CookieSameSiteMode { get; set; } = SameSiteMode.Lax;
     }
 }


### PR DESCRIPTION
Option to set the SameSite mode for cookies. This is necessary when a site runs in a iframe with a different parent domain.