### PR TITLE
Use return value of evaluateTemplate in FillStringByClass

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -493,7 +493,7 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Services
             // Evaluate template, working with if...else...then statements
             if (evaluateTemplate)
             {
-                EvaluateTemplate(inputString);
+                inputString = EvaluateTemplate(inputString);
             }
 
             return inputString;


### PR DESCRIPTION
In the FillStringByClass method in StringReplacementService the evaluateTemplate parameter did nothing because the result of the EvaluateTemplate call wasn't used.