### PR TITLE
Added support for virtual columns

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -488,11 +488,11 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                                 paymentServiceProvider.id AS paymentServiceProviderId,
                                 paymentServiceProvider.title AS paymentServiceProviderTitle,
                                 paymentServiceProviderType.`value` AS paymentServiceProviderType,
-                                paymentMethodFee.`value` AS paymentMethodFee,
+                                paymentMethodFee.value_as_decimal AS paymentMethodFee,
                                 paymentMethodVisibility.`value` AS paymentMethodVisibility,
                                 paymentMethodExternalName.`value` AS paymentMethodExternalName,
-                                paymentMethodMinimalAmount.`value` AS paymentMethodMinimalAmount,
-                                paymentMethodMaximumAmount.`value` AS paymentMethodMaximumAmount,
+                                paymentMethodMinimalAmount.value_as_decimal AS paymentMethodMinimalAmount,
+                                paymentMethodMaximumAmount.value_as_decimal AS paymentMethodMaximumAmount,
                                 IF(paymentMethodUseMinimalAmount.`value` = 1, TRUE, FALSE) AS paymentMethodUseMinimalAmount,
                                 IF(paymentMethodUseMaximumAmount.`value` = 1, TRUE, FALSE) AS paymentMethodUseMaximumAmount,
 
@@ -664,11 +664,11 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                                 paymentServiceProvider.id AS paymentServiceProviderId,
                                 paymentServiceProvider.title AS paymentServiceProviderTitle,
                                 paymentServiceProviderType.`value` AS paymentServiceProviderType,
-                                paymentMethodFee.`value` AS paymentMethodFee,
+                                paymentMethodFee.value_as_decimal AS paymentMethodFee,
                                 paymentMethodVisibility.`value` AS paymentMethodVisibility,
                                 paymentMethodExternalName.`value` AS paymentMethodExternalName,
-                                paymentMethodMinimalAmount.`value` AS paymentMethodMinimalAmount,
-                                paymentMethodMaximumAmount.`value` AS paymentMethodMaximumAmount,
+                                paymentMethodMinimalAmount.value_as_decimal AS paymentMethodMinimalAmount,
+                                paymentMethodMaximumAmount.value_as_decimal AS paymentMethodMaximumAmount,
                                 CAST(IFNULL(paymentMethodUseMinimalAmount.`value`, 0) AS SIGNED) AS paymentMethodUseMinimalAmount,
                                 CAST(IFNULL(paymentMethodUseMaximumAmount.`value`, 0) AS SIGNED) AS paymentMethodUseMaximumAmount,
 
@@ -1340,9 +1340,9 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
         private async Task<PaymentMethodSettingsModel> DataRowToPaymentMethodSettingsModelAsync(DataRow dataRow)
         {
             // Build the payment settings model.
-            Decimal.TryParse(dataRow.Field<string>("paymentMethodFee")?.Replace(",", "."), NumberStyles.Any, new CultureInfo("en-US"), out var fee);
-            Decimal.TryParse(dataRow.Field<string?>(Constants.PaymentMethodMinimalAmountProperty)?.Replace(",", "."), NumberStyles.Any, new CultureInfo("en-US"), out var minimalAmountProperty );
-            Decimal.TryParse(dataRow.Field<string?>(Constants.PaymentMethodMaximumAmountProperty)?.Replace(",", "."), NumberStyles.Any, new CultureInfo("en-US"), out var maximumAmountProperty);
+            var fee = dataRow.Field<decimal?>("paymentMethodFee") ?? 0;
+            var minimalAmountProperty = dataRow.Field<decimal?>(Constants.PaymentMethodMinimalAmountProperty) ?? 0;
+            var maximumAmountProperty = dataRow.Field<decimal?>(Constants.PaymentMethodMaximumAmountProperty) ?? 0;
 
             var result = new PaymentMethodSettingsModel
             {

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -2093,9 +2093,9 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     SELECT
                         vatrule.id,
                         IFNULL(country.`value`, '') AS country,
-                        IFNULL(b2b.`value`, '') AS b2b,
-                        COALESCE(vatratecode.`value`, vatrate.`value`, '') AS vatrate,
-                        IFNULL(percentage.`value`, '') AS percentage
+                        IFNULL(b2b.value_as_int, 0) AS b2b,
+                        COALESCE(vatratecode.value_as_int, vatrate.value_as_int, 0) AS vatrate,
+                        IFNULL(percentage.value_as_decimal, 0) AS percentage
                     FROM `{WiserTableNames.WiserItem}` AS vatrule
                     LEFT JOIN `{WiserTableNames.WiserItemDetail}` AS country ON country.item_id = vatrule.id AND country.`key` = 'country'
                     LEFT JOIN `{WiserTableNames.WiserItemDetail}` AS b2b ON b2b.item_id = vatrule.id AND b2b.`key` = 'b2b'
@@ -2109,14 +2109,14 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                 {
                     var rule = new VatRule { Country = row.Field<string>("country") };
 
-                    var ruleB2BValue = row.Field<string>("b2b");
-                    if (Int32.TryParse(ruleB2BValue, out var ruleB2B)) rule.B2B = ruleB2B;
+                    var ruleB2BValue = row.Field<long>("b2b");
+                    var vatRateValue = row.Field<long>("vatrate");
+                    var rulePercentageValue = row.Field<decimal>("percentage");
 
-                    var ruleVatRateValue = row.Field<string>("vatrate");
-                    if (Int32.TryParse(ruleVatRateValue, out var ruleVatRate)) rule.VatRate = ruleVatRate;
-
-                    var rulePercentageValue = row.Field<string>("percentage");
-                    if (Decimal.TryParse(rulePercentageValue, out var rulePercentage)) rule.Percentage = rulePercentage;
+                    // The "value_as_int" column returns a long, so we need to convert it to an int.
+                    if (ruleB2BValue > 0) rule.B2B = Convert.ToInt32(ruleB2BValue);
+                    if (vatRateValue > 0) rule.VatRate = Convert.ToInt32(vatRateValue);
+                    if (rulePercentageValue > 0) rule.Percentage = rulePercentageValue;
 
                     vatRules.Add(rule);
                 }

--- a/GeeksCoreLibrary/Modules/Databases/Enums/VirtualTypes.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Enums/VirtualTypes.cs
@@ -1,0 +1,16 @@
+﻿namespace GeeksCoreLibrary.Modules.Databases.Enums;
+
+/// <summary>
+/// The types of virtual columns for columns that are not stored in the database.
+/// </summary>
+public enum VirtualTypes
+{
+    /// <summary>
+    /// Column values are not stored, but are evaluated when rows are read, immediately after any BEFORE triggers. A virtual column takes no storage.
+    /// </summary>
+    Virtual,
+    /// <summary>
+    /// Column values are evaluated and stored when rows are inserted or updated. A stored column does require storage space and can be indexed.
+    /// </summary>
+    Stored
+}

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -55,7 +55,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
             new WiserTableDefinitionModel
             {
                 Name = WiserTableNames.WiserItemDetail,
-                LastUpdate = new DateTime(2021, 9, 1),
+                LastUpdate = new DateTime(2024, 2, 19),
                 Columns = new List<ColumnSettingsModel>
                 {
                     new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
@@ -64,13 +64,46 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
                     new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                     new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                     new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
+                    new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
+                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
                     new("long_value", MySqlDbType.MediumText)
                 },
                 Indexes = new List<IndexSettingsModel>
                 {
-                    new(WiserTableNames.WiserItemDetail, "key_value", IndexTypes.Normal, new List<string> { "key", "value" }),
-                    new(WiserTableNames.WiserItemDetail, "item_id_key_value", IndexTypes.Normal, new List<string> { "item_id", "key", "value" }),
-                    new(WiserTableNames.WiserItemDetail, "item_id_group", IndexTypes.Normal, new List<string> { "item_id", "groupname", "key" })
+                    new(WiserTableNames.WiserItemDetail, "key_value", IndexTypes.Normal, new List<string> { "key(50)", "value(100)" }),
+                    new(WiserTableNames.WiserItemDetail, "key_int_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemDetail, "key_decimal_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_decimal" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value(40)" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_int_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_key_decimal_value", IndexTypes.Normal, new List<string> { "item_id", "key(40)", "value_as_decimal" }),
+                    new(WiserTableNames.WiserItemDetail, "item_id_group", IndexTypes.Normal, new List<string> { "item_id", "groupname", "key(40)" })
+                }
+            },
+
+            // wiser_itemlinkdetail
+            new WiserTableDefinitionModel
+            {
+                Name = WiserTableNames.WiserItemLinkDetail,
+                LastUpdate = new DateTime(2024, 2, 19),
+                Columns = new List<ColumnSettingsModel>
+                {
+                    new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
+                    new("language_code", MySqlDbType.VarChar, 5, notNull: true, defaultValue: "", comment: "leeg betekent beschikbaar voor alle talen"),
+                    new("itemlink_id", MySqlDbType.UInt64, notNull: true, defaultValue: "0"),
+                    new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: "", comment: "optionele groepering van items, zoals een 'specs' tabel"),
+                    new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
+                    new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
+                    new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
+                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
+                    new("long_value", MySqlDbType.MediumText, comment: "Voor waardes die niet in 'value' passen, zoals van HTMLeditors")
+                },
+                Indexes = new List<IndexSettingsModel>
+                {
+                    new(WiserTableNames.WiserItemLinkDetail, "itemlink_key", IndexTypes.Unique, new List<string> { "itemlink_id", "key", "language_code" }, "voor opbouwen productoverzicht"),
+                    new(WiserTableNames.WiserItemLinkDetail, "itemlink_id", IndexTypes.Normal, new List<string> { "itemlink_id" }, "voor zoeken waardes van 1 item"),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_value", IndexTypes.Normal, new List<string> { "key(50)", "value(100)" }, "filteren van items"),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_int_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_int" }),
+                    new(WiserTableNames.WiserItemLinkDetail, "key_decimal_value", IndexTypes.Normal, new List<string> { "key(50)", "value_as_decimal" })
                 }
             },
 

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -65,7 +65,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
                     new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                     new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
                     new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
-                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
+                    new("value_as_decimal", MySqlDbType.Decimal, 65, 30, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
                     new("long_value", MySqlDbType.MediumText)
                 },
                 Indexes = new List<IndexSettingsModel>
@@ -94,7 +94,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Helpers
                     new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                     new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
                     new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
-                    new("value_as_decimal", MySqlDbType.Decimal, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
+                    new("value_as_decimal", MySqlDbType.Decimal, 65, 30, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
                     new("long_value", MySqlDbType.MediumText, comment: "Voor waardes die niet in 'value' passen, zoals van HTMLeditors")
                 },
                 Indexes = new List<IndexSettingsModel>

--- a/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/ColumnSettingsModel.cs
@@ -13,7 +13,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         {
         }
 
-        public ColumnSettingsModel(string name, MySqlDbType type, int length = 0, int decimals = 2, string defaultValue = null, bool notNull = false, bool addIndex = false, IndexTypes indexType = IndexTypes.Normal, bool autoIncrement = false, IList<string> enumValues = null, string comment = null, string addAfterColumnName = null, bool updateTimeStampOnChange = false, string characterSet = "utf8mb4", string collation = "utf8mb4_general_ci", bool isPrimaryKey = false)
+        public ColumnSettingsModel(string name, MySqlDbType type, int length = 0, int decimals = 2, string defaultValue = null, bool notNull = false, bool addIndex = false, IndexTypes indexType = IndexTypes.Normal, bool autoIncrement = false, IList<string> enumValues = null, string comment = null, string addAfterColumnName = null, bool updateTimeStampOnChange = false, string characterSet = "utf8mb4", string collation = "utf8mb4_general_ci", bool isPrimaryKey = false, bool isVirtual = false, VirtualTypes? virtualType = null, string virtualExpression = null)
         {
             Name = name;
             Type = type;
@@ -31,6 +31,9 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
             CharacterSet = characterSet;
             Collation = collation;
             IsPrimaryKey = isPrimaryKey;
+            IsVirtual = isVirtual;
+            VirtualType = virtualType ?? VirtualTypes.Virtual;
+            VirtualExpression = virtualExpression;
         }
 
         /// <summary>
@@ -113,5 +116,22 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         /// Gets or sets whether this column should be part of the primary key.
         /// </summary>
         public bool IsPrimaryKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether this column is a virtual column.
+        /// </summary>
+        public bool IsVirtual { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of virtual column.
+        /// This is only used if <see cref="IsVirtual"/> is set to <see langword="true"/>.
+        /// </summary>
+        public VirtualTypes VirtualType { get; set; } = VirtualTypes.Virtual;
+
+        /// <summary>
+        /// Gets or sets the expression for a virtual column.
+        /// This is only used if <see cref="IsVirtual"/> is set to <see langword="true"/>.
+        /// </summary>
+        public string VirtualExpression { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
@@ -9,12 +9,13 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         {
         }
 
-        public IndexSettingsModel(string tableName , string name, IndexTypes type = IndexTypes.Normal, List<string> fields = null)
+        public IndexSettingsModel(string tableName , string name, IndexTypes type = IndexTypes.Normal, List<string> fields = null, string comment = null)
         {
             Name = name;
             Type = type;
             TableName = tableName;
             Fields = fields ?? new List<string>();
+            Comment = comment;
         }
 
         /// <summary>
@@ -36,5 +37,10 @@ namespace GeeksCoreLibrary.Modules.Databases.Models
         /// Gets or sets the fields that are part of this index.
         /// </summary>
         public List<string> Fields { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the comment describing the index.
+        /// </summary>
+        public string Comment { get; set; }
     }
 }

--- a/GeeksCoreLibrary/Modules/Redirect/Services/RedirectService.cs
+++ b/GeeksCoreLibrary/Modules/Redirect/Services/RedirectService.cs
@@ -33,17 +33,17 @@ namespace GeeksCoreLibrary.Modules.Redirect.Services
                 databaseConnection.AddParameter("url4", uri.PathAndQuery.Split('?')[0]); // Without host without query-strings
             }
 
-            var query = $@"SELECT 	
-	                        oldUrl.`value` AS oldUrl,
-	                        newUrl.`value` AS newUrl,
-	                        permanent.`value` AS permanent	                        
+            var query = $@"SELECT
+                            oldUrl.`value` AS oldUrl,
+                            newUrl.`value` AS newUrl,
+                            permanent.`value` AS permanent
                         FROM {WiserTableNames.WiserItem} AS redirect
                         JOIN {WiserTableNames.WiserItemDetail} AS oldUrl ON oldUrl.item_id = redirect.id AND oldUrl.`key` = 'oldurl' AND oldUrl.`value` IN (?url1, ?url2{(String.IsNullOrEmpty(uri.Query) ? String.Empty : ", ?url3, ?url4")})                            
                         JOIN {WiserTableNames.WiserItemDetail} AS newUrl ON newUrl.item_id = redirect.id AND newUrl.`key` = 'newurl'
                         LEFT JOIN {WiserTableNames.WiserItemDetail} AS permanent ON permanent.item_id=redirect.id AND permanent.`key` = 'permanent'
                         LEFT JOIN {WiserTableNames.WiserItemDetail} AS ordering ON ordering.item_id=redirect.id AND ordering.`key` = 'ordering'
                         WHERE redirect.entity_type = 'redirect'
-                        ORDER BY ordering.`value` + 0 DESC
+                        ORDER BY ordering.value_as_int DESC
                         LIMIT 1";
 
             var dataTable = await databaseConnection.GetAsync(query);


### PR DESCRIPTION
MySQL table columns can now be virtual. Added `value_as_int` and `value_as_decimal` columns to `wiser_itemdetail` and `wiser_itemlinkdetail`. Also fixed an issue with creating indexes when setting the length of the index. A few queries have also been updated to use the new columns.

Related Wiser pull request: https://github.com/happy-geeks/wiser/pull/247

Asana:
https://app.asana.com/0/29553867016121/1203457154031219
https://app.asana.com/0/29553867016121/1202994198179349