### PR TITLE
Removed interface to get PSP service instance by name string

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -979,8 +979,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                     };
                 }
 
-                // Get the correct service based on name.
-                var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(paymentMethodSettings.PaymentServiceProvider.Title);
+                // Get the correct service based on type.
+                var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(paymentMethodSettings.PaymentServiceProvider.Type);
                 paymentServiceProviderService.LogPaymentActions = paymentMethodSettings.PaymentServiceProvider.LogAllRequests;
 
                 return await paymentServiceProviderService.HandlePaymentRequestAsync(conceptOrders, userDetails, paymentMethodSettings, uniquePaymentNumber);
@@ -1373,7 +1373,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
             }
 
             // Build the PSP settings model based on the type of PSP.
-            var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(result.PaymentServiceProvider.Title);
+            var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(result.PaymentServiceProvider.Type);
             result.PaymentServiceProvider = await paymentServiceProviderService.GetProviderSettingsAsync(result.PaymentServiceProvider);
 
             return result;

--- a/GeeksCoreLibrary/Modules/Payments/Interfaces/IPaymentServiceProviderServiceFactory.cs
+++ b/GeeksCoreLibrary/Modules/Payments/Interfaces/IPaymentServiceProviderServiceFactory.cs
@@ -5,7 +5,5 @@ namespace GeeksCoreLibrary.Modules.Payments.Interfaces
     public interface IPaymentServiceProviderServiceFactory
     {
         IPaymentServiceProviderService GetPaymentServiceProviderService(PaymentServiceProviders paymentServiceProvider);
-
-        IPaymentServiceProviderService GetPaymentServiceProviderService(string paymentServiceProviderName);
     }
 }

--- a/GeeksCoreLibrary/Modules/Payments/Services/PaymentServiceProviderServiceFactory.cs
+++ b/GeeksCoreLibrary/Modules/Payments/Services/PaymentServiceProviderServiceFactory.cs
@@ -22,7 +22,7 @@ namespace GeeksCoreLibrary.Modules.Payments.Services
             return GetPaymentServiceProviderService(paymentServiceProviderName);
         }
 
-        public IPaymentServiceProviderService GetPaymentServiceProviderService(string paymentServiceProviderName)
+        private IPaymentServiceProviderService GetPaymentServiceProviderService(string paymentServiceProviderName)
         {
             var serviceProviderType = FindTypeInLoadedAssemblies(paymentServiceProviderName);
             if (serviceProviderType == null)


### PR DESCRIPTION
Removed interface to get PSP service instance by name string.
All OrderProcessesService calls to get a PSP service now use the type enum.
Previously there were 2 calls using the Title string and 2 calls using the Type enum.

This breaks if there is curently a client that has a PSP configured where the title and enum don't match!

Asana: https://app.asana.com/0/1205090868730163/1206175423560611