### PR TITLE
Added support for /template.gcl?id=x

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -70,6 +70,10 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                 var context = HttpContext;
                 var templateName = HttpContextHelpers.GetRequestValue(context, "templatename");
                 Int32.TryParse(HttpContextHelpers.GetRequestValue(context, "templateid"), out templateId);
+                if (templateId <= 0)
+                {
+                    Int32.TryParse(HttpContextHelpers.GetRequestValue(context, "id"), out templateId);
+                }
                 logger.LogDebug($"GetAsync content from HTML template, templateName: '{templateName}', templateId: '{templateId}'.");
 
                 if (String.IsNullOrWhiteSpace(templateName) && templateId <= 0)


### PR DESCRIPTION
Having /template.gcl?templateid=x is kinda redundant

Asana: https://app.asana.com/0/1205090868730163/1206749493060709

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206749493060709