### PR TITLE
Revert a concept order to a basket if paymentOut fails and concept or…

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -1039,7 +1039,19 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                 try
                 {
                     // Delete the concept order(s) if this failed.
-                    await DeleteConceptOrdersAsync(conceptOrders);
+                    if (basketToConceptOrderMethod == OrderProcessBasketToConceptOrderMethods.Convert)
+                    {
+                        // Convert concept order back to basket
+                        foreach (var (main, lines) in conceptOrders)
+                        {
+                            await shoppingBasketsService.RevertConceptOrderToBasketAsync(main, lines);
+                        }
+                    }
+                    else
+                    {
+                        // Delete concept order (is copy of basket)
+                        await DeleteConceptOrdersAsync(conceptOrders);    
+                    }
                 }
                 catch (Exception deleteException)
                 {

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Interfaces/IShoppingBasketsService.cs
@@ -85,6 +85,12 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Interfaces
         Task<(ulong ConceptOrderId, WiserItemModel ConceptOrder, List<WiserItemModel> ConceptOrderLines)> MakeConceptOrderFromBasketAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, OrderProcessBasketToConceptOrderMethods basketToConceptOrderMethod);
 
         /// <summary>
+        /// Reverts a concept order to a basket if paymentOut failed
+        /// </summary>
+        /// <returns></returns>
+        Task RevertConceptOrderToBasketAsync(WiserItemModel conceptOrder, List<WiserItemModel> conceptOrderLines);
+
+        /// <summary>
         /// Turns a concept order into a final order.
         /// </summary>
         Task ConvertConceptOrderToOrderAsync(WiserItemModel conceptOrder, ShoppingBasketCmsSettingsModel settings);

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/CachedShoppingBasketsService.cs
@@ -92,13 +92,19 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket.Services
         {
             return await shoppingBasketsService.MakeConceptOrderFromBasketAsync(shoppingBasket, basketLines, settings, basketToConceptOrderMethod);
         }
+        
+        /// <inheritdoc />
+        public async Task RevertConceptOrderToBasketAsync(WiserItemModel conceptOrder, List<WiserItemModel> conceptOrderLines)
+        {
+            await shoppingBasketsService.RevertConceptOrderToBasketAsync(conceptOrder, conceptOrderLines);
+        }
 
         /// <inheritdoc />
         public async Task ConvertConceptOrderToOrderAsync(WiserItemModel conceptOrder, ShoppingBasketCmsSettingsModel settings)
         {
             await shoppingBasketsService.ConvertConceptOrderToOrderAsync(conceptOrder, settings);
         }
-
+        
         /// <inheritdoc />
         public async Task<string> ReplaceBasketInTemplateAsync(WiserItemModel shoppingBasket, List<WiserItemModel> basketLines, ShoppingBasketCmsSettingsModel settings, string template, bool replaceUserAccountVariables = false, bool stripNotExistingVariables = true, IDictionary<string, string> userDetails = null, bool isForConfirmationEmail = false, IDictionary<string, object> additionalReplacementData = null, bool forQuery = false)
         {


### PR DESCRIPTION
# Describe your changes

Revert a concept order to a basket if paymentOut fails and concept order is created by a convert action instead of a copy action. I did this change, because otherwise the basket will be gone when you cancel a payment or when the payment process fails. Only copies of the basket may be deleted, when a convert action is done from basket to concept order, then this convert action needs to be reverted.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [] I added new unit tests for my changes if applicable

# Related pull requests

# Link to Asana ticket
