### PR TITLE
Fixed Wiser item saves not using prefix tables correctly

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -77,6 +77,7 @@ namespace GeeksCoreLibrary.Core.Services
         public const string AutoIncrementPropertySuffix = "_auto_increment";
         public const string SaveValueAsItemLinkKey = "saveValueAsItemLink";
         public const string CurrentItemIsDestinationIdKey = "currentItemIsDestinationId";
+        public const string EntityTypeKey = "entityType";
         public const string LinkTypeNumberKey = "linkTypeNumber";
         public const string DefaultInputType = "text";
         public const string LinkOrderingFieldName = "__ordering";
@@ -1035,10 +1036,10 @@ WHERE item.id = ?itemId");
                                         destinationIds.Add(integerValue);
                                     }
 
-                                    var linkTablePrefix = await GetTablePrefixForLinkAsync(linkTypeNumber, wiserItem.EntityType);
+                                    var currentItemIsDestinationId = fieldOptions[key].ContainsKey(CurrentItemIsDestinationIdKey) && (bool) fieldOptions[key][CurrentItemIsDestinationIdKey];
+                                    var linkTablePrefix = await GetTablePrefixForLinkAsync(linkTypeNumber, currentItemIsDestinationId ? Convert.ToString(fieldOptions[key][EntityTypeKey]) : wiserItem.EntityType);
 
                                     databaseConnection.AddParameter("linkTypeNumber", linkTypeNumber);
-                                    var currentItemIsDestinationId = fieldOptions[key].ContainsKey(CurrentItemIsDestinationIdKey) && (bool) fieldOptions[key][CurrentItemIsDestinationIdKey];
 
                                     // Delete any previous links that were added via this field.
                                     // NOTE: Here we make an assumption that the given linkTypeNumber is not used for anything else!
@@ -1229,7 +1230,7 @@ SET @saveHistory = ?saveHistoryGcl;
                             }
                             else
                             {
-                                updateQueryBuilder.Add($"UPDATE {WiserTableNames.WiserItemLinkDetail} SET `key` = ?key{counter}, `value` = ?value{counter}, `long_value` = ?longValue{counter}, `groupname` = ?groupName{counter}, language_code = ?languageCode{counter} WHERE id = ?itemDetailId{counter};");
+                                updateQueryBuilder.Add($"UPDATE {linkTablePrefix}{WiserTableNames.WiserItemLinkDetail} SET `key` = ?key{counter}, `value` = ?value{counter}, `long_value` = ?longValue{counter}, `groupname` = ?groupName{counter}, language_code = ?languageCode{counter} WHERE id = ?itemDetailId{counter};");
                             }
 
                             if (alsoSaveSeoValue)
@@ -1241,7 +1242,7 @@ SET @saveHistory = ?saveHistoryGcl;
                                 }
                                 else
                                 {
-                                    updateQueryBuilder.Add($"UPDATE {WiserTableNames.WiserItemLinkDetail} SET `key` = ?key{SeoPropertySuffix}{counter}, `value` = ?value{SeoPropertySuffix}{counter}, `long_value` = ?longValue{SeoPropertySuffix}{counter}, `groupname` = ?groupName{counter}, language_code = ?languageCode{counter} WHERE id = ?itemIDetailId{counter};");
+                                    updateQueryBuilder.Add($"UPDATE {linkTablePrefix}{WiserTableNames.WiserItemLinkDetail} SET `key` = ?key{SeoPropertySuffix}{counter}, `value` = ?value{SeoPropertySuffix}{counter}, `long_value` = ?longValue{SeoPropertySuffix}{counter}, `groupname` = ?groupName{counter}, language_code = ?languageCode{counter} WHERE id = ?itemDetailId{counter};");
                                 }
                             }
 


### PR DESCRIPTION
# Describe your changes

The WiserItemsService is not saving item details and item links correctly to tables with a link prefix.
For the UPDATE query the prefix was simply forgotten. And for saving links the "currentItemIsDestinationId" setting was ignored for getting the correct link prefix.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Running Wiser with GCL locally and saving varies item details on the Fetim platform and confirm in the database the data is stored in the correct tables.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205727761850957/1206657052949247
