### PR TITLE
Disable query-caching for SQL templates when cachingminutes < 0

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -1226,7 +1226,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 queryTemplate.GroupingSettings.GroupingColumn = "id";
             }
 
-            var dataTable = await databaseConnection.GetAsync(query);
+            var dataTable = await databaseConnection.GetAsync(query,skipCache:queryTemplate.CachingMinutes<0);
             var result = dataTable.Rows.Count == 0 ? new JArray() : dataTable.ToJsonArray(queryTemplate.GroupingSettings, encryptionKey, skipNullValues, allowValueDecryption, recursive, childItemsMustHaveId);
 
             if (pusherMatches.Any())

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1292,7 +1292,7 @@ ORDER BY id ASC");
                 queryTemplate.GroupingSettings.GroupingColumn = "id";
             }
 
-            var dataTable = await databaseConnection.GetAsync(query);
+            var dataTable = await databaseConnection.GetAsync(query,skipCache:queryTemplate.CachingMinutes<0);
             var result = dataTable.Rows.Count == 0 ? new JArray() : dataTable.ToJsonArray(queryTemplate.GroupingSettings, encryptionKey, skipNullValues, allowValueDecryption, recursive, childItemsMustHaveId);
 
             if (pusherMatches.Any())


### PR DESCRIPTION
# Describe your changes

Query caching for json.jcl requests did not work at all. Now it works in basic. Default caching minutes set to -1 means no caching (so backwards compatibility is not broken). Set to 0 or >0 query caching is applied for these requests. Resulting in more then 50% speed gain (depending on the query)

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket

Add a link to the Asana ticket. Note that **_ONLY_** the URL should be added, not the name of the ticket!
