### PR TITLE
Fix/optimized loading of assamblys with nopsp

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -884,7 +884,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
                 var basketSettings = await shoppingBasketsService.GetSettingsAsync();
                 foreach (var (main, lines) in shoppingBaskets)
                 {
-                    if (paymentMethodSettings.PaymentServiceProvider.Type != PaymentServiceProviders.NoPsp && basketToConceptOrderMethod == OrderProcessBasketToConceptOrderMethods.Convert)
+                    var copyBasketToConceptOrderOnPspPayment  = (await objectsService.FindSystemObjectByDomainNameAsync("psp_copy_basket_to_concept_order","1")) == "1";
+                    if (paymentMethodSettings.PaymentServiceProvider.Type != PaymentServiceProviders.NoPsp && basketToConceptOrderMethod == OrderProcessBasketToConceptOrderMethods.Convert && copyBasketToConceptOrderOnPspPayment)
                     {
                         // Converting a basket to a concept order is only allowed for payment methods that don't go via an external PSP.
                         // Otherwise users can create an order with only one product, start a payment, go back to the website and add several more products,

--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -1497,8 +1497,12 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
             }
 
             // Build the PSP settings model based on the type of PSP.
-            var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(result.PaymentServiceProvider.Type);
-            result.PaymentServiceProvider = await paymentServiceProviderService.GetProviderSettingsAsync(result.PaymentServiceProvider);
+            if (result.PaymentServiceProvider.Type != PaymentServiceProviders.NoPsp)
+            {
+                //Only load assemblies when provider is not NoPsp 
+                var paymentServiceProviderService = paymentServiceProviderServiceFactory.GetPaymentServiceProviderService(result.PaymentServiceProvider.Type);
+                result.PaymentServiceProvider = await paymentServiceProviderService.GetProviderSettingsAsync(result.PaymentServiceProvider);
+            } 
 
             return result;
         }

--- a/GeeksCoreLibrary/GeeksCoreLibrary.csproj
+++ b/GeeksCoreLibrary/GeeksCoreLibrary.csproj
@@ -5,11 +5,11 @@
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.2.1</Version>
+    <Version>4.2.2</Version>
     <Company>Happy Horizon B.V.</Company>
     <Description>Our base/core library that we use for most of our other projects.</Description>
-    <AssemblyVersion>4.2.1.0</AssemblyVersion>
-    <FileVersion>4.2.1.0</FileVersion>
+    <AssemblyVersion>4.2.2.0</AssemblyVersion>
+    <FileVersion>4.2.2.0</FileVersion>
     <PackageDescription>Geeks Core Library</PackageDescription>
     <RepositoryUrl>https://github.com/happy-geeks/geeks-core-library.git</RepositoryUrl>
 	<RepositoryType>git</RepositoryType>


### PR DESCRIPTION
# Describe your changes

When PSP is noPsp it is not necessary to load the assembly via refactoring, because noPSP is a class within the GCL. Optimized this for better performance.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by stepping through the lines and placed an order with NoPSP, this order was placed succesfully

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket

Add a link to the Asana ticket. Note that **_ONLY_** the URL should be added, not the name of the ticket!
