### PR TITLE
Generated PDFs can copy by default

### DIFF
--- a/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
@@ -178,8 +178,8 @@ namespace GeeksCoreLibrary.Modules.GclConverters.Services
             }
 
             // Security settings.
-            converter.PdfSecurityOptions.CanEditContent = (await objectsService.FindSystemObjectByDomainNameAsync("pdf_can_edit_content")).Equals("true", StringComparison.OrdinalIgnoreCase);
-            converter.PdfSecurityOptions.CanCopyContent = (await objectsService.FindSystemObjectByDomainNameAsync("pdf_can_copy_content")).Equals("true", StringComparison.OrdinalIgnoreCase);
+            converter.PdfSecurityOptions.CanEditContent = (await objectsService.FindSystemObjectByDomainNameAsync("pdf_can_edit_content", "false")).Equals("true", StringComparison.OrdinalIgnoreCase);
+            converter.PdfSecurityOptions.CanCopyContent = (await objectsService.FindSystemObjectByDomainNameAsync("pdf_can_copy_content", "true")).Equals("true", StringComparison.OrdinalIgnoreCase);
             converter.PdfSecurityOptions.OwnerPassword = await objectsService.FindSystemObjectByDomainNameAsync("pdf_password");
 
             if (String.IsNullOrWhiteSpace(converter.PdfSecurityOptions.OwnerPassword))


### PR DESCRIPTION
# Describe your changes

Added default values for the pdf_can_copy (true)and pdf_can_edit (false) settings for when they are not set in a project.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Local run of the Cando configurator and requesting a configuration email. Checking the pdf received in the mail.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1206917764054482
