### PR TITLE
Rendering shopping basket will now also use the ExtraDataForReplacements property

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
@@ -319,6 +319,15 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket
         {
             var result = new StringBuilder();
 
+            if (ExtraDataForReplacements != null && ExtraDataForReplacements.Any())
+            {
+                extraData ??= new Dictionary<string, object>();
+                foreach (var keyValuePair in ExtraDataForReplacements)
+                {
+                    extraData.Add(keyValuePair.Key, keyValuePair.Value);
+                }
+            }
+
             if (Lines?.Count == 0)
             {
                 var template = Settings.TemplateEmpty ?? "";

--- a/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
@@ -319,6 +319,7 @@ namespace GeeksCoreLibrary.Components.ShoppingBasket
         {
             var result = new StringBuilder();
 
+            // If there is extra data saved for replacements, add it to the extra data dictionary that is used in the replacements later.
             if (ExtraDataForReplacements != null && ExtraDataForReplacements.Any())
             {
                 extraData ??= new Dictionary<string, object>();


### PR DESCRIPTION
# Describe your changes

Rendering shopping basket will now also use the ExtraDataForReplacements property. It didn't do this before, so the extraData that you can enter in the `InvokeAsync` function wasn't actually used.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I needed this functionality for a new project and there I noticed that it didn't work. After I made this change, I verified that the functionality now works correctly in that project.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1206533651519632
