### PR TITLE
When getting html to pdf settings get the default background property name from system objects.

### DIFF
--- a/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
@@ -275,6 +275,8 @@ namespace GeeksCoreLibrary.Modules.GclConverters.Services
                 ItemId = templateItemId
             };
             
+            pdfSettings.BackgroundPropertyName = await objectsService.FindSystemObjectByDomainNameAsync("pdf_backgroundpropertyname");
+            
             var query = $"SELECT `key`, CONCAT_WS('', `value`, `long_value`) AS value, language_code FROM {WiserTableNames.WiserItemDetail} WHERE item_id = ?templateItemId";
             databaseConnection.AddParameter("templateItemId", templateItemId);
             var dataTable = await databaseConnection.GetAsync(query);


### PR DESCRIPTION
# Describe your changes

The GetHtmlToPdfSettingsAsync method gets name of the background from the item details however the image upload property, which gets used to add the backrgound image to the item, adds the image to wiser_itemfile and doesn't anything to wiser_itemdetail. This means this function then can't find the image settings.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Generated a PDF with a background image added via the image_upload field. First before the change, there was no background shown. Then with the change, background was now added.

No effect when generating a PDF with a template that did not have a background

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1206533651519639
