### PR TITLE
Fix pdf settings footer being put in header.

### DIFF
--- a/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
@@ -149,7 +149,7 @@ namespace GeeksCoreLibrary.Modules.GclConverters.Services
             converter.PdfDocumentOptions.ShowFooter = (await objectsService.FindSystemObjectByDomainNameAsync("pdf_footer_show")).Equals("true", StringComparison.OrdinalIgnoreCase);
             if (String.IsNullOrWhiteSpace(settings.Footer))
             {
-                settings.Header = await objectsService.FindSystemObjectByDomainNameAsync("pdf_footer_text");
+                settings.Footer = await objectsService.FindSystemObjectByDomainNameAsync("pdf_footer_text");
             }
             if (!String.IsNullOrWhiteSpace(settings.Footer))
             {


### PR DESCRIPTION
# Describe your changes

After checking whether the footer setting was empty it got the footer text from system objects and placed it in the header.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Generated a PDF from a template

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No ticket.
