### PR TITLE
Replace references to LegacyTemplatesService type with correct type

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -45,7 +45,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
     public class TemplatesService : ITemplatesService
     {
         private readonly GclSettings gclSettings;
-        private readonly ILogger<LegacyTemplatesService> logger;
+        private readonly ILogger<TemplatesService> logger;
         private readonly IDatabaseConnection databaseConnection;
         private readonly IStringReplacementsService stringReplacementsService;
         private readonly IHttpContextAccessor httpContextAccessor;
@@ -61,9 +61,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         private readonly IReplacementsMediator replacementsMediator;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="LegacyTemplatesService"/>.
+        /// Initializes a new instance of <see cref="TemplatesService"/>.
         /// </summary>
-        public TemplatesService(ILogger<LegacyTemplatesService> logger,
+        public TemplatesService(ILogger<TemplatesService> logger,
             IOptions<GclSettings> gclSettings,
             IDatabaseConnection databaseConnection,
             IStringReplacementsService stringReplacementsService,


### PR DESCRIPTION
# Describe your changes

In the TemplateService, the logger type parameter and the xml comment on the contructor referred to the LegacyTemplatesService which is a different type. This caused some confusing logs where exceptions in new projects seemingly happened in legacy code.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I only checked whether the GCL build correctly.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No ticket
