### PR TITLE
Fixed a caching issue with page widgets

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1641,7 +1641,13 @@ ORDER BY IFNULL(linkToParent.destination_item_id, 0) ASC, IFNULL(linkToParent.or
         /// <inheritdoc />
         public async Task<List<PageWidgetModel>> GetPageWidgetsAsync(ITemplatesService templatesService, int templateId, bool includeGlobalSnippets = true)
         {
-            var results = includeGlobalSnippets ? await templatesService.GetGlobalPageWidgetsAsync() : new List<PageWidgetModel>();
+            var results = new List<PageWidgetModel>();
+
+            // Add global snippets to the page.
+            if (includeGlobalSnippets)
+            {
+                results.AddRange(await GetGlobalPageWidgetsAsync());
+            }
 
             if (templateId <= 0)
             {


### PR DESCRIPTION
# Describe your changes

When the page widgets got loaded, they were added to the list of global page widgets, but that caused the cached version of the global page widgets to be populated with the page widgets, causing every page to suddenly start loading that specific page widget. This branch fixes that by always creating a new list and populating it with both the global page widgets and the specific page widgets.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested loading a page that had a page widget, then loading another page to see if that other page didn't get the specific page template.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1199894242406919/1207147750879799)