### PR TITLE
Add support for generating mailbox parcel labels

### DIFF
--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Controllers/PostNLController.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Controllers/PostNLController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Modules.PostalServices.PostNL.Interfaces;
+using GeeksCoreLibrary.Modules.PostalServices.PostNL.Models;
 
 namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Controllers
 {
@@ -12,18 +13,23 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Controllers
 
         public PostNLController(IPostNLService postNLService)
         {
-            this.postNlService = postNLService;
+            postNlService = postNLService;
         }
         
+        /// <summary>
+        /// Generate shipping label for the given order
+        /// </summary>
+        /// <param name="model">model containing order data for which to generate the label</param>
+        /// <returns>Ok response or BadRequest if no order ids are given</returns>
         [HttpGet, Route("shipping-label")]
-        public async Task<IActionResult> GenerateShippingLabelAsync([FromQuery] string encryptedOrderIds)
+        public async Task<IActionResult> GenerateShippingLabelAsync([FromQuery] ShippingLabelRequestModel model)
         {
-            if (String.IsNullOrWhiteSpace(encryptedOrderIds))
+            if (String.IsNullOrWhiteSpace(model.EncryptedOrderIds))
             {
-                BadRequest("No order id specified");
+                return BadRequest("No order id specified");
             }
 
-            return Ok(await postNlService.GenerateShippingLabelAsync(encryptedOrderIds));
+            return Ok(await postNlService.GenerateShippingLabelAsync(model.EncryptedOrderIds, model.ParcelType));
         }
     }
 }

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Interfaces/IPostNLService.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Interfaces/IPostNLService.cs
@@ -20,21 +20,24 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Interfaces
         /// </summary>
         /// <param name="orderId">OrderId of the order a barcode must be created for</param>
         /// <param name="shippingLocation">The location the package of the order will be send to</param>
+        /// <param name="parcelType">The parcel type for which to create the barcode</param>
         /// <returns>Model containing the information about the created barcode</returns>
-        Task<BarcodeResponseModel> CreateNewBarcodeAsync(string orderId, PostNLService.ShippingLocations shippingLocation = PostNLService.ShippingLocations.Netherlands);
+        Task<BarcodeResponseModel> CreateNewBarcodeAsync(string orderId, ShippingLocations shippingLocation = ShippingLocations.Netherlands, ParcelType parcelType = ParcelType.Standard);
 
         /// <summary>
         /// Gets the settings of a specified shipping location
         /// </summary>
         /// <param name="shippingLocation">The shipping location the order must be send to</param>
+        /// <param name="parcelType">The parcel type for which to get the settings</param>
         /// <returns>Model of settings of the specified shipping location</returns>
-        Task<SettingsModel> GetSettingsAsync(PostNLService.ShippingLocations shippingLocation);
+        Task<SettingsModel> GetSettingsAsync(ShippingLocations shippingLocation, ParcelType parcelType);
 
         /// <summary>
         /// Generate the shipping label based on the specified orderId
         /// </summary>
         /// <param name="encryptedOrderIds">Comma separated string of orderIds to create a shipping label</param>
+        /// <param name="parcelType">The parcel type for which to generate the label</param>
         /// <returns>Action result containing the text for the reason of the result or error</returns>
-        Task<List<string>> GenerateShippingLabelAsync(string encryptedOrderIds);
+        Task<List<string>> GenerateShippingLabelAsync(string encryptedOrderIds, ParcelType parcelType);
     }
 }

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ParcelType.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ParcelType.cs
@@ -1,0 +1,16 @@
+namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Models;
+
+/// <summary>
+/// Specifies the type of parcel
+/// </summary>
+public enum ParcelType
+{
+    /// <summary>
+    /// Standard parcel
+    /// </summary>
+    Standard,
+    /// <summary>
+    /// Mailbox parcel
+    /// </summary>
+    Mailbox
+}

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ShippingLabelRequestModel.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ShippingLabelRequestModel.cs
@@ -1,0 +1,7 @@
+namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Models;
+
+public class ShippingLabelRequestModel
+{
+    public string EncryptedOrderIds { get; set; }
+    public ParcelType ParcelType { get; set; } = ParcelType.Standard;
+}

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ShippingLocations.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Models/ShippingLocations.cs
@@ -1,0 +1,8 @@
+namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Models;
+
+public enum ShippingLocations
+{
+    Netherlands,
+    Europe,
+    Global
+}

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Services/PostNLService.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Services/PostNLService.cs
@@ -38,8 +38,7 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             this.wiserItemsService = wiserItemsService;
         }
 
-        private static readonly string[] europeanCountries = ["AT", "IT", "BE", "LV", "BG", "LT", "HR", "LU", "CY", "CZ", "DK", "EE", "PL", "FI", "PT", "FR", "RO", "DE", "SK", "SI", "GR", "ES", "HU", "SE", "IE" ];
-
+        private static readonly List<string> europeanCountries = new() { "AT", "IT", "BE", "LV", "BG", "LT", "HR", "LU", "CY", "CZ", "DK", "EE", "PL", "FI", "PT", "FR", "RO", "DE", "SK", "SI", "GR", "ES", "HU", "SE", "IE" };
         /// <summary>
         /// Cleans the PostNL log table
         /// </summary>

--- a/GeeksCoreLibrary/Modules/PostalServices/PostNL/Services/PostNLService.cs
+++ b/GeeksCoreLibrary/Modules/PostalServices/PostNL/Services/PostNLService.cs
@@ -38,14 +38,7 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             this.wiserItemsService = wiserItemsService;
         }
 
-        public static List<string> EuropeanCountries = new() { "AT", "IT", "BE", "LV", "BG", "LT", "HR", "LU", "CY", "CZ", "DK", "EE", "PL", "FI", "PT", "FR", "RO", "DE", "SK", "SI", "GR", "ES", "HU", "SE", "IE" };
-
-        public enum ShippingLocations
-        {
-            Netherlands,
-            Europe,
-            Global
-        }
+        private static readonly string[] europeanCountries = ["AT", "IT", "BE", "LV", "BG", "LT", "HR", "LU", "CY", "CZ", "DK", "EE", "PL", "FI", "PT", "FR", "RO", "DE", "SK", "SI", "GR", "ES", "HU", "SE", "IE" ];
 
         /// <summary>
         /// Cleans the PostNL log table
@@ -55,12 +48,9 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             await databaseConnection.ExecuteAsync($"DELETE FROM {PostNlLogTableName} WHERE datetime < DATE_SUB(NOW(), INTERVAL 2 WEEK)");
         }
 
-        /// <summary>
-        /// Gets the settings for the specified shipping location
-        /// </summary>
-        /// <param name="shippingLocation"></param>
-        /// <returns></returns>
-        public async Task<SettingsModel> GetSettingsAsync(ShippingLocations shippingLocation)
+        /// <inheritdoc/>
+        public async Task<SettingsModel> GetSettingsAsync(ShippingLocations shippingLocation,
+            ParcelType parcelType = ParcelType.Standard)
         {
             var result = new SettingsModel();
             switch (shippingLocation)
@@ -93,6 +83,11 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
                     throw new ArgumentOutOfRangeException(nameof(shippingLocation), shippingLocation, null);
             }
 
+            if (parcelType == ParcelType.Mailbox)
+            {
+                result.ProductCode = "2928";
+            }
+
             return result;
         }
 
@@ -120,12 +115,8 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             return countryCode;
         }
 
-        /// <summary>
-        /// Generate the shipping label based on the specified orderId
-        /// </summary>
-        /// <param name="encryptedOrderIds">Comma separated string of orderIds to create a shipping label</param>
-        /// <returns>Action result containing the text for the reason of the result or error</returns>
-        public async Task<List<string>> GenerateShippingLabelAsync(string encryptedOrderIds)
+        /// <inheritdoc/>
+        public async Task<List<string>> GenerateShippingLabelAsync(string encryptedOrderIds, ParcelType modelParcelType)
         {
             var result = new List<string>();
 
@@ -170,7 +161,7 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
                 {
                     shippingLocation = ShippingLocations.Netherlands;
                 }
-                else if (EuropeanCountries.Any(c => c.Equals(shippingAddress.Countrycode, StringComparison.OrdinalIgnoreCase)))
+                else if (europeanCountries.Any(c => c.Equals(shippingAddress.Countrycode, StringComparison.OrdinalIgnoreCase)))
                 {
                     shippingLocation = ShippingLocations.Europe;
                 }
@@ -179,9 +170,9 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
                     shippingLocation = ShippingLocations.Global;
                 }
 
-                barcode = (await CreateNewBarcodeAsync(orderId, shippingLocation))?.Barcode;
+                barcode = (await CreateNewBarcodeAsync(orderId, shippingLocation, modelParcelType))?.Barcode;
 
-                var settings = await GetSettingsAsync(shippingLocation);
+                var settings = await GetSettingsAsync(shippingLocation, modelParcelType);
                 var postNlRequest = new ShipmentRequestModel
                 {
                     Customer = new CustomerModel
@@ -295,13 +286,9 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             return result;
         }
 
-        /// <summary>
-        /// Creates a new barcode using the PostNL Api
-        /// </summary>
-        /// <param name="orderId">The orderId</param>
-        /// <param name="shippingLocation">The location the order will be send to</param>
-        /// <returns>A model containing the barcode created using the api</returns>
-        public async Task<BarcodeResponseModel> CreateNewBarcodeAsync(string orderId, ShippingLocations shippingLocation = ShippingLocations.Netherlands)
+        /// <inheritdoc/>
+        public async Task<BarcodeResponseModel> CreateNewBarcodeAsync(string orderId,
+            ShippingLocations shippingLocation = ShippingLocations.Netherlands, ParcelType parcelType = ParcelType.Standard)
         {
             var exceptionMessage = "";
             var responseString = "";
@@ -310,8 +297,8 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             try
             {
                 var restClient = new RestClient(gclSettings.PostNlApiBaseUrl);
-                var restRequest = new RestRequest("/shipment/v1_1/barcode", Method.Get);
-                var settings = await GetSettingsAsync(shippingLocation);
+                var restRequest = new RestRequest("/shipment/v2_2/barcode");
+                var settings = await GetSettingsAsync(shippingLocation, parcelType);
 
                 restRequest.AddQueryParameter("CustomerCode", settings.CustomerCode);
                 restRequest.AddQueryParameter("CustomerNumber", settings.CustomerNumber);
@@ -347,12 +334,7 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             }
         }
 
-        /// <summary>
-        /// Generates a new label using the PostNL api
-        /// </summary>
-        /// <param name="orderId">The orderId of the order the label must be created for</param>
-        /// <param name="request">Request model containing all the data used for creating the label</param>
-        /// <returns>Model containing the information of the generated label</returns>
+        /// <inheritdoc/>
         public async Task<ShipmentResponseModel> CreateTrackTraceLabelAsync(string orderId, ShipmentRequestModel request)
         {
             var exceptionMessage = "";
@@ -362,7 +344,7 @@ namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Services
             try
             {
                 var restClient = new RestClient(gclSettings.PostNlApiBaseUrl);
-                var restRequest = new RestRequest("/v1/shipment?confirm=true", Method.Post);
+                var restRequest = new RestRequest("/shipment/v2_2/label?confirm=true", Method.Post);
                 requestString = JsonConvert.SerializeObject(request, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 restRequest.AddParameter("application/json", requestString, ParameterType.RequestBody);
                 restRequest.AddJsonBody(request);


### PR DESCRIPTION
# Describe your changes

Adds option to generate POSTNL label for mailbox parcels. This uses to product code for unsorted mail.

Potential breaking changes: The ShippingLocations enum was moved to the namespace GeeksCoreLibrary.Modules.PostalServices.PostNL.Models

When generating labels via the POSTNL API this now used a higher version of the API from v1 to v2.2. In my tests I didn't find any issues but considering it's a major version difference, I think it is at least significant enough to mention.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Generated labels with new option for mailbox parcels and standard, inspecting the response for the API to check whether the correct label type was generated and checking whether the PDF was generated correctly

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1205247186052420/
