### PR TITLE
Fix the save history setting on entity level

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -229,6 +229,11 @@ namespace GeeksCoreLibrary.Core.Services
             {
                 wiserItem.ModuleId = entityTypeSettings.ModuleId;
             }
+            
+            if (!entityTypeSettings!.SaveHistory)
+            {
+                saveHistory = false;
+            }
       
             var retries = 0;
             var transactionCompleted = false;
@@ -638,6 +643,11 @@ VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)");
             // Get the settings of the entity type.
             var entityTypeSettings = await wiserItemsService.GetEntityTypeSettingsAsync(wiserItem.EntityType, wiserItem.ModuleId);
             var tablePrefix = wiserItemsService.GetTablePrefixForEntity(entityTypeSettings);
+            
+            if (!entityTypeSettings!.SaveHistory)
+            {
+                saveHistory = false;
+            }
 
             var retries = 0;
             var transactionCompleted = false;
@@ -2899,6 +2909,7 @@ WHERE {String.Join(" AND ", where)}";
                         ShowOverviewTab = !dataRow.IsNull("show_overview_tab") && Convert.ToBoolean(dataRow["show_overview_tab"]),
                         ShowTitleField = !dataRow.IsNull("show_title_field") && Convert.ToBoolean(dataRow["show_title_field"]),
                         DisplayName = dataRow.Field<string>("displayName"),
+                        SaveHistory = Convert.ToBoolean(dataRow["save_history"]),
                         DeleteAction = dataRow.Field<string>("delete_action")?.ToLowerInvariant() switch
                         {
                             null => EntityDeletionTypes.Archive,


### PR DESCRIPTION
# Describe your changes

The GCL did not read this setting from the database and didn't use it for create and update. Deleted used it but was always false since the value was not read.

This change will read the value for the save history setting and add it to the create and update calls.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested this by placing the GCL in WTS and see if with the save history setting on and off the correct results were given. Repeated this process with Wiser.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1199894242406919/1206810943709101