### PR TITLE
Allow CSS and JS templates in partial templates

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Interfaces/IPagesService.cs
@@ -34,8 +34,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="javascriptTemplates">A list with IDs of javascript templates, from the template module of Wiser, that should be added to this page.</param>
         /// <param name="bodyHtml">The complete HTML of the body of this page.</param>
         /// <param name="templateId">Optional: The ID of the template that is used for this page. Leave empty if you're creating a view model for something that is not a template from the Wiser template module.</param>
+        /// <param name="useGeneralLayout">Optional: Whether the page should use the website's general layout.</param>
         /// <returns>The model for the view.</returns>
-        Task<PageViewModel> CreatePageViewModelAsync(List<PageResourceModel> externalCss, List<int> cssTemplates, List<PageResourceModel> externalJavascript, List<int> javascriptTemplates, string bodyHtml, int templateId = 0);
+        Task<PageViewModel> CreatePageViewModelAsync(List<PageResourceModel> externalCss, List<int> cssTemplates, List<PageResourceModel> externalJavascript, List<int> javascriptTemplates, string bodyHtml, int templateId = 0, bool useGeneralLayout = true);
 
         /// <summary>
         /// Sets the SEO meta data for the current page.

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -195,7 +195,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<PageViewModel> CreatePageViewModelAsync(List<PageResourceModel> externalCss, List<int> cssTemplates, List<PageResourceModel> externalJavascript, List<int> javascriptTemplates, string bodyHtml, int templateId = 0)
+        public async Task<PageViewModel> CreatePageViewModelAsync(List<PageResourceModel> externalCss, List<int> cssTemplates, List<PageResourceModel> externalJavascript, List<int> javascriptTemplates, string bodyHtml, int templateId = 0, bool useGeneralLayout = true)
         {
             var viewModel = new PageViewModel();
             var currentUrl = HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext).ToString();
@@ -205,30 +205,33 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
 
             viewModel.Widgets = await templatesService.GetPageWidgetsAsync(templateId);
 
-            // Add CSS for all pages.
-            var generalStandardCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css);
-            externalCss.AddRange(generalStandardCss.ExternalFiles);
-            if (!String.IsNullOrWhiteSpace(generalStandardCss.Content))
+            if (useGeneralLayout)
             {
-                viewModel.Css.GeneralStandardCssFileName = $"/css/gcl_general.css?mode=Standard&c={generalStandardCss.LastChangeDate:yyyyMMddHHmmss}";
-            }
+                // Add CSS for all pages.
+                var generalStandardCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css);
+                externalCss.AddRange(generalStandardCss.ExternalFiles);
+                if (!String.IsNullOrWhiteSpace(generalStandardCss.Content))
+                {
+                    viewModel.Css.GeneralStandardCssFileName = $"/css/gcl_general.css?mode=Standard&c={generalStandardCss.LastChangeDate:yyyyMMddHHmmss}";
+                }
 
-            var generalInlineHeadCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.InlineHead);
-            if (!String.IsNullOrWhiteSpace(generalInlineHeadCss.Content))
-            {
-                viewModel.Css.GeneralInlineHeadCss = generalInlineHeadCss.Content;
-            }
+                var generalInlineHeadCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.InlineHead);
+                if (!String.IsNullOrWhiteSpace(generalInlineHeadCss.Content))
+                {
+                    viewModel.Css.GeneralInlineHeadCss = generalInlineHeadCss.Content;
+                }
 
-            var generalSyncFooterCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.SyncFooter);
-            if (!String.IsNullOrWhiteSpace(generalSyncFooterCss.Content))
-            {
-                viewModel.Css.GeneralSyncFooterCssFileName = $"/css/gcl_general.css?mode=SyncFooter&c={generalSyncFooterCss.LastChangeDate:yyyyMMddHHmmss}";
-            }
+                var generalSyncFooterCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.SyncFooter);
+                if (!String.IsNullOrWhiteSpace(generalSyncFooterCss.Content))
+                {
+                    viewModel.Css.GeneralSyncFooterCssFileName = $"/css/gcl_general.css?mode=SyncFooter&c={generalSyncFooterCss.LastChangeDate:yyyyMMddHHmmss}";
+                }
 
-            var generalAsyncFooterCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.AsyncFooter);
-            if (!String.IsNullOrWhiteSpace(generalAsyncFooterCss.Content))
-            {
-                viewModel.Css.GeneralAsyncFooterCssFileName = $"/css/gcl_general.css?mode=AsyncFooter&c={generalAsyncFooterCss.LastChangeDate:yyyyMMddHHmmss}";
+                var generalAsyncFooterCss = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Css, ResourceInsertModes.AsyncFooter);
+                if (!String.IsNullOrWhiteSpace(generalAsyncFooterCss.Content))
+                {
+                    viewModel.Css.GeneralAsyncFooterCssFileName = $"/css/gcl_general.css?mode=AsyncFooter&c={generalAsyncFooterCss.LastChangeDate:yyyyMMddHHmmss}";
+                }
             }
 
             // Add css for this specific page.
@@ -298,40 +301,44 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 }
             }
 
-            // Add JavaScript for all pages.
             var moveAllJavaScriptToBottom = (await objectsService.FindSystemObjectByDomainNameAsync("javascriptmovetobottom", "false")).Equals("true", StringComparison.OrdinalIgnoreCase);
-            var generalStandardJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js);
-            externalJavascript.AddRange(generalStandardJavaScript.ExternalFiles);
-            if (!String.IsNullOrWhiteSpace(generalStandardJavaScript.Content))
+
+            if (useGeneralLayout)
             {
-                if (moveAllJavaScriptToBottom)
+                // Add JavaScript for all pages.
+                var generalStandardJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js);
+                externalJavascript.AddRange(generalStandardJavaScript.ExternalFiles);
+                if (!String.IsNullOrWhiteSpace(generalStandardJavaScript.Content))
+                {
+                    if (moveAllJavaScriptToBottom)
+                    {
+                        viewModel.Javascript.GeneralSyncFooterJavaScriptFileName ??= new List<string>();
+                        viewModel.Javascript.GeneralSyncFooterJavaScriptFileName.Add($"/scripts/gcl_general.js?mode=Standard&c={generalStandardJavaScript.LastChangeDate:yyyyMMddHHmmss}");
+                    }
+                    else
+                    {
+                        viewModel.Javascript.GeneralStandardJavaScriptFileName = $"/scripts/gcl_general.js?mode=Standard&c={generalStandardJavaScript.LastChangeDate:yyyyMMddHHmmss}";
+                    }
+                }
+
+                var generalInlineHeadJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.InlineHead);
+                if (!String.IsNullOrWhiteSpace(generalInlineHeadJavaScript.Content))
+                {
+                    viewModel.Javascript.GeneralInlineHeadJavaScript = generalInlineHeadJavaScript.Content;
+                }
+
+                var generalSyncFooterJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.SyncFooter);
+                if (!String.IsNullOrWhiteSpace(generalSyncFooterJavaScript.Content))
                 {
                     viewModel.Javascript.GeneralSyncFooterJavaScriptFileName ??= new List<string>();
-                    viewModel.Javascript.GeneralSyncFooterJavaScriptFileName.Add($"/scripts/gcl_general.js?mode=Standard&c={generalStandardJavaScript.LastChangeDate:yyyyMMddHHmmss}");
+                    viewModel.Javascript.GeneralSyncFooterJavaScriptFileName.Add($"/scripts/gcl_general.js?mode=SyncFooter&c={generalSyncFooterJavaScript.LastChangeDate:yyyyMMddHHmmss}");
                 }
-                else
+
+                var generalAsyncFooterJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.AsyncFooter);
+                if (!String.IsNullOrWhiteSpace(generalAsyncFooterJavaScript.Content))
                 {
-                    viewModel.Javascript.GeneralStandardJavaScriptFileName = $"/scripts/gcl_general.js?mode=Standard&c={generalStandardJavaScript.LastChangeDate:yyyyMMddHHmmss}";
+                    viewModel.Javascript.GeneralAsyncFooterJavaScriptFileName = $"/scripts/gcl_general.js?mode=AsyncFooter&c={generalAsyncFooterJavaScript.LastChangeDate:yyyyMMddHHmmss}";
                 }
-            }
-
-            var generalInlineHeadJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.InlineHead);
-            if (!String.IsNullOrWhiteSpace(generalInlineHeadJavaScript.Content))
-            {
-                viewModel.Javascript.GeneralInlineHeadJavaScript = generalInlineHeadJavaScript.Content;
-            }
-
-            var generalSyncFooterJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.SyncFooter);
-            if (!String.IsNullOrWhiteSpace(generalSyncFooterJavaScript.Content))
-            {
-                viewModel.Javascript.GeneralSyncFooterJavaScriptFileName ??= new List<string>();
-                viewModel.Javascript.GeneralSyncFooterJavaScriptFileName.Add($"/scripts/gcl_general.js?mode=SyncFooter&c={generalSyncFooterJavaScript.LastChangeDate:yyyyMMddHHmmss}");
-            }
-
-            var generalAsyncFooterJavaScript = await templatesService.GetGeneralTemplateValueAsync(TemplateTypes.Js, ResourceInsertModes.AsyncFooter);
-            if (!String.IsNullOrWhiteSpace(generalAsyncFooterJavaScript.Content))
-            {
-                viewModel.Javascript.GeneralAsyncFooterJavaScriptFileName = $"/scripts/gcl_general.js?mode=AsyncFooter&c={generalAsyncFooterJavaScript.LastChangeDate:yyyyMMddHHmmss}";
             }
 
             // Add Javascript for this specific page.
@@ -405,7 +412,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             // Get SEO data and replace the body with data from seo module if applicable.
-            if (await seoService.SeoModuleIsEnabledAsync())
+            if (useGeneralLayout && await seoService.SeoModuleIsEnabledAsync())
             {
                 viewModel.MetaData = await seoService.GetSeoDataForPageAsync(HttpContextHelpers.GetOriginalRequestUri(httpContextAccessor?.HttpContext));
 
@@ -454,7 +461,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             }
 
             // Handle any left over seo module things.
-            if (bodyHtml.Contains("[{seomodule_"))
+            if (useGeneralLayout && bodyHtml.Contains("[{seomodule_"))
             {
                 bodyHtml = bodyHtml.Replace("[{seomodule_content}]", "", StringComparison.OrdinalIgnoreCase);
                 bodyHtml = Regex.Replace(bodyHtml, @"\[{seomodule_.*?}\|(.*?)\]", "$1");
@@ -479,6 +486,8 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
             viewModel.Css.ExternalCss.AddRange(externalCss);
             viewModel.Javascript.ExternalJavascript.AddRange(externalScripts);
             viewModel.Body = bodyHtml;
+
+            if (!useGeneralLayout) return viewModel;
 
             // Add viewport.
             var viewportSystemObjectValue = await objectsService.FindSystemObjectByDomainNameAsync("metatag_viewport", "false");


### PR DESCRIPTION
# Describe your changes

Partials templates can now be loaded with CSS and JS templates if they're linked directly to the partial template. If there are CSS and/or JS templates linked to the partial HTML template, a basic view is generated. If no CSS and JS templates are linked, only the partial template's HTML will be returned.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested partial views with and without linked CSS and/or JS templates and checked if the partial template **with** resources had a basic view, and the partial template **without** resources only returned the partial template's HTML.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1200346761113317/1207345825491538)