### PR TITLE
Set original_price if not exists when adding coupon

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -3018,6 +3018,12 @@ WHERE coupon.entity_type = 'coupon'", true);
                     {
                         continue;
                     }
+                    
+                    var originalPrice = line.GetDetailValue(Constants.OriginalPricePropertyName);
+                    if (String.IsNullOrEmpty(originalPrice))
+                    {
+                        line.SetDetail(Constants.OriginalPricePropertyName, line.GetDetailValue<decimal>(settings.PricePropertyName));
+                    }
 
                     totalPrice += await GetLinePriceAsync(shoppingBasket, line, settings, useOriginalPrice: divideDiscountOverProducts);
                 }
@@ -3030,6 +3036,12 @@ WHERE coupon.entity_type = 'coupon'", true);
                     if (excludedItems.Any(item => item.ItemId == itemId))
                     {
                         continue;
+                    }
+
+                    var originalPrice = line.GetDetailValue(Constants.OriginalPricePropertyName);
+                    if (String.IsNullOrEmpty(originalPrice))
+                    {
+                        line.SetDetail(Constants.OriginalPricePropertyName, line.GetDetailValue<decimal>(settings.PricePropertyName));
                     }
 
                     totalPrice += await GetLinePriceAsync(shoppingBasket, line, settings);


### PR DESCRIPTION
# Describe your changes

In handleCoupon setoriginal_price itemdetail to basket lines to the price value if it doesn't exist. Without this value the calculation later in this method results in a price of 0 which causes the coupon to be seen as invalid.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1206533651519632
