### PR TITLE
Fix WiserItemLinkDetail index definition

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -98,8 +98,8 @@ public class WiserTableDefinitions
             {
                 new(WiserTableNames.WiserItemLinkDetail, "itemlink_key", IndexTypes.Unique, new List<string> {"itemlink_id", "key", "language_code"}),
                 new(WiserTableNames.WiserItemLinkDetail, "key_value", IndexTypes.Normal, new List<string> {"key(50)", "value(100)"}),
-                new(WiserTableNames.WiserItemLinkDetail, "itemlink_id_key_value", IndexTypes.Normal, new List<string> {"item_id", "key(40)", "value(40)"}),
-                new(WiserTableNames.WiserItemLinkDetail, "itemlink_id_group", IndexTypes.Normal, new List<string> {"item_id", "groupname", "key(40)"})
+                new(WiserTableNames.WiserItemLinkDetail, "itemlink_id_key_value", IndexTypes.Normal, new List<string> {"itemlink_id", "key(40)", "value(40)"}),
+                new(WiserTableNames.WiserItemLinkDetail, "itemlink_id_group", IndexTypes.Normal, new List<string> {"itemlink_id", "groupname", "key(40)"})
             }
         },
 


### PR DESCRIPTION
# Describe your changes

The index WiserItemLinkDetail table definition was on a column that didn't exist. 
The `itemlink_id_key_value` and `itemlink_id_group` indexes were put on item_id but this table has an itemlink_id column instead.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

After making this change CheckAndUpdateTablesAsync was able to run properly.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1199995500457439/1207599134140250
