### PR TITLE
Fixed caching problem with baskets

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -409,7 +409,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     {
                         // Retrieve the TempData object, but make sure it doesn't cause a NullReferenceException.
                         var tempData = httpContextAccessor.HttpContext?.Items;
-                        var dataKey = $"ShoppingBasketQueriesExecuted_{settings.CookieName}";
+                        var dataKey = $"ShoppingBasketQueriesExecuted_{itemId}";
                         var allowGeneralQueries = tempData == null || !tempData.ContainsKey(dataKey) || Convert.ToInt32(tempData[dataKey]) != 1;
 
                         // Get extra details on line level, overwrite existing details.
@@ -2854,15 +2854,7 @@ WHERE coupon.entity_type = 'coupon'", true);
                 return;
             }
 
-            var user = await accountsService.GetUserDataFromCookieAsync();
-            var extraReplacements = new Dictionary<string, object>
-            {
-                { "Account_MainUserId", user.MainUserId },
-                { "Account_UserId", user.UserId },
-                { "AccountWiser2_MainUserId", user.MainUserId },
-                { "AccountWiser2_UserId", user.UserId }
-            };
-            query = stringReplacementsService.DoHttpRequestReplacements(await ReplaceBasketInTemplateAsync(shoppingBasket, basketLines, settings, stringReplacementsService.DoSessionReplacements(stringReplacementsService.DoReplacements(query, extraReplacements, forQuery: true), true), stripNotExistingVariables: false, forQuery: true), true);
+            query = stringReplacementsService.DoHttpRequestReplacements(await ReplaceBasketInTemplateAsync(shoppingBasket, basketLines, settings, stringReplacementsService.DoSessionReplacements(await accountsService.DoAccountReplacementsAsync(query, forQuery: true), true), stripNotExistingVariables: false, forQuery: true), true);
 
             var queryResult = await databaseConnection.GetAsync(query, true);
 


### PR DESCRIPTION
# Describe your changes

Fixed problem that extra data query results were cached globally instead of per basket. This caused problems for projects that allow multiple baskets at once.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I have tested this with the customer were we noticed this problem.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1206533774168792
