### PR TITLE
Fixed problem that links were sometimes not merged when they should be

### DIFF
--- a/GeeksCoreLibrary/Modules/Branches/Helpers/BranchesHelpers.cs
+++ b/GeeksCoreLibrary/Modules/Branches/Helpers/BranchesHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Branches.Models;
 
@@ -61,7 +60,7 @@ namespace GeeksCoreLibrary.Modules.Branches.Helpers
         /// <param name="action">The action from wiser_history.</param>
         /// <param name="objectId">The item_id from wiser_history.</param>
         /// <param name="tableName">The table_name from wiser_history.</param>
-        public static void TrackObjectAction(List<ObjectCreatedInBranchModel> trackedObjects, string action, ulong objectId, string tableName)
+        public static void TrackObjectAction(List<ObjectCreatedInBranchModel> trackedObjects, string action, string objectId, string tableName)
         {
             var wiserObject = trackedObjects.FirstOrDefault(i => i.ObjectId == objectId && String.Equals(i.TableName, tableName, StringComparison.OrdinalIgnoreCase));
             switch (action)

--- a/GeeksCoreLibrary/Modules/Branches/Models/ObjectCreatedInBranchModel.cs
+++ b/GeeksCoreLibrary/Modules/Branches/Models/ObjectCreatedInBranchModel.cs
@@ -8,7 +8,7 @@ public class ObjectCreatedInBranchModel
     /// <summary>
     /// Gets or sets the ID of the object.
     /// </summary>
-    public ulong ObjectId { get; set; }
+    public string ObjectId { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the table that contains the object.


### PR DESCRIPTION
# Describe your changes

Fixed problem that links were sometimes not merged when they should be. This was caused by the fact that the ID of `wiser_itemlink` is not saved in `wiser_history`, but this code assumed that it was.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I have tested these changes by making a fork database of a backup just before the moment that the original problem occurred. I then verified that I could reproduce the problem before making any changes and then tested my changes to see if they fixed the problem, which they did, and not cause new probems, which they didn't.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser-task-scheduler/pull/203

# Link to Asana ticket

https://app.asana.com/0/7257459017111/1207597501842581/1207646424960318/f
