### PR TITLE
Added wiser_history with new column "target_id" to WiserTableDefinitions

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -1055,6 +1055,28 @@ public class WiserTableDefinitions
                 new(WiserTableNames.GclRequestLog, "idx_host", IndexTypes.Normal, new List<string> {"host", "path", "method"}),
                 new(WiserTableNames.GclRequestLog, "idx_path", IndexTypes.Normal, new List<string> {"path", "method"})
             }
+        },
+
+        // wiser_history
+        new WiserTableDefinitionModel
+        {
+            Name = WiserTableNames.WiserHistory,
+            LastUpdate = new DateTime(2024, 7, 18),
+            Columns = new List<ColumnSettingsModel>
+            {
+                new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
+                new("action", MySqlDbType.VarChar, 255, notNull: true),
+                new("tablename", MySqlDbType.VarChar, 255, notNull: true),
+                new("item_id", MySqlDbType.UInt64, notNull: true, defaultValue: "0"),
+                new("changed_on", MySqlDbType.DateTime, notNull: true, defaultValue: "CURRENT_TIMESTAMP"),
+                new("changed_by", MySqlDbType.VarChar, 50, notNull: true, defaultValue: ""),
+                new("field", MySqlDbType.VarChar, 255, notNull: true, defaultValue: ""),
+                new("oldvalue", MySqlDbType.MediumText),
+                new("newvalue", MySqlDbType.MediumText),
+                new("language_code", MySqlDbType.VarChar, 5, notNull: true, defaultValue: ""),
+                new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
+                new("target_id", MySqlDbType.UInt64, notNull: true, defaultValue: "0")
+            }
         }
     };
 }


### PR DESCRIPTION
# Describe your changes

Added `wiser_history` with new column `target_id` to `WiserTableDefinitions`. This is needed for being able to properly merge changes that are done in `wiser_itemdetail` tables when merging a Wiser branch. Some changes, such as changes to `language_code` and `key`, were never merged.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I tested this by making several test branches in the wiser demo database and doing lots of test merges there.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser/pull/651
https://github.com/happy-geeks/wiser-task-scheduler/pull/222

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1207370849820110
