### PR TITLE
Improved query caching

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -89,6 +90,12 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             cacheName.Append(query.ToSha512Simple());
             foreach (var (key, value) in parameters.OrderBy(item => item.Key))
             {
+                if (!query.Contains($"?{key}", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Don't include parameters that are not used in the query.
+                    continue;
+                }
+
                 cacheName.Append($"{key}={value}");
             }
 
@@ -97,7 +104,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 async cacheEntry =>
                 {
                     cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;
-                    return await databaseConnection.GetAsync(query);
+                    return await databaseConnection.GetAsync(query, cleanUp: cleanUp, useWritingConnectionIfAvailable: useWritingConnectionIfAvailable);
                 }, cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Database));
         }
 


### PR DESCRIPTION
# Describe your changes

The query caching in GCL adds SQL parameters to the cache key, to make sure that the same query with different parameter values would never return the same result. There was a problem with this however; if parameters were added that aren't used in that particular query, then that would also cause multiple cache entries, even though that's not necessary. This caused an issue that queries were not cached enough, because there would often be parameters added to the connection that are needed for other queries. This PR fixes that issue by only using parameters that are actually used in the query that is being cached.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By running the GCL in a random webshop and debugging the code to see if the queries get cached better now.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No Asana ticket. This issue was found thanks to In-vista.
