### PR TITLE
Removed configurator cache setting

### DIFF
--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -204,11 +204,6 @@ namespace GeeksCoreLibrary.Core.Models
         public TimeSpan DefaultWiserItemsCacheDuration { get; set; } = new(1, 0, 0);
 
         /// <summary>
-        /// The amount of time to cache Configurators.
-        /// </summary>
-        public TimeSpan DefaultConfiguratorsCacheDuration { get; set; } = new(1, 0, 0);
-
-        /// <summary>
         /// The amount of time to cache various aspects of the ShoppingBasket.
         /// </summary>
         public TimeSpan DefaultShoppingBasketsCacheDuration { get; set; } = new(1, 0, 0);


### PR DESCRIPTION
# Describe your changes

The configurator cache setting has no purpose anymore, so it's been removed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested if the project still compiles. The setting wasn't actually used anymore, so there's nothing to test.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira issue key

CON-286