### PR TITLE
Fixed NRE for missing logger

### DIFF
--- a/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
@@ -180,7 +180,8 @@ namespace GeeksCoreLibrary.Core.Extensions
                 }
                 catch (Exception exception)
                 {
-                    builder.ApplicationServices.GetService<ILogger>().LogError(exception, "Error while updating tables.");
+                    var logger = builder.ApplicationServices.GetService<ILogger>();
+                    logger?.LogError(exception, "Error while updating tables.");
                 }
             });
 


### PR DESCRIPTION
# Describe your changes

In the startup functions in the GCL a NullReferenceException would occur if no logger is set when updating tables failed.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tried to run the project that was affected by this bug again after the fix and confirmed it could start up without issues.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No Asana ticket, ran into this issue while trying to debug a project.