### PR TITLE
Cache-Control middleware

### DIFF
--- a/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
+++ b/GeeksCoreLibrary/Core/Extensions/ConfigurationServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ namespace GeeksCoreLibrary.Core.Extensions
 
             builder.UseMiddleware<AddAntiForgeryMiddleware>();
             builder.UseMiddleware<OutputCachingMiddleware>();
+            builder.UseMiddleware<AddCacheHeaderValueMiddleware>();
             builder.UseStaticFiles();
 
             builder.UseRouting();

--- a/GeeksCoreLibrary/Core/Middlewares/AddCacheHeaderValueMiddleware.cs
+++ b/GeeksCoreLibrary/Core/Middlewares/AddCacheHeaderValueMiddleware.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GeeksCoreLibrary.Core.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GeeksCoreLibrary.Core.Middlewares;
+
+public class AddCacheHeaderValueMiddleware
+{
+    private readonly RequestDelegate next;
+    private readonly ILogger<AddCacheHeaderValueMiddleware> logger;
+    private readonly GclSettings gclSettings;
+
+    public AddCacheHeaderValueMiddleware(RequestDelegate next, ILogger<AddCacheHeaderValueMiddleware> logger, IOptions<GclSettings> gclSettings)
+    {
+        this.next = next;
+        this.logger = logger;
+        this.gclSettings = gclSettings.Value;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        logger.LogDebug("Invoked AddCacheHeaderValueMiddleware");
+            
+        // Get the path of the current HTTP request.
+        var requestPath = context.Request.Path.Value;
+            
+        // Retrieve the list of cache-control rules from the app settings.
+        var cacheControlRules = gclSettings.CacheControlRules;
+
+        // Find the first rule that matches the current request path (case-insensitive comparison).
+        var matchingRule = cacheControlRules?.FirstOrDefault(rule => rule.FilePath.Equals(requestPath, StringComparison.OrdinalIgnoreCase));
+
+        // If a matching rule is found, set the Cache-Control header in the response.
+        if (matchingRule != null)
+        {
+            context.Response.Headers["Cache-Control"] = matchingRule.HeaderValue;
+            logger.LogDebug("Cache-Control header set to '{HeaderValue}' for path '{RequestPath}'.", matchingRule.HeaderValue, requestPath);
+        }
+
+        await next.Invoke(context);
+    }
+}

--- a/GeeksCoreLibrary/Core/Models/CacheControlRuleSettingsModel.cs
+++ b/GeeksCoreLibrary/Core/Models/CacheControlRuleSettingsModel.cs
@@ -1,0 +1,14 @@
+﻿namespace GeeksCoreLibrary.Core.Models;
+
+public class CacheControlRuleSettingsModel
+{
+    /// <summary>
+    /// Gets or sets the file path that requires a specific cache-control header.
+    /// </summary>
+    public string FilePath { get; set; }
+        
+    /// <summary>
+    /// Gets or sets the cache-control header value to be applied to the specified file path.
+    /// </summary>
+    public string HeaderValue { get; set; }
+}

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -271,6 +271,6 @@ namespace GeeksCoreLibrary.Core.Models
         /// <summary>
         /// List of rules defining which cache-control headers to apply to specific file paths.
         /// </summary>
-        public List<CacheControlRuleSettingsModel> CacheControlRules { get; set; } = [];
+        public List<CacheControlRuleSettingsModel> CacheControlRules { get; set; } = new List<CacheControlRuleSettingsModel>();
     }
 }

--- a/GeeksCoreLibrary/Core/Models/GclSettings.cs
+++ b/GeeksCoreLibrary/Core/Models/GclSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Modules.Communication.Models;
@@ -266,5 +267,10 @@ namespace GeeksCoreLibrary.Core.Models
         /// Settings for request logging.
         /// </summary>
         public RequestLoggingOptions RequestLoggingOptions { get; set; } = new();
+
+        /// <summary>
+        /// List of rules defining which cache-control headers to apply to specific file paths.
+        /// </summary>
+        public List<CacheControlRuleSettingsModel> CacheControlRules { get; set; } = [];
     }
 }


### PR DESCRIPTION
# Describe your changes

Add middleware for configuring cache-control header values for file paths via appsettings.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Set the following appsettings in a development web project:
```
"GCL": {
    ...
    "CacheControlRules": [
      {
        "filePath" :  "//scripts/jjl-core.min.js", <-- don't ask me why the web project is requesting "//"
        "headerValue":  "max-age=12345"
      }
    ]
  }
```
And then checked within the chrome devtools in the gordijnen vadainbv configurator, in which the given filePath is being requested, is the only one with a Source-Control header with value max-age=12345.

Given Cache-Control rule:
![image](https://github.com/user-attachments/assets/b1c40184-3056-49e6-a06e-b43a54f6b5d8)

Other JS requests without Cache-Control rules:
![image](https://github.com/user-attachments/assets/445d80cd-bf51-4d68-a191-a02b436307e6)

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1199894242406919/1207022541266964
