### PR TITLE
Removed virtual columns from wiser_itemdetail and wiser_itemlinkdetail in table definations.

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -64,8 +64,6 @@ public class WiserTableDefinitions
                 new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                 new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                 new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
-                new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
-                new("value_as_decimal", MySqlDbType.Decimal, 65, 30, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
                 new("long_value", MySqlDbType.MediumText)
             },
             Indexes = new List<IndexSettingsModel>
@@ -90,8 +88,6 @@ public class WiserTableDefinitions
                 new("groupname", MySqlDbType.VarChar, 100, notNull: true, defaultValue: "", comment: "optionele groepering van items, zoals een 'specs' tabel"),
                 new("key", MySqlDbType.VarChar, 100, notNull: true, defaultValue: ""),
                 new("value", MySqlDbType.VarChar, 1000, notNull: true, defaultValue: ""),
-                new("value_as_int", MySqlDbType.Int64, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS SIGNED)"),
-                new("value_as_decimal", MySqlDbType.Decimal, 65, 30, isVirtual: true, virtualType: VirtualTypes.Virtual, virtualExpression: "CAST(`value` AS DECIMAL(65,30))"),
                 new("long_value", MySqlDbType.MediumText, comment: "Voor waardes die niet in 'value' passen, zoals van HTMLeditors")
             },
             Indexes = new List<IndexSettingsModel>


### PR DESCRIPTION
# Describe your changes

Removed virtual columns from table definitions so that they are no longer added to (new) databases, we don't use them anymore.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

There is nothing to test here.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser/pull/709

# Link to Asana ticket

https://app.asana.com/0/29553867016121/1207008950317958
