### PR TITLE
Don't use html encoding for regex pattern attribute in order processservice

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCheckoutSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCheckoutSettingsModel.cs
@@ -57,14 +57,14 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Models
         internal string TemplateFieldError { get; }
 
         [DefaultValue(@"<div id='container_{fieldId}' class='field {errorClass} {fieldClass}'>
-    <input type='{inputType}' id='{fieldId}' name='{fieldId}' placeholder='{placeholder}' {required} {pattern} value='{value}' {tabindex} />
+    <input type='{inputType}' id='{fieldId}' name='{fieldId}' placeholder='{placeholder}' {required} {pattern:Raw} value='{value}' {tabindex} />
     [if({label}!)]<label for='{fieldId}'>{label}</label>[endif]
     {error}
 </div>")]
         internal string TemplateInputField { get; }
 
         [DefaultValue(@"<div id='container_{fieldId}' class='field multi-line {errorClass} {fieldClass}'>
-    <textarea type='{inputType}' id='{fieldId}' name='{fieldId}' placeholder='{placeholder}' {required} {pattern} {tabindex}>{value}</textarea>
+    <textarea type='{inputType}' id='{fieldId}' name='{fieldId}' placeholder='{placeholder}' {required} {pattern:Raw} {tabindex}>{value}</textarea>
     [if({label}!)]<label for='{fieldId}'>{label}</label>[endif]
     {error}
 </div>")]


### PR DESCRIPTION
# Describe your changes

In place of the {Pattern} replacement the GCL would try to add `pattern='{field.Pattern}'`. Because of the HTML encoding the single quotes would get replaced. Then there would be double quotes placed around that resulting it to look like: `pattern="'{field.Pattern}'"`.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Added pattern into a WiserFormField type that was used in an orderprocess. Above was the result. Added the :Raw formatter and the regex worked correctly again.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1208257594052329/f
