### PR TITLE
Skip cache when saving item detail

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -4395,7 +4395,7 @@ LIMIT 1";
                             query += " FOR UPDATE";
                         }
 
-                        var dataTable = await databaseConnection.GetAsync(query);
+                        var dataTable = await databaseConnection.GetAsync(query, skipCache: true);
                         if (dataTable.Rows.Count > 0)
                         {
                             itemDetail.Id = dataTable.Rows[0].Field<ulong>("id");
@@ -4425,7 +4425,7 @@ SELECT LAST_INSERT_ID() AS newDetailId;";
 
                         if (!String.IsNullOrEmpty(query))
                         {
-                            var dataTable = await databaseConnection.GetAsync(query);
+                            var dataTable = await databaseConnection.GetAsync(query, skipCache: true, useWritingConnectionIfAvailable: true);
                             itemDetail.Id = Convert.ToUInt64(dataTable.Rows[0]["newDetailId"]);
                         }
                     }


### PR DESCRIPTION
# Describe your changes

Skip cache in 2 queries in save item detail method.

First is a query that checks whether a detail exists, 
second is an insert of the detail using the GetAsync. Since this is an insert it should also use the writing connection.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Got duplicate key errors when debugging an issue with caching enabled, after adding this change the errors disappeared.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1208083523017881
