### PR TITLE
Fix template permissions bug when caching is active

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Interfaces/ITemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Interfaces/ITemplatesService.cs
@@ -21,8 +21,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="parentId">Optional: The ID of the parent of the template to get.</param>
         /// <param name="parentName">Optional: The name of the parent of template to get.</param>
         /// <param name="includeContent">Optional: Whether or not to include the contents of the template. Default value is <see langword="true"/>.</param>
+        /// <param name="skipPermissions">Optional: Whether to skip the check if the user has the permissions to see the template</param>
         /// <returns></returns>
-        Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true);
+        Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true, bool skipPermissions = false);
 
         /// <summary>
         /// Get only the contents and ID of a template. Must supply either an ID or a name.
@@ -353,5 +354,24 @@ namespace GeeksCoreLibrary.Modules.Templates.Interfaces
         /// <param name="includeGlobalSnippets">Optional: Whether to include global snippets that are added for all pages. Default is <see langword="true"/>.</param>
         /// <returns>A list of HTML snippets for the given template, in the order that they should be added to the page.</returns>
         Task<List<PageWidgetModel>> GetPageWidgetsAsync(ITemplatesService templatesService, int templateId, bool includeGlobalSnippets = true);
+
+        /// <summary>
+        /// Checks the permissions of the template and returns an empty template with Id 0 if user does not have permission
+        /// This result and check is the same GetTemplateAsync does if permissions are not skipped
+        /// </summary>
+        /// <param name="template">The template to check permissions on.</param>
+        /// <remarks>You can GetTemplatePermissionSettingsAsync to get a template model with only the relevant properties filled.</remarks>
+        /// <returns>Returns the given template if user has permissions or empty template with Id 0 if they do not.</returns>
+        Task<Template> CheckTemplatePermissionsAsync(Template template);
+
+        /// <summary>
+        /// Gets a template model with only the permissions settings filled
+        /// </summary>
+        /// <param name="id">Optional: The ID of the template.</param>
+        /// <param name="name">Optional: The name of the template.</param>
+        /// <param name="parentId">Optional: The ID of the parent directory, in case you only want to search in a specific directory when looking up a template by name.</param>
+        /// <param name="parentName">Optional: The ID of the parent directory, in case you only want to search in a specific directory when looking up a template by name.</param>
+        /// <returns>Template model with only the permissions settings filled</returns>
+        Task<Template> GetTemplatePermissionSettingsAsync(int id = 0, string name = "", int parentId = 0, string parentName = "");
     }
 }

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyCachedTemplatesService.cs
@@ -62,7 +62,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         }
 
         /// <inheritdoc />
-        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true)
+        public async Task<Template> GetTemplateAsync(int id = 0, string name = "", TemplateTypes? type = null, int parentId = 0, string parentName = "", bool includeContent = true, bool skipPermissions = false)
         {
             if (id <= 0 && String.IsNullOrEmpty(name))
             {
@@ -529,6 +529,22 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
         public async Task<List<PageWidgetModel>> GetPageWidgetsAsync(ITemplatesService service, int templateId, bool includeGlobalSnippets = true)
         {
             return await templatesService.GetPageWidgetsAsync(service, templateId, includeGlobalSnippets);
+        }
+
+        public async Task<Template> CheckTemplatePermissionsAsync(Template template)
+        {
+            return await templatesService.CheckTemplatePermissionsAsync(template);
+        }
+
+        public async Task<Template> GetTemplatePermissionSettingsAsync(int id = 0, string name = "", int parentId = 0, string parentName = "")
+        {
+            var cacheName = $"TemplatePermissionSettings_{id}_{name}_{parentId}_{parentName}_{branchesService.GetDatabaseNameFromCookie()}";
+            return await cache.GetOrAddAsync(cacheName,
+                async cacheEntry =>
+                {
+                    cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultTemplateCacheDuration;
+                    return await templatesService.GetTemplatePermissionSettingsAsync(id, name, parentId, parentName);
+                }, cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Templates));
         }
 
         /// <summary>


### PR DESCRIPTION
# Describe your changes

When a user was logged in, went to a page you can only see while logged in and then logged out he would still be able to see the page. This was because the result of the permissions check got cached. These changes fixes this by adding the result of the permissions check to the caching key and seperately checking permissions in the CachedTemplateService

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

On a website where most pages contained templates that required user login. I navigated through several pages, and logged in and out several times. This was done locally with settings caching duration set to 1 hour and environment on acceptance.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1208083523017881/f
