### PR TITLE
Skip cache when getting item files

### DIFF
--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -69,7 +69,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
                 WHERE item_id = ?itemId AND property_name = ?propertyName
                 ORDER BY ordering ASC, id ASC
-                LIMIT {fileNumber - 1},1");
+                LIMIT {fileNumber - 1},1", skipCache: true);
 
             if (!ValidateQueryResult(getImageResult, encryptedItemId))
             {
@@ -112,7 +112,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
                 WHERE itemlink_id = ?itemLinkId AND property_name = ?propertyName
                 ORDER BY ordering ASC, id ASC
-                LIMIT {fileNumber - 1},1");
+                LIMIT {fileNumber - 1},1", skipCache: true);
 
             if (!ValidateQueryResult(getImageResult, encryptedItemLinkId))
             {
@@ -152,7 +152,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             var getImageResult = await databaseConnection.GetAsync($@"
                 SELECT content_type, content, content_url, protected
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
-                WHERE id = ?fileId");
+                WHERE id = ?fileId", skipCache: true);
 
             if (!ValidateQueryResult(getImageResult, encryptedItemId))
             {
@@ -195,7 +195,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
                 WHERE item_id = ?itemId AND property_name = ?propertyName
                 ORDER BY ordering ASC, id ASC
-                LIMIT {fileNumber - 1},1");
+                LIMIT {fileNumber - 1},1", skipCache: true);
 
             if (!ValidateQueryResult(getFileResult, encryptedItemId))
             {
@@ -237,7 +237,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
                 WHERE itemlink_id = ?itemLinkId AND property_name = ?propertyName
                 ORDER BY ordering ASC, id ASC
-                LIMIT {fileNumber - 1},1");
+                LIMIT {fileNumber - 1},1", skipCache: true);
 
             if (!ValidateQueryResult(getFileResult, encryptedItemLinkId))
             {
@@ -276,7 +276,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
             var getFileResult = await databaseConnection.GetAsync($@"
                 SELECT content, content_url, protected
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
-                WHERE id = ?fileId");
+                WHERE id = ?fileId", skipCache: true);
 
             if (!ValidateQueryResult(getFileResult, encryptedItemId))
             {


### PR DESCRIPTION
# Describe your changes

Wiser items files was cached using the filesystem using the filename and also using the query cache. This causes issues for functionalitity where the file can change. For example when the user can add and change an image.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested it with functionality where the end user could change change an image to a different one. Before the change the cached image would get shown after updating the image, after the change it would correctly update.

No slowdown in image loading was detected because the files are still being cached using the filesystem.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1208464225403868/f
