### PR TITLE
Fix redirect to relative uri

### DIFF
--- a/GeeksCoreLibrary/Modules/Redirect/Middlewares/RedirectMiddleWare.cs
+++ b/GeeksCoreLibrary/Modules/Redirect/Middlewares/RedirectMiddleWare.cs
@@ -50,7 +50,9 @@ namespace GeeksCoreLibrary.Modules.Redirect.Middlewares
                 var redirectRule = await redirectService.GetRedirectAsync(oldUrl);
                 if (!String.IsNullOrEmpty(redirectRule.NewUrl))
                 {
-                    redirectToUrl = redirectRule.NewUrl;
+                    var baseUri = HttpContextHelpers.GetBaseUri(context);
+                    // If the NewUrl is relative the baseUri is used to turn it into an absolute url.
+                    redirectToUrl = new Uri(baseUri, redirectRule.NewUrl).AbsoluteUri;
                     redirectPermanent = redirectRule.Permanent;
                     logger.LogDebug($"Handle redirect module, redirect from  '{redirectRule.OldUrl}' to '{redirectRule.NewUrl}'.");
                 }


### PR DESCRIPTION
# Describe your changes

When using the redirect module to redirect to a relative url there would be an UriFormat exception when doing the redirect.
This fixes that by getting the baseUrl of the request and turning the relative url in an absolute url.

This allows redirects to work correctly across different environments.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Made two redirect rules. One with an absolute newUrl and one with a relative newUrl and tested wether both redirects worked correctly after the change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1208538439984826/f
