### PR TITLE
Get item file image by filename

### DIFF
--- a/GeeksCoreLibrary/Modules/ItemFiles/Controllers/ItemFilesController.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Controllers/ItemFilesController.cs
@@ -34,14 +34,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Controllers
             [FromQuery] string fileType = null, [FromQuery] string type = null,
             [FromQuery] string encryptedId = null)
         {
-            if (String.Equals(fileType, "name", StringComparison.OrdinalIgnoreCase))
+            if (itemId == 0 || String.IsNullOrWhiteSpace(propertyName))
             {
-                if (String.IsNullOrWhiteSpace(fileName))
-                {
-                    return NotFound();
-                }
+                return NotFound();
             }
-            else if (itemId == 0 || String.IsNullOrWhiteSpace(propertyName))
+            // Also check if fileName is empty when fileType is "name"
+            if (String.Equals(fileType, "name", StringComparison.OrdinalIgnoreCase) && String.IsNullOrWhiteSpace(fileName))
             {
                 return NotFound();
             }
@@ -61,7 +59,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Controllers
                     (fileBytes, lastModified) = await itemFilesService.GetWiserDirectImageAsync(itemId, preferredWidth, preferredHeight, fileName, resizeMode, anchorPosition, encryptedId, entityType: type);
                     break;
                 case "NAME":
-                    (fileBytes, lastModified) = await itemFilesService.GetWiserImageByFileNameAsync(propertyName, preferredWidth, preferredHeight, fileName, resizeMode, anchorPosition, encryptedId, entityType: type);
+                    (fileBytes, lastModified) = await itemFilesService.GetWiserImageByFileNameAsync(itemId, propertyName, preferredWidth, preferredHeight, fileName, resizeMode, anchorPosition, encryptedId, entityType: type);
                     break;
                 default:
                     (fileBytes, lastModified) = await itemFilesService.GetWiserItemImageAsync(itemId, propertyName, preferredWidth, preferredHeight, fileName, fileNumber, resizeMode, anchorPosition, encryptedId, entityType: type);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Controllers/ItemFilesController.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Controllers/ItemFilesController.cs
@@ -34,7 +34,14 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Controllers
             [FromQuery] string fileType = null, [FromQuery] string type = null,
             [FromQuery] string encryptedId = null)
         {
-            if (itemId == 0 || String.IsNullOrWhiteSpace(propertyName))
+            if (String.Equals(fileType, "name", StringComparison.OrdinalIgnoreCase))
+            {
+                if (String.IsNullOrWhiteSpace(fileName))
+                {
+                    return NotFound();
+                }
+            }
+            else if (itemId == 0 || String.IsNullOrWhiteSpace(propertyName))
             {
                 return NotFound();
             }
@@ -52,6 +59,9 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Controllers
                     break;
                 case "DIRECT":
                     (fileBytes, lastModified) = await itemFilesService.GetWiserDirectImageAsync(itemId, preferredWidth, preferredHeight, fileName, resizeMode, anchorPosition, encryptedId, entityType: type);
+                    break;
+                case "NAME":
+                    (fileBytes, lastModified) = await itemFilesService.GetWiserImageByFileNameAsync(propertyName, preferredWidth, preferredHeight, fileName, resizeMode, anchorPosition, encryptedId, entityType: type);
                     break;
                 default:
                     (fileBytes, lastModified) = await itemFilesService.GetWiserItemImageAsync(itemId, propertyName, preferredWidth, preferredHeight, fileName, fileNumber, resizeMode, anchorPosition, encryptedId, entityType: type);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Interfaces/IItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Interfaces/IItemFilesService.cs
@@ -9,48 +9,62 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Interfaces
         /// <summary>
         /// Attempts to retrieve an image linked to an item. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
         /// </summary>
-        /// <param name="itemId"></param>
-        /// <param name="propertyName"></param>
-        /// <param name="preferredWidth"></param>
-        /// <param name="preferredHeight"></param>
-        /// <param name="filename"></param>
-        /// <param name="fileNumber"></param>
-        /// <param name="resizeMode"></param>
-        /// <param name="anchorPosition"></param>
-        /// <param name="encryptedItemId"></param>
+        /// <param name="itemId">The Wiser item ID the image is linked to.</param>
+        /// <param name="propertyName">The property name the image is linked to.</param>
+        /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
+        /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
+        /// <param name="filename">The filename of the image as it's saved in Wiser. It is not case-sensitive.</param>
+        /// <param name="fileNumber">Which image number should be retrieved in case there are more than one image linked to the same item with the same property name. Starts at 1.</param>
+        /// <param name="resizeMode">Optional: The resize mode to use. Refer to documentation to learn what the different resize modes do. The default is <see cref="ResizeModes.Normal"/>.</param>
+        /// <param name="anchorPosition">Optional: The anchor position to use when the resizing of the images causes it to be cropped. The default is <see cref="AnchorPositions.Center"/>.</param>
+        /// <param name="encryptedItemId">Optional: When the image is protected, the encrypted item ID needs to be provided to retrieve it. Leave it on <c>null</c> if the image is not protected.</param>
         /// <param name="entityType">Optional: If there is a separate wiser_itemfile table for the specified item, then enter the entity type here so that we can find it.</param>
-        /// <returns></returns>
+        /// <returns>A value tuple containing the bytes of the image file and the last modified date.</returns>
         Task<(byte[] FileBytes, DateTime LastModified)> GetWiserItemImageAsync(ulong itemId, string propertyName, int preferredWidth, int preferredHeight, string filename, int fileNumber, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null);
 
         /// <summary>
         /// Attempts to retrieve an image linked to a link between two items. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
         /// </summary>
-        /// <param name="itemLinkId"></param>
-        /// <param name="propertyName"></param>
-        /// <param name="preferredWidth"></param>
-        /// <param name="preferredHeight"></param>
-        /// <param name="filename"></param>
-        /// <param name="fileNumber"></param>
-        /// <param name="resizeMode"></param>
-        /// <param name="anchorPosition"></param>
-        /// <param name="encryptedItemLinkId"></param>
+        /// <param name="itemLinkId">The Wiser item link ID the image is linked to.</param>
+        /// <param name="propertyName">The property name the image is linked to.</param>
+        /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
+        /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
+        /// <param name="filename">The filename of the image as it's saved in Wiser. It is not case-sensitive.</param>
+        /// <param name="fileNumber">Which image number should be retrieved in case there are more than one image linked to the same item with the same property name. Starts at 1.</param>
+        /// <param name="resizeMode">Optional: The resize mode to use. Refer to documentation to learn what the different resize modes do. The default is <see cref="ResizeModes.Normal"/>.</param>
+        /// <param name="anchorPosition">Optional: The anchor position to use when the resizing of the images causes it to be cropped. The default is <see cref="AnchorPositions.Center"/>.</param>
+        /// <param name="encryptedItemLinkId">Optional: When the image is protected, the encrypted item link ID needs to be provided to retrieve it. Leave it on <c>null</c> if the image is not protected.</param>
         /// <param name="linkType">Optional: If there is a separate wiser_itemfile table for the specified item link, then enter the link type number here so that we can find it.</param>
-        /// <returns></returns>
+        /// <returns>A value tuple containing the bytes of the image file and the last modified date.</returns>
         Task<(byte[] FileBytes, DateTime LastModified)> GetWiserItemLinkImageAsync(ulong itemLinkId, string propertyName, int preferredWidth, int preferredHeight, string filename, int fileNumber, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemLinkId = null, int linkType = 0);
 
         /// <summary>
         /// Attempts to retrieve an image directly, via file ID. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
         /// </summary>
         /// <param name="itemId"></param>
-        /// <param name="preferredWidth"></param>
-        /// <param name="preferredHeight"></param>
-        /// <param name="filename"></param>
-        /// <param name="resizeMode"></param>
-        /// <param name="anchorPosition"></param>
-        /// <param name="encryptedItemId"></param>
+        /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
+        /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
+        /// <param name="filename">The filename of the image as it's saved in Wiser. It is not case-sensitive.</param>
+        /// <param name="resizeMode">Optional: The resize mode to use. Refer to documentation to learn what the different resize modes do. The default is <see cref="ResizeModes.Normal"/>.</param>
+        /// <param name="anchorPosition">Optional: The anchor position to use when the resizing of the images causes it to be cropped. The default is <see cref="AnchorPositions.Center"/>.</param>
+        /// <param name="encryptedItemId">Optional: When the image is protected, the encrypted item ID needs to be provided to retrieve it. Leave it on <c>null</c> if the image is not protected.</param>
         /// <param name="entityType">Optional: If there is a separate wiser_itemfile table for the specified item, then enter the entity type here so that we can find it.</param>
-        /// <returns></returns>
+        /// <returns>A value tuple containing the bytes of the image file and the last modified date.</returns>
         Task<(byte[] FileBytes, DateTime LastModified)> GetWiserDirectImageAsync(ulong itemId, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null);
+
+        /// <summary>
+        /// Attempts to retrieve an image based on the image's filename. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
+        /// </summary>
+        /// <param name="propertyName">The property name the image is linked to.</param>
+        /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
+        /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
+        /// <param name="filename">The filename of the image as it's saved in Wiser. It is not case-sensitive.</param>
+        /// <param name="resizeMode">Optional: The resize mode to use. Refer to documentation to learn what the different resize modes do. The default is <see cref="ResizeModes.Normal"/>.</param>
+        /// <param name="anchorPosition">Optional: The anchor position to use when the resizing of the images causes it to be cropped. The default is <see cref="AnchorPositions.Center"/>.</param>
+        /// <param name="encryptedItemId">Optional: When the image is protected, the encrypted item ID needs to be provided to retrieve it. Leave it on <c>null</c> if the image is not protected.</param>
+        /// <param name="entityType">Optional: If there is a separate wiser_itemfile table for the specified item, then enter the entity type here so that we can find it.</param>
+        /// <returns>A value tuple containing the bytes of the image file and the last modified date.</returns>
+        Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null);
 
         /// <summary>
         /// Attempts to retrieve a file linked to an item. A 404 status will be returned if no file was found.

--- a/GeeksCoreLibrary/Modules/ItemFiles/Interfaces/IItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Interfaces/IItemFilesService.cs
@@ -41,7 +41,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Interfaces
         /// <summary>
         /// Attempts to retrieve an image directly, via file ID. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
         /// </summary>
-        /// <param name="itemId"></param>
+        /// <param name="itemId">The Wiser item file ID of the image.</param>
         /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
         /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
         /// <param name="filename">The filename of the image as it's saved in Wiser. It is not case-sensitive.</param>
@@ -55,6 +55,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Interfaces
         /// <summary>
         /// Attempts to retrieve an image based on the image's filename. Will return a no-image if no image was found. A 404 status will be returned if a no-image file could not be found either.
         /// </summary>
+        /// <param name="itemId">The Wiser item ID the image is linked to.</param>
         /// <param name="propertyName">The property name the image is linked to.</param>
         /// <param name="preferredWidth">The preferred width the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred width.</param>
         /// <param name="preferredHeight">The preferred height the image should be resized to. Based on the resize mode and height the width might end up smaller than the preferred height.</param>
@@ -64,7 +65,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Interfaces
         /// <param name="encryptedItemId">Optional: When the image is protected, the encrypted item ID needs to be provided to retrieve it. Leave it on <c>null</c> if the image is not protected.</param>
         /// <param name="entityType">Optional: If there is a separate wiser_itemfile table for the specified item, then enter the entity type here so that we can find it.</param>
         /// <returns>A value tuple containing the bytes of the image file and the last modified date.</returns>
-        Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null);
+        Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(ulong itemId, string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null);
 
         /// <summary>
         /// Attempts to retrieve a file linked to an item. A 404 status will be returned if no file was found.

--- a/GeeksCoreLibrary/Modules/ItemFiles/Middlewares/WiserItemFilesMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Middlewares/WiserItemFilesMiddleware.cs
@@ -65,21 +65,11 @@ public class WiserItemFilesMiddleware
     /// <param name="queryStringFromUrl">The query string from the URI.</param>
     private void HandleRewrites(HttpContext context, string path, QueryString queryStringFromUrl)
     {
-        string requestPath;
-
         // Check if the current URL is that of an image or a file.
-        // First check if it's being matched on a file name.
-        var urlRegex = new Regex(@"(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+))?(?:\/(?<fileType>name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
+        var urlRegex = new Regex(@"(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct|name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
         var matchResult = urlRegex.Match(path);
         if (!matchResult.Success)
         {
-            urlRegex = new Regex(@"(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
-            matchResult = urlRegex.Match(path);
-        }
-
-        if (!matchResult.Success)
-        {
-            // If the URL is not an image, check if it's a file.
             urlRegex = new Regex(@"(?:file\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>.+?)(?:\/(?<fileNumber>\d+))?(?:\/)(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
             matchResult = urlRegex.Match(path);
             if (!matchResult.Success)
@@ -87,14 +77,12 @@ public class WiserItemFilesMiddleware
                 return;
             }
 
-            requestPath = "/wiser-file.gcl";
+            context.Request.Path = "/wiser-file.gcl";
         }
         else
         {
-            requestPath = "/wiser-image.gcl";
+            context.Request.Path = "/wiser-image.gcl";
         }
-
-        context.Request.Path = requestPath;
 
         // Add all values from the regex to the query string for the controller.
         foreach (Group group in matchResult.Groups)

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -63,13 +63,13 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
         }
 
         /// <inheritdoc />
-        public async Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
+        public async Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(ulong itemId, string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
         {
             var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-            var localFilename = $"image_wiser{entityTypePart}_filename_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
+            var localFilename = $"image_wiser{entityTypePart}_{itemId}_filename_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
             if (gclSettings.DefaultItemFileCacheDuration.TotalSeconds <= 0 || !ValidateItemFile(localFilename))
             {
-                return await itemFilesService.GetWiserImageByFileNameAsync(propertyName, preferredWidth, preferredHeight, filename, resizeMode, anchorPosition, encryptedItemId, entityType);
+                return await itemFilesService.GetWiserImageByFileNameAsync(itemId, propertyName, preferredWidth, preferredHeight, filename, resizeMode, anchorPosition, encryptedItemId, entityType);
             }
 
             return await GetFileBytesAsync(localFilename);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using GeeksCoreLibrary.Modules.ItemFiles.Models;
 using Constants = GeeksCoreLibrary.Modules.ItemFiles.Models.Constants;
 
 namespace GeeksCoreLibrary.Modules.ItemFiles.Services
@@ -28,7 +27,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
         public async Task<(byte[] FileBytes, DateTime LastModified)> GetWiserItemImageAsync(ulong itemId, string propertyName, int preferredWidth, int preferredHeight, string filename, int fileNumber, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
         {
             var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-            var localFilename = $"image_wiser2{entityTypePart}_{itemId}_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{filename}";
+            var localFilename = $"image_wiser{entityTypePart}_{itemId}_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{Path.GetFileName(filename)}";
             if (gclSettings.DefaultItemFileCacheDuration.TotalSeconds <= 0 || !ValidateItemFile(localFilename))
             {
                 return await itemFilesService.GetWiserItemImageAsync(itemId, propertyName, preferredWidth, preferredHeight, filename, fileNumber, resizeMode, anchorPosition, encryptedItemId, entityType);
@@ -41,7 +40,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
         public async Task<(byte[] FileBytes, DateTime LastModified)> GetWiserItemLinkImageAsync(ulong itemLinkId, string propertyName, int preferredWidth, int preferredHeight, string filename, int fileNumber, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemLinkId = null, int linkType = 0)
         {
             var linkTypePart = linkType == 0 ? "" : $"_{linkType}";
-            var localFilename = $"image_wiser2_{itemLinkId}_itemlink{linkTypePart}_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{filename}";
+            var localFilename = $"image_wiser_{itemLinkId}_itemlink{linkTypePart}_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{fileNumber}_{Path.GetFileName(filename)}";
             if (gclSettings.DefaultItemFileCacheDuration.TotalSeconds <= 0 || !ValidateItemFile(localFilename))
             {
                 return await itemFilesService.GetWiserItemLinkImageAsync(itemLinkId, propertyName, preferredWidth, preferredHeight, filename, fileNumber, resizeMode, anchorPosition, encryptedItemLinkId, linkType);
@@ -54,10 +53,23 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
         public async Task<(byte[] FileBytes, DateTime LastModified)> GetWiserDirectImageAsync(ulong itemId, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
         {
             var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-            var localFilename = $"image_wiser2{entityTypePart}_{itemId}_direct_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{filename}";
+            var localFilename = $"image_wiser{entityTypePart}_{itemId}_direct_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
             if (gclSettings.DefaultItemFileCacheDuration.TotalSeconds <= 0 || !ValidateItemFile(localFilename))
             {
                 return await itemFilesService.GetWiserDirectImageAsync(itemId, preferredWidth, preferredHeight, filename, resizeMode, anchorPosition, encryptedItemId, entityType);
+            }
+
+            return await GetFileBytesAsync(localFilename);
+        }
+
+        /// <inheritdoc />
+        public async Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
+        {
+            var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
+            var localFilename = $"image_wiser{entityTypePart}_filename_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
+            if (gclSettings.DefaultItemFileCacheDuration.TotalSeconds <= 0 || !ValidateItemFile(localFilename))
+            {
+                return await itemFilesService.GetWiserImageByFileNameAsync(propertyName, preferredWidth, preferredHeight, filename, resizeMode, anchorPosition, encryptedItemId, entityType);
             }
 
             return await GetFileBytesAsync(localFilename);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Extensions;
@@ -172,24 +173,46 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
         }
 
         /// <inheritdoc />
-        public async Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
+        public async Task<(byte[] fileBytes, DateTime lastModified)> GetWiserImageByFileNameAsync(ulong itemId, string propertyName, int preferredWidth, int preferredHeight, string filename, ResizeModes resizeMode = ResizeModes.Normal, AnchorPositions anchorPosition = AnchorPositions.Center, string encryptedItemId = null, string entityType = null)
         {
+            if (!TryGetFinalId(itemId, encryptedItemId, out var finalItemId) || finalItemId == 0 || String.IsNullOrWhiteSpace(filename))
+            {
+                return (null, DateTime.MinValue);
+            }
+
             var tablePrefix = await wiserItemsService.GetTablePrefixForEntityAsync(entityType);
 
             databaseConnection.ClearParameters();
-            databaseConnection.AddParameter("filename", Path.GetFileNameWithoutExtension(filename));
+            databaseConnection.AddParameter("itemId", finalItemId);
             databaseConnection.AddParameter("propertyName", propertyName);
-            var getImageResult = await databaseConnection.GetAsync($@"
-                SELECT content_type, content, content_url, protected
+            var getImagesResult = await databaseConnection.GetAsync($"""
+                SELECT content_type, content, content_url, file_name, protected
                 FROM `{tablePrefix}{WiserTableNames.WiserItemFile}`
-                WHERE REPLACE(file_name, extension, '') = ?fileName AND property_name = ?propertyName
+                WHERE item_id = ?itemId AND property_name = ?propertyName
                 ORDER BY ordering ASC, id ASC
-                LIMIT 1", skipCache: true);
+                """, skipCache: true);
 
-            if (!ValidateQueryResult(getImageResult, encryptedItemId))
+            // First retrieve the data row with the image that has the right file name.
+            DataRow imageDataRow = null;
+            foreach (var dataRow in getImagesResult.Rows.Cast<DataRow>())
+            {
+                var dataRowFileName = dataRow.Field<string>("file_name");
+                if (String.IsNullOrWhiteSpace(dataRowFileName)) continue;
+
+                if (!Path.GetFileNameWithoutExtension(dataRowFileName).Equals(Path.GetFileNameWithoutExtension(filename), StringComparison.OrdinalIgnoreCase)) continue;
+
+                imageDataRow = dataRow;
+                break;
+            }
+
+            if (imageDataRow != null)
             {
                 // If file is protected, but tried to retrieve it without an encrypted item ID should result in a 404 status.
-                return (null, DateTime.MinValue);
+                var isProtected = Convert.ToBoolean(imageDataRow["protected"]);
+                if (isProtected && String.IsNullOrWhiteSpace(encryptedItemId))
+                {
+                    return (null, DateTime.MinValue);
+                }
             }
 
             var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
@@ -200,11 +223,11 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 return (null, DateTime.MinValue);
             }
 
-            var localFilename = $"image_wiser{entityTypePart}_filename_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
+            var localFilename = $"image_wiser{entityTypePart}_{itemId}_filename_{propertyName}_{resizeMode:G}-{anchorPosition:G}_{preferredWidth}_{preferredHeight}_{Path.GetFileName(filename)}";
             var fileLocation = Path.Combine(localDirectory, localFilename);
 
             // Calling HandleImage with the dataRow parameter set to null will cause the function to return a no-image if possible.
-            return await HandleImage(getImageResult.Rows.Count == 0 ? null : getImageResult.Rows[0], fileLocation, propertyName, preferredWidth, preferredHeight, resizeMode, anchorPosition);
+            return await HandleImage(imageDataRow, fileLocation, propertyName, preferredWidth, preferredHeight, resizeMode, anchorPosition);
         }
 
         /// <inheritdoc />
@@ -457,7 +480,7 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
 
                 var extension = Path.GetExtension(saveLocation);
 
-                // Final check to see if a the image bytes were retrieved.
+                // Final check to see if the image bytes were retrieved.
                 if (fileBytes == null || fileBytes.Length == 0)
                 {
                     // Try to get a no-image file instead.


### PR DESCRIPTION
# Describe your changes

Allows for an image to be retrieved by file name. This is meant for a collection of images that belong to a single item and property name.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build to determine it would retrieve an image by file name correctly, and that it would return a 404 status code if an image couldn't be found.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira issue key

CON-601