### PR TITLE
Remove fields with scoped-lifetime from middleware

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Middlewares/RewriteUrlToOrderProcessMiddleware.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Middlewares/RewriteUrlToOrderProcessMiddleware.cs
@@ -13,7 +13,6 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Middlewares
     {
         private readonly RequestDelegate next;
         private readonly ILogger<RewriteUrlToOrderProcessMiddleware> logger;
-        private IOrderProcessesService orderProcessesService;
 
         public RewriteUrlToOrderProcessMiddleware(RequestDelegate next, ILogger<RewriteUrlToOrderProcessMiddleware> logger)
         {
@@ -28,8 +27,6 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Middlewares
         public async Task Invoke(HttpContext context, IOrderProcessesService orderProcessesService)
         {
             logger.LogDebug("Invoked RewriteUrlToOrderProcessMiddleware");
-
-            this.orderProcessesService = orderProcessesService;
 
             if (HttpContextHelpers.IsGclMiddleWarePage(context))
             {
@@ -55,7 +52,7 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Middlewares
                 context.Items.Add(Constants.OriginalPathAndQueryStringKey, $"{path}{queryString.Value}");
             }
 
-            await HandleRewritesAsync(context, path, queryString);
+            await HandleRewritesAsync(context, path, queryString, orderProcessesService);
 
             await this.next.Invoke(context);
         }
@@ -67,7 +64,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Middlewares
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="path">The path of the current URI.</param>
         /// <param name="queryStringFromUrl">The query string from the URI.</param>
-        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl)
+        /// <param name="orderProcessesService">The order process service used to g</param>
+        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, IOrderProcessesService orderProcessesService)
         {
             // Only handle the redirecting to webpages on normal URLs, not on images, css, js, etc.
             var regEx = new Regex(Core.Models.CoreConstants.UrlsToSkipForMiddlewaresRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));

--- a/GeeksCoreLibrary/Components/WebPage/Middlewares/RewriteUrlToWebPageMiddleware.cs
+++ b/GeeksCoreLibrary/Components/WebPage/Middlewares/RewriteUrlToWebPageMiddleware.cs
@@ -16,8 +16,6 @@ namespace GeeksCoreLibrary.Components.WebPage.Middlewares
     {
         private readonly RequestDelegate next;
         private readonly ILogger<RewriteUrlToWebPageMiddleware> logger;
-        private IObjectsService objectsService;
-        private IWebPagesService webPagesService;
 
         public RewriteUrlToWebPageMiddleware(RequestDelegate next, ILogger<RewriteUrlToWebPageMiddleware> logger)
         {
@@ -36,9 +34,6 @@ namespace GeeksCoreLibrary.Components.WebPage.Middlewares
         public async Task Invoke(HttpContext context, IObjectsService objectsService, IWebPagesService webPagesService)
         {
             logger.LogDebug("Invoked RewriteUrlToWebPageMiddleware");
-
-            this.objectsService = objectsService;
-            this.webPagesService = webPagesService;
 
             if (HttpContextHelpers.IsGclMiddleWarePage(context))
             {
@@ -64,7 +59,7 @@ namespace GeeksCoreLibrary.Components.WebPage.Middlewares
                 context.Items.Add(Constants.OriginalPathAndQueryStringKey, $"{path}{queryString.Value}");
             }
 
-            await HandleRewritesAsync(context, path, queryString);
+            await HandleRewritesAsync(context, path, queryString, objectsService, webPagesService);
 
             await this.next.Invoke(context);
         }
@@ -76,7 +71,7 @@ namespace GeeksCoreLibrary.Components.WebPage.Middlewares
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="path">The path of the current URI.</param>
         /// <param name="queryStringFromUrl">The query string from the URI.</param>
-        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl)
+        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, IObjectsService objectsService, IWebPagesService webPagesService)
         {
             // Only handle the redirecting to webpages on normal URLs, not on images, css, js, etc.
             var regEx = new Regex(Core.Models.CoreConstants.UrlsToSkipForMiddlewaresRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));

--- a/GeeksCoreLibrary/Components/WebPage/Middlewares/RewriteUrlToWebPageMiddleware.cs
+++ b/GeeksCoreLibrary/Components/WebPage/Middlewares/RewriteUrlToWebPageMiddleware.cs
@@ -71,6 +71,8 @@ namespace GeeksCoreLibrary.Components.WebPage.Middlewares
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="path">The path of the current URI.</param>
         /// <param name="queryStringFromUrl">The query string from the URI.</param>
+        /// <param name="objectsService">The objectService used to get the system settings.</param>
+        /// <param name="webPagesService">The webpagesService used to find the webpage based on the url.</param>
         private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, IObjectsService objectsService, IWebPagesService webPagesService)
         {
             // Only handle the redirecting to webpages on normal URLs, not on images, css, js, etc.

--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
@@ -111,9 +111,9 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="path">The path of the current URI.</param>
         /// <param name="queryStringFromUrl">The query string from the URI.</param>
-        /// <param name="templatesService"></param>
-        /// <param name="objectsService"></param>
-        /// <param name="databaseConnection"></param>
+        /// <param name="templatesService">The templates service.</param>
+        /// <param name="objectsService">The objects service.</param>
+        /// <param name="databaseConnection">The database connection.</param>
         private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, ITemplatesService templatesService, IObjectsService objectsService, IDatabaseConnection databaseConnection)
         {
             logger.LogDebug($"Start HandleRewrites, path: {path}");

--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
@@ -24,9 +24,6 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
     {
         private readonly RequestDelegate next;
         private readonly ILogger<RewriteUrlToTemplateMiddleware> logger;
-        private IObjectsService objectsService;
-        private IDatabaseConnection databaseConnection;
-        private ITemplatesService templatesService;
 
         public RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<RewriteUrlToTemplateMiddleware> logger)
         {
@@ -41,10 +38,6 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
         public async Task Invoke(HttpContext context, IObjectsService objectsService, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
         {
             logger.LogDebug("Invoked RewriteUrlToTemplateMiddleware");
-
-            this.objectsService = objectsService;
-            this.databaseConnection = databaseConnection;
-            this.templatesService = templatesService;
 
             if (HttpContextHelpers.IsGclMiddleWarePage(context))
             {
@@ -106,7 +99,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
                 context.Items.Add(Constants.OriginalPathAndQueryStringKey, $"{path}{queryString.Value}");
             }
 
-            await HandleRewritesAsync(context, path, queryString);
+            await HandleRewritesAsync(context, path, queryString, templatesService, objectsService, databaseConnection);
 
             await this.next.Invoke(context);
         }
@@ -118,7 +111,10 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
         /// <param name="context">The current <see cref="HttpContext"/>.</param>
         /// <param name="path">The path of the current URI.</param>
         /// <param name="queryStringFromUrl">The query string from the URI.</param>
-        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl)
+        /// <param name="templatesService"></param>
+        /// <param name="objectsService"></param>
+        /// <param name="databaseConnection"></param>
+        private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, ITemplatesService templatesService, IObjectsService objectsService, IDatabaseConnection databaseConnection)
         {
             logger.LogDebug($"Start HandleRewrites, path: {path}");
 
@@ -165,7 +161,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
             }
 
             // If we haven't found a matching URL yet, check the old legacy settings.
-            var urlRewrites = (await GetValues("url_syntax_templates")).ToList();
+            var urlRewrites = (await GetValues("url_syntax_templates", objectsService)).ToList();
             var fixedUrlQuery = await objectsService.FindSystemObjectByDomainNameAsync("fixedurl_query");
 
             // If there is a query for fixed URLs, add the results to the urlRewrites list.
@@ -225,7 +221,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
 
                     var newQueryString = String.Join(String.Empty, new[]
                     {
-                        $"?gclcmspagepath={await this.objectsService.FindSystemObjectByDomainNameAsync("cmsprefix")}",
+                        $"?gclcmspagepath={await objectsService.FindSystemObjectByDomainNameAsync("cmsprefix")}",
                         String.Join("/", webpagePath),
                         queryString.Value,
                         queryStringFromUrl.Value
@@ -285,7 +281,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Middlewares
         /// </summary>
         /// <param name="objectName">The name / key of the system object to retreive.</param>
         /// <returns>A list of string values.</returns>
-        private async Task<IEnumerable<string>> GetValues(string objectName)
+        private async Task<IEnumerable<string>> GetValues(string objectName, IObjectsService objectsService)
         {
             var value = await objectsService.FindSystemObjectByDomainNameAsync(objectName);
             var urlRewrites = value.Split(new[] { "\r", "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
# Describe your changes

The scoped lifetime services that were injected in the Invoke method of a middleware would get added as a field. Because a middleware is a singleton this would cause the service to be usuable accross diferent request and as such different threads.

This could result in exceptions that are hard to debug like connections that are already in use, or values suddenly being different because they were changed on a different thread.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Clicked around on a GCL site with CLR Exception Breakpoints turned on. Before the change I would get exception on most requests especially in the checkout. After the changes I got nearly no exceptions, all easily explainable.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
