### PR TITLE
Bugfix/wiser item definition

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -32,7 +32,7 @@ public class WiserTableDefinitions
                 new("ordering", MySqlDbType.Int24, notNull: true, defaultValue: "0"),
                 new("entity_type", MySqlDbType.VarChar, 100, notNull: true, defaultValue: "0"),
                 new("moduleid", MySqlDbType.Int32, 11, notNull: true, defaultValue: "0"),
-                new("published_environment", MySqlDbType.Int16, notNull: true, defaultValue: "15"),
+                new("published_environment", MySqlDbType.Int24, notNull: true, defaultValue: "15"),
                 new("readonly", MySqlDbType.Int16, notNull: true, defaultValue: "0"),
                 new("title", MySqlDbType.VarChar, 255, notNull: true, defaultValue: ""),
                 new("added_on", MySqlDbType.DateTime, notNull: true, defaultValue: "CURRENT_TIMESTAMP"),

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -22,7 +22,7 @@ public class WiserTableDefinitions
         new WiserTableDefinitionModel
         {
             Name = WiserTableNames.WiserItem,
-            LastUpdate = new DateTime(2024, 2, 2),
+            LastUpdate = new DateTime(2024, 10, 28),
             Columns = new List<ColumnSettingsModel>
             {
                 new("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),


### PR DESCRIPTION
# Describe your changes

Bugfix in wiser_item table definition. Published environment should be Int24, so mediumint is created in MySQL table. If published environment is tinyiny, then Wiser code fails with conversion errors from SByte to Int. 

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Changed the published environment column type to mediumint on prefix table created by the GCL. Problem getting item meta data in Wiser solved. 

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
