### PR TITLE
Pass StringSplitOptions in Split function instead of filtering with linq

### DIFF
--- a/GeeksCoreLibrary/Components/Filter/Services/FiltersService.cs
+++ b/GeeksCoreLibrary/Components/Filter/Services/FiltersService.cs
@@ -563,7 +563,7 @@ namespace GeeksCoreLibrary.Components.Filter.Services
             {
                 var selectPart = new StringBuilder(",");
                 var joinPart = new StringBuilder();
-                foreach (var extraFilterProperty in extraFilterProperties.Split(',').Where(String.IsNullOrWhiteSpace).Select(p => p.Trim()))
+                foreach (var extraFilterProperty in extraFilterProperties.Split(',', StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries))
                 {
                     selectPart.Append($"`{extraFilterProperty}`.`value` AS `{extraFilterProperty}`,");
                     joinPart.AppendLine($"LEFT JOIN {WiserTableNames.WiserItemDetail} AS `{extraFilterProperty}` ON `{extraFilterProperty}`.item_id = filters.id AND `{extraFilterProperty}`.`key` = '{extraFilterProperty}' {GetLanguageQueryPart(extraFilterProperty, languageCode)}");
@@ -664,7 +664,7 @@ namespace GeeksCoreLibrary.Components.Filter.Services
                 if (!String.IsNullOrEmpty(extraFilterProperties))
                 {
                     filterGroup.ExtraProperties = new SortedList<string, string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var extraFilterProperty in extraFilterProperties.Split(',').Where(p => !String.IsNullOrWhiteSpace(p) && !filterGroup.ExtraProperties.ContainsKey(p)).Select(p => p.Trim()))
+                    foreach (var extraFilterProperty in extraFilterProperties.Split(',', StringSplitOptions.TrimEntries|StringSplitOptions.RemoveEmptyEntries).Where(p => !filterGroup.ExtraProperties.ContainsKey(p)))
                     {
                         filterGroup.ExtraProperties.Add(extraFilterProperty, row.IsNull(extraFilterProperty) ? "" : row[extraFilterProperty].ToString());
                     }


### PR DESCRIPTION
# Describe your changes

When getting the values in extraFilterProperty it used Linq to filter out the empty values and trim to values at least it is supposed to. Instead because of a missing not operator before the String.IsNullOrWhiteSpace it didn't passthrough any values.

After fixing this I also spotted a change that should make this more efficient and I think more readable by passing StringSplitOptions to the Split method to filter out and trim the values. 

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested on existing filter component with user the extraFilterProperty to pass in extra filter info.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1204297502076149/1208684662867212/f
