### PR TITLE
Fixed problem with logging in users and immediately needing the cookie

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Account.cs
+++ b/GeeksCoreLibrary/Components/Account/Account.cs
@@ -48,7 +48,7 @@ namespace GeeksCoreLibrary.Components.Account
         private readonly GclSettings gclSettings;
         private readonly IObjectsService objectsService;
         private readonly ICommunicationsService communicationsService;
-        
+
         #region Enums
 
         public enum ComponentModes
@@ -1842,6 +1842,8 @@ namespace GeeksCoreLibrary.Components.Account
 
             var offset = (amountOfDaysToRememberCookie ?? 0) <= 0 ? (DateTimeOffset?)null : DateTimeOffset.Now.AddDays(amountOfDaysToRememberCookie.Value);
             HttpContextHelpers.WriteCookie(HttpContext, Settings.CookieName, cookieValue, offset, isEssential: true);
+            // Save the cookie in the HttpContext.Items, so that we can use it in the rest of the request, because we can't read the cookie from the response.
+            HttpContext.Items[Settings.CookieName] = cookieValue;
 
             if (decryptedUserId == 0)
             {

--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using GeeksCoreLibrary.Core.Models;
-using GeeksCoreLibrary.Modules.Templates.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -420,7 +419,6 @@ public static class HttpContextHelpers
     /// <returns>A <see cref="Uri"/> containing the base URL.</returns>
     public static Uri GetBaseUri(HttpContext httpContext, bool alwaysHttps = false)
     {
-        
         return httpContext?.Request == null
             ? new Uri("https://localhost/")
             : new Uri($"{(alwaysHttps ? "https" : httpContext.Request.Scheme)}://{httpContext.Request.Host.Value}{httpContext.Request.PathBase.Value}");


### PR DESCRIPTION
# Describe your changes

Fixed problem that if we log in a user and then request the data of that user within the same request, we would get an empty result. This was because the login cookie was only added to the response, not to the current request.

This went wrong with a customer website that uses the OCI standard for placing orders. They do POST request to certain endpoints, with login credentials and an cXML that contains the order that they want to place. We need to log them in and then immediately get the user ID from the cookie and use that to place the order for that user. This went wrong, because we couldn't read the cookie at that point.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

This was tested via the same customer by simulating OCI order requests via PostMan. I was able to reproduce the issue and then verify that it was fixed.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1208744482937211
