### PR TITLE
Fix triming and removing empty entries for bcc en cc when setting up an e-mail

### DIFF
--- a/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
+++ b/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
@@ -277,8 +277,8 @@ WHERE id = ?id";
         public async Task<int> SendEmailAsync(string receiver, string subject, string body, string receiverName = null, string cc = null, string bcc = null, string replyTo = null, string replyToName = null, string sender = null, string senderName = null, DateTime? sendDate = null, List<ulong> attachments = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
-            var receiverAddresses = receiver.Split(';');
-            var receiverNames = (receiverName ?? "").Split(";");
+            var receiverAddresses = receiver.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            var receiverNames = (receiverName ?? "").Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             for (var i = 0; i < receiverAddresses.Length; i++)
             {
                 var receiverModel = new CommunicationReceiverModel { Address = receiverAddresses[i] };
@@ -293,13 +293,13 @@ WHERE id = ?id";
             var bccAddresses = new List<string>();
             if (!String.IsNullOrWhiteSpace(bcc))
             {
-                bccAddresses.AddRange(bcc.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries & StringSplitOptions.TrimEntries));
+                bccAddresses.AddRange(bcc.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
             }
 
             var ccAddresses = new List<string>();
             if (!String.IsNullOrWhiteSpace(cc))
             {
-                ccAddresses.AddRange(cc.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries & StringSplitOptions.TrimEntries));
+                ccAddresses.AddRange(cc.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
             }
 
             return await SendEmailAsync(receivers, subject, body, ccAddresses, bccAddresses, replyTo, replyToName, sender, senderName, sendDate, attachments);
@@ -624,7 +624,7 @@ WHERE id = ?id";
         public async Task<int> SendSmsAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
-            var receiverAddresses = receiver.Split(';');
+            var receiverAddresses = receiver.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             foreach (var receiverAddress in receiverAddresses)
             {
                 var receiverModel = new CommunicationReceiverModel { Address = receiverAddress };
@@ -767,7 +767,7 @@ WHERE id = ?id";
         public async Task<int> SendWhatsAppAsync(string receiver, string body, string sender = null, string senderName = null, DateTime? sendDate = null, List<string> attachments = null)
         {
             var receivers = new List<CommunicationReceiverModel>();
-            var receiverAddresses = receiver.Split(';');
+            var receiverAddresses = receiver.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             foreach (var receiverAddress in receiverAddresses)
             {
                 var receiverModel = new CommunicationReceiverModel { Address = receiverAddress };
@@ -1086,7 +1086,7 @@ WHERE id = ?id";
             var receivers = dataRow.Field<string>("receiver_list");
             if (!String.IsNullOrWhiteSpace(receivers))
             {
-                result.ReceiversList = receivers.Split(";", StringSplitOptions.TrimEntries & StringSplitOptions.RemoveEmptyEntries).ToList();
+                result.ReceiversList = receivers.Split(";", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).ToList();
             }
 
             return result;


### PR DESCRIPTION
# Describe your changes

In an earlier PR the wrong bitwise operator was used which resulted in StringSplitOptions functionality being set to StringSplitOptions .None. This fixes that.

I also found another place where this mistake was made and then went through all usages of Split to see wether it should be trimmed and empty entries removed.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Changed set bcc settings on test account on a GCL site to a value that would go wrong before and had it send a mail.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Corrects mistake in https://github.com/happy-geeks/geeks-core-library/pull/693

# Link to Asana ticket

N/A
