### PR TITLE
Removed dependency on `IWebHostEnvironment`

### DIFF
--- a/GeeksCoreLibrary/Modules/Amazon/Services/CachedAmazonS3Service.cs
+++ b/GeeksCoreLibrary/Modules/Amazon/Services/CachedAmazonS3Service.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Amazon.Interfaces;
 using GeeksCoreLibrary.Modules.Amazon.Models;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace GeeksCoreLibrary.Modules.Amazon.Services;
@@ -13,13 +11,11 @@ namespace GeeksCoreLibrary.Modules.Amazon.Services;
 public class CachedAmazonS3Service : IAmazonS3Service
 {
     private readonly GclSettings gclSettings;
-    private readonly IWebHostEnvironment webHostEnvironment;
     private readonly IAmazonS3Service amazonS3Service;
 
-    public CachedAmazonS3Service(IOptions<GclSettings> gclSettings, IWebHostEnvironment webHostEnvironment, IAmazonS3Service amazonS3Service)
+    public CachedAmazonS3Service(IOptions<GclSettings> gclSettings, IAmazonS3Service amazonS3Service)
     {
         this.gclSettings = gclSettings.Value;
-        this.webHostEnvironment = webHostEnvironment;
         this.amazonS3Service = amazonS3Service;
     }
 
@@ -39,7 +35,7 @@ public class CachedAmazonS3Service : IAmazonS3Service
     public async Task<bool> DownloadObjectFromBucketAsync(string bucketName, string objectName, string saveDirectory, AwsSettings awsSettings = null)
     {
         // First check if local file exists.
-        var fileInfo = new FileInfo(Path.Combine(FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment), objectName));
+        var fileInfo = new FileInfo(Path.Combine(saveDirectory, objectName));
         if (fileInfo.Exists && DateTime.UtcNow.Subtract(fileInfo.LastWriteTimeUtc) <= gclSettings.DefaultItemFileCacheDuration)
         {
             return true;


### PR DESCRIPTION
# Describe your changes

The cached version of the Amazon S3 service had a dependency on `IWebHostEnvironment` that made no sense. It's been removed, and the only place where it was used has been replaced with the proper save directory parameter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested to see if the cached variant built the correct file path using the correct save directory value.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira issue key

CON-672