### PR TITLE
Disable cache for configuration query in WTS health check

### DIFF
--- a/GeeksCoreLibrary/Modules/HealthChecks/Services/WtsHealthService.cs
+++ b/GeeksCoreLibrary/Modules/HealthChecks/Services/WtsHealthService.cs
@@ -49,8 +49,7 @@ public class WtsHealthService : IHealthCheck
         }
 
         var query = $"SELECT configuration, time_id, state, next_run FROM wts_services WHERE {String.Join(" AND ", conditions)}";
-        var datatable = await databaseConnection.GetAsync(query);
-
+        var datatable = await databaseConnection.GetAsync(query, skipCache: true);
         if (datatable.Rows.Count == 0)
         {
             return HealthCheckResult.Unhealthy("No data found");


### PR DESCRIPTION
# Describe your changes

The WTS healthcheck should always use the latest data but the result of the query to get the current status of the configurations in the WTS got cached.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used the WTS healthcheck endpoint `/health/wts/`

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1206033897144715/f
