### PR TITLE
Added some error handling when downloading external files

### DIFF
--- a/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
+++ b/GeeksCoreLibrary/Modules/Communication/Services/CommunicationsService.cs
@@ -608,7 +608,15 @@ WHERE id = ?id";
                 byte[] fileBytes;
                 if (!String.IsNullOrWhiteSpace(wiserItemFile.ContentUrl))
                 {
-                    fileBytes = await httpClientService.Client.GetByteArrayAsync(wiserItemFile.ContentUrl);
+                    var fileResult = await httpClientService.Client.GetAsync(wiserItemFile.ContentUrl);
+                    if (fileResult.StatusCode == HttpStatusCode.OK)
+                    {
+                        fileBytes = await fileResult.Content.ReadAsByteArrayAsync();
+                    }
+                    else
+                    {
+                        throw new Exception($"Could not download the file from the WiserItemFile URL: {wiserItemFile.ContentUrl}");
+                    }
                 }
                 else
                 {

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Extensions;
@@ -489,8 +490,11 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                         {
                             if (Uri.IsWellFormedUriString(contentUrl, UriKind.Absolute))
                             {
-                                var requestUri = new Uri(contentUrl);
-                                fileBytes = await httpClientService.Client.GetByteArrayAsync(requestUri);
+                                var fileResult = await httpClientService.Client.GetAsync(contentUrl);
+                                if (fileResult.StatusCode == HttpStatusCode.OK)
+                                {
+                                    fileBytes = await fileResult.Content.ReadAsByteArrayAsync();
+                                }
                             }
                             else
                             {
@@ -566,8 +570,11 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
 
                     if (Uri.IsWellFormedUriString(contentUrl, UriKind.Absolute))
                     {
-                        var requestUri = new Uri(contentUrl);
-                        fileBytes = await httpClientService.Client.GetByteArrayAsync(requestUri);
+                        var fileResult = await httpClientService.Client.GetAsync(contentUrl);
+                        if (fileResult.StatusCode == HttpStatusCode.OK)
+                        {
+                            fileBytes = await fileResult.Content.ReadAsByteArrayAsync();
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
# Describe your changes

Improvement for downloading files from external URLs. We now check if the HTTP response status is actually a 200, before we load the byte array. Otherwise we were constantly downloading 404/500 paqes and trying to save that as an image.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By testing if valid responses still work and if 404 responses are no longer being loaded into the byte array.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
