### PR TITLE
Fixed deadlock error handling

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -16,10 +16,12 @@ using GeeksCoreLibrary.Components.OrderProcess.Interfaces;
 using GeeksCoreLibrary.Components.OrderProcess.Models;
 using GeeksCoreLibrary.Components.ShoppingBasket.Interfaces;
 using GeeksCoreLibrary.Components.ShoppingBasket.Models;
+using GeeksCoreLibrary.Core.Exceptions;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Services;
 using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
@@ -357,11 +359,11 @@ namespace GeeksCoreLibrary.Components.OrderProcess
 
                             transactionCompleted = true;
                         }
-                        catch (MySqlException mySqlException)
+                        catch (GclQueryException queryException)
                         {
                             await DatabaseConnection.RollbackTransactionAsync(false);
 
-                            if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                            if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                             {
                                 // Exception is a deadlock or something similar, retry the transaction.
                                 retries++;

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -12,10 +12,12 @@ using GeeksCoreLibrary.Components.OrderProcess.Enums;
 using GeeksCoreLibrary.Components.ShoppingBasket.Interfaces;
 using GeeksCoreLibrary.Components.ShoppingBasket.Models;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
+using GeeksCoreLibrary.Core.Exceptions;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Services;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
@@ -551,7 +553,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
                     transactionCompleted = true;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -560,7 +562,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -904,11 +906,11 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     await databaseConnection.CommitTransactionAsync();
                     transactionCompleted = true;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -1875,7 +1877,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
                     transactionCompleted = true;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -1884,7 +1886,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -1988,7 +1990,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     if (createNewTransaction) await databaseConnection.CommitTransactionAsync();
                     transactionCompleted = true;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -1997,7 +1999,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -2006,7 +2008,7 @@ WHERE `order`.entity_type IN ('{OrderProcess.Models.Constants.OrderEntityType}',
                     else
                     {
                         // Exception is not a deadlock, or we reached the maximum amount of retries, rethrow it.
-                        logger.LogError(mySqlException, "An error occured while trying to add one or more lines to the shopping basket.");
+                        logger.LogError(queryException.InnerException, "An error occured while trying to add one or more lines to the shopping basket.");
                         throw;
                     }
                 }

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -16,6 +16,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Exceptions;
+using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Models;
 using GeeksCoreLibrary.Modules.Databases.Services;
@@ -150,7 +151,7 @@ namespace GeeksCoreLibrary.Core.Services
 
                     return wiserItem;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -159,7 +160,7 @@ namespace GeeksCoreLibrary.Core.Services
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -318,11 +319,11 @@ VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)");
 
                     return wiserItem;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -567,7 +568,7 @@ VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)");
 
                     return result;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -576,7 +577,7 @@ VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)");
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -1304,7 +1305,7 @@ SET @saveHistory = ?saveHistoryGcl;
 
                     return wiserItem;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -1313,7 +1314,7 @@ SET @saveHistory = ?saveHistoryGcl;
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -1670,7 +1671,7 @@ VALUES ('UNDELETE_ITEM', 'wiser_item', ?itemId, IFNULL(@_username, USER()), ?ent
 
                     return result;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     if (!createNewTransaction)
                     {
@@ -1679,7 +1680,7 @@ VALUES ('UNDELETE_ITEM', 'wiser_item', ?itemId, IFNULL(@_username, USER()), ?ent
 
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;
@@ -4269,11 +4270,11 @@ WHERE id = ?saveDetailId";
 
                     transactionCompleted = true;
                 }
-                catch (MySqlException mySqlException)
+                catch (GclQueryException queryException)
                 {
                     await databaseConnection.RollbackTransactionAsync(false);
 
-                    if (MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.Number) && retries < gclSettings.MaximumRetryCountForQueries)
+                    if (MySqlHelpers.IsErrorToRetry(queryException) && retries < gclSettings.MaximumRetryCountForQueries)
                     {
                         // Exception is a deadlock or something similar, retry the transaction.
                         retries++;

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/MySqlHelpers.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/MySqlHelpers.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
+using GeeksCoreLibrary.Core.Exceptions;
+using GeeksCoreLibrary.Modules.Databases.Services;
 using MySqlConnector;
 
 namespace GeeksCoreLibrary.Modules.Databases.Helpers;
@@ -21,5 +24,40 @@ public static class MySqlHelpers
         }
 
         return colMappings;
+    }
+
+    /// <summary>
+    /// Check whether the given <see cref="MySqlException"/> is an error that can be fixed by retrying the same operation again.
+    /// </summary>
+    /// <param name="mySqlException">The exception to check.</param>
+    /// <returns>Whether the operation that caused this exception is something that can be fixed by retrying the same operation again.</returns>
+    public static bool IsErrorToRetry(MySqlException mySqlException)
+    {
+        return MySqlDatabaseConnection.MySqlErrorCodesToRetry.Contains(mySqlException.ErrorCode);
+    }
+
+    /// <summary>
+    /// Check whether the given <see cref="InvalidOperationException"/> is an error that can be fixed by retrying the same operation again.
+    /// </summary>
+    /// <param name="invalidOperationException">The exception to check.</param>
+    /// <returns>Whether the operation that caused this exception is something that can be fixed by retrying the same operation again.</returns>
+    public static bool IsErrorToRetry(InvalidOperationException invalidOperationException)
+    {
+        return invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Check whether the given <see cref="GclQueryException"/> is an error that can be fixed by retrying the same operation again.
+    /// </summary>
+    /// <param name="gclQueryException">The exception to check.</param>
+    /// <returns>Whether the operation that caused this exception is something that can be fixed by retrying the same operation again.</returns>
+    public static bool IsErrorToRetry(GclQueryException gclQueryException)
+    {
+        return gclQueryException.InnerException switch
+        {
+            MySqlException mySqlException => IsErrorToRetry(mySqlException),
+            InvalidOperationException invalidOperationException => IsErrorToRetry(invalidOperationException),
+            _ => false
+        };
     }
 }

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -16,7 +16,6 @@ using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Branches.Interfaces;
 using GeeksCoreLibrary.Modules.Databases.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
-using GeeksCoreLibrary.Modules.Databases.Models;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -31,14 +30,14 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
 {
     public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
     {
-        public static readonly List<int> MySqlErrorCodesToRetry = new()
+        public static readonly List<MySqlErrorCode> MySqlErrorCodesToRetry = new()
         {
-            (int) MySqlErrorCode.LockDeadlock,
-            (int) MySqlErrorCode.LockWaitTimeout,
-            (int) MySqlErrorCode.UnableToConnectToHost,
-            (int) MySqlErrorCode.TooManyUserConnections,
-            (int) MySqlErrorCode.ConnectionCountError,
-            (int) MySqlErrorCode.TableDefinitionChanged
+            MySqlErrorCode.LockDeadlock,
+            MySqlErrorCode.LockWaitTimeout,
+            MySqlErrorCode.UnableToConnectToHost,
+            MySqlErrorCode.TooManyUserConnections,
+            MySqlErrorCode.ConnectionCountError,
+            MySqlErrorCode.TableDefinitionChanged
         };
 
         private const string Localhost = "127.0.0.1";
@@ -169,7 +168,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (InvalidOperationException invalidOperationException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
+                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(invalidOperationException))
                 {
                     logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, invalidOperationException);
@@ -183,22 +182,15 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
                 // so retrying a single query in a transaction is not very useful on most/all cases.
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
-                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
-                {
-                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
-                    return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
-                }
-
-                // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                throw new GclQueryException("Error trying to run query", query, mySqlException);
+                Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                return await GetAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
             }
             finally
             {
@@ -259,7 +251,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (InvalidOperationException invalidOperationException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
+                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(invalidOperationException))
                 {
                     logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, invalidOperationException);
@@ -273,22 +265,15 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
                 // so retrying a single query in a transaction is not very useful on most/all cases.
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
-                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
-                {
-                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
-                    return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);
-                }
-
-                // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                throw new GclQueryException("Error trying to run query", query, mySqlException);
+                Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                return await ExecuteAsync(query, retryCount + 1, useWritingConnectionIfAvailable, cleanUp);
             }
             finally
             {
@@ -393,7 +378,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             }
             catch (InvalidOperationException invalidOperationException)
             {
-                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !invalidOperationException.Message.Contains("This MySqlConnection is already in use", StringComparison.OrdinalIgnoreCase))
+                if (retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(invalidOperationException))
                 {
                     logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, invalidOperationException);
@@ -407,22 +392,15 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
                 // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
                 // so retrying a single query in a transaction is not very useful on most/all cases.
                 // Also, if we've reached the maximum number of retries, don't retry anymore.
-                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries)
+                if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(mySqlException))
                 {
                     logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
                     throw new GclQueryException("Error trying to run query", query, mySqlException);
                 }
 
                 // If we're not in a transaction, retry the query if it's a deadlock.
-                if (MySqlErrorCodesToRetry.Contains(mySqlException.Number))
-                {
-                    Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
-                    return await InsertRecordAsync(query, retryCount + 1, useWritingConnectionIfAvailable);
-                }
-
-                // For any other errors, just throw the exception.
-                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
-                throw new GclQueryException("Error trying to run query", query, mySqlException);
+                Thread.Sleep(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+                return await InsertRecordAsync(query, retryCount + 1, useWritingConnectionIfAvailable);
             }
             finally
             {
@@ -845,7 +823,7 @@ namespace GeeksCoreLibrary.Modules.Databases.Services
             {
                 // Checks if the exception is about the timezone or something else related to MySQL.
                 // Not setting timezones when they are not available should not be logged as en error.
-                if (mySqlException.Number == 1298)
+                if (mySqlException.ErrorCode == MySqlErrorCode.UnknownTimeZone)
                 {
                     logger.LogInformation($"The time zone is not set to '{gclSettings.DatabaseTimeZone}', because that timezone is not available in the database.");
                 }


### PR DESCRIPTION
# Describe your changes

A while ago, a change was made in the GCL to always throw a custom new `GclQueryException` when an error occurs while executing an MySQL query. This caused error handling based on `MySqlException` to no longer work. I fixed this now so that the error handling works with `GclQueryException`.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By simulating exceptions and testing if the error handling works.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests


# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1208880798391869
