### PR TITLE
Image transparency changes

### DIFF
--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -650,15 +650,15 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                     throw new NotSupportedException("Unsupported file type.");
             }
 
+            var fillColor = MagickColors.Transparent;
+            if (!imageFormat.InList(MagickFormat.Gif, MagickFormat.Png, MagickFormat.WebP, MagickFormat.Tif, MagickFormat.Tiff, MagickFormat.Avif, MagickFormat.Jxl))
+            {
+                fillColor = MagickColors.White;
+            }
+
             byte[] outFileBytes;
             if (preferredWidth > 0 && preferredHeight > 0)
             {
-                var fillColor = MagickColors.Transparent;
-                if (!extension.InList(".gif", ".png", ".webp"))
-                {
-                    fillColor = MagickColors.White;
-                }
-
                 // GIF images are a bit different because they have multiple frames.
                 if (imageFormat == MagickFormat.Gif)
                 {
@@ -670,6 +670,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
 
                     foreach (var frame in collection)
                     {
+                        if (fillColor != MagickColors.Transparent)
+                        {
+                            frame.BackgroundColor = fillColor;
+                            frame.Alpha(AlphaOption.Remove);
+                        }
+
                         switch (resizeMode)
                         {
                             case ResizeModes.Normal:
@@ -697,6 +703,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 else
                 {
                     using var image = new MagickImage(fileBytes);
+
+                    if (fillColor != MagickColors.Transparent)
+                    {
+                        image.BackgroundColor = fillColor;
+                        image.Alpha(AlphaOption.Remove);
+                    }
 
                     if (imageFormat.InList(MagickFormat.Jpg, MagickFormat.WebP))
                     {
@@ -741,6 +753,15 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                     // during the animation. More info here: http://www.imagemagick.org/Usage/anim_basics/#coalesce
                     collection.Coalesce();
 
+                    if (fillColor != MagickColors.Transparent)
+                    {
+                        foreach (var frame in collection)
+                        {
+                            frame.BackgroundColor = fillColor;
+                            frame.Alpha(AlphaOption.Remove);
+                        }
+                    }
+
                     // Now, after removing the original optimizations, optimize the result again.
                     // This can potentially reduce the file size by quite a bit.
                     collection.OptimizePlus();
@@ -751,6 +772,12 @@ namespace GeeksCoreLibrary.Modules.ItemFiles.Services
                 else
                 {
                     using var image = new MagickImage(fileBytes);
+
+                    if (fillColor != MagickColors.Transparent)
+                    {
+                        image.BackgroundColor = fillColor;
+                        image.Alpha(AlphaOption.Remove);
+                    }
 
                     if (imageFormat.InList(MagickFormat.Jpg, MagickFormat.WebP))
                     {


### PR DESCRIPTION
# Describe your changes

Changes how transparency is handled when converting an image with a format that supports transparency to an image format that doesn't support transparency. Previously it would revert to the default, which is always black. Now it fills the transparent part with white pixels and actively removes the alpha channel.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build to test what happens when converting an image with an alpha channel (like PNG and WebP) to an image without an alpha channel (JPEG) and confirmed that the transparent pixels were replaced with white pixels.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira issue key

CON-154