### PR TITLE
changed variableName used in query to prevent it from being overwritten

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -425,22 +425,22 @@ VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)");
                                     WHERE id = ?itemId
                                 );
 
-                                SET @newItemId = (SELECT LAST_INSERT_ID());
+                                SET @lastInsertedId = (SELECT LAST_INSERT_ID());
 
                                 {addItemLinkQuery}
 
                                 #Duplicate values
                                 INSERT INTO {tablePrefix}{WiserTableNames.WiserItemDetail} (language_code, item_id, groupname, `key`, `value`, long_value)
-                                (SELECT language_code, @newItemId, groupname, `key`, `value`, long_value FROM {tablePrefix}{WiserTableNames.WiserItemDetail} WHERE item_id = ?itemId);
+                                (SELECT language_code, @lastInsertedId, groupname, `key`, `value`, long_value FROM {tablePrefix}{WiserTableNames.WiserItemDetail} WHERE item_id = ?itemId);
 
                                 #Duplicate files
                                 INSERT INTO {tablePrefix}{WiserTableNames.WiserItemFile} (item_id, content_type, content, content_url, width, height, file_name, extension, title, property_name, added_on, added_by)
-                                (SELECT @newItemId, content_type, content, content_url, width, height, file_name, extension, title, property_name, NOW(), ?username FROM {tablePrefix}{WiserTableNames.WiserItemFile} WHERE item_id = ?itemId);
+                                (SELECT @lastInsertedId, content_type, content, content_url, width, height, file_name, extension, title, property_name, NOW(), ?username FROM {tablePrefix}{WiserTableNames.WiserItemFile} WHERE item_id = ?itemId);
 
-                                SELECT @newItemId AS newItemId, we.icon, {(useItemParentId ? "0" : "@newLinkId")} AS newLinkId, i.title
+                                SELECT @lastInsertedId AS newItemId, we.icon, {(useItemParentId ? "0" : "@newLinkId")} AS newLinkId, i.title
                                 FROM {tablePrefix}{WiserTableNames.WiserItem} i
                                 LEFT JOIN {WiserTableNames.WiserEntity} we ON we.name = i.entity_type
-                                WHERE i.id = @newItemId
+                                WHERE i.id = @lastInsertedId
                                 LIMIT 1;";
 
                 var dataTable = await databaseConnection.GetAsync(query, true);


### PR DESCRIPTION
# Describe your changes

There was a issue with the duplication of configurators at one of our customers, the variable gets replaced which results in a query that reads "123 = last_inserted_id();" which ofcourse is invalid code and causes a issue.

I renamed this variable so its not overwritten anymore.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?
on wiserdemo since we lack SSH support to test it locally on the affected database

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests
NA

# Link to Asana ticket
CON-818
