### PR TITLE
Fixed problem that the RolesService.GetRolesAsync function returned way too many rows since the latest change.

### DIFF
--- a/GeeksCoreLibrary/Core/Models/RoleModel.cs
+++ b/GeeksCoreLibrary/Core/Models/RoleModel.cs
@@ -21,9 +21,4 @@ public class RoleModel
     /// Gets or sets all permissions for this role.
     /// </summary>
     public List<PermissionModel> Permissions { get; set; }
-    
-    /// <summary>
-    /// Gets or sets the ip addresses of the role.
-    /// </summary>
-    public List<string> IpAddresses { get; set; }
 }

--- a/GeeksCoreLibrary/Core/Services/RolesService.cs
+++ b/GeeksCoreLibrary/Core/Services/RolesService.cs
@@ -32,22 +32,20 @@ public class RolesService : IRolesService, ITransientService
         string query;
         if (includePermissions)
         {
-            query = $$"""
-                      SELECT 
-                          role.id, 
-                          role.role_name,
-                          user_role.ip_addresses,
-                          permission.item_id,
-                          permission.entity_property_id,
-                          permission.module_id,
-                          permission.permissions,
-                      	permission.endpoint_url,
-                      	permission.endpoint_http_method
-                      FROM {{WiserTableNames.WiserRoles}} AS role 
-                      LEFT JOIN {{WiserTableNames.WiserUserRoles}} AS user_role ON user_role.role_id = role.id
-                      LEFT JOIN {{WiserTableNames.WiserPermission}} AS permission ON permission.role_id = role.id
-                      ORDER BY role_name ASC
-                      """;
+            query = $"""
+                    SELECT 
+                        role.id, 
+                        role.role_name,
+                        permission.item_id,
+                        permission.entity_property_id,
+                        permission.module_id,
+                        permission.permissions,
+                        permission.endpoint_url,
+                        permission.endpoint_http_method
+                    FROM {WiserTableNames.WiserRoles} AS role 
+                    LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = role.id
+                    ORDER BY role_name ASC
+                    """;
         }
         else
         {
@@ -72,8 +70,7 @@ public class RolesService : IRolesService, ITransientService
                 role = new RoleModel
                 {
                     Id = roleId,
-                    Name = dataRow.Field<string>("role_name"),
-                    IpAddresses = dataRow.IsNull("ip_addresses") ? null : JsonConvert.DeserializeObject<List<string>>(dataRow.Field<string>("ip_addresses"))
+                    Name = dataRow.Field<string>("role_name")
                 };
 
                 results.Add(role);

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -2020,10 +2020,11 @@ public class WiserItemsService(
         // First check permissions based on module ID.
         var permissionsQuery = $"""
                                 SELECT permission.permissions
-                                                                    FROM {WiserTableNames.WiserUserRoles} AS user_role
-                                                                    JOIN {tablePrefix}{WiserTableNames.WiserItem} AS item ON item.id = ?itemId AND item.moduleid > 0
-                                                                    LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.module_id = item.moduleid
-                                                                    WHERE user_role.user_id = ?userId AND (user_role.ip_addresses IS NULL OR JSON_CONTAINS(user_role.ip_addresses, JSON_QUOTE(?userIp)))
+                                FROM {WiserTableNames.WiserUserRoles} AS user_role
+                                JOIN {tablePrefix}{WiserTableNames.WiserItem} AS item ON item.id = ?itemId AND item.moduleid > 0
+                                LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.module_id = item.moduleid
+                                WHERE user_role.user_id = ?userId
+                                AND (user_role.ip_addresses IS NULL OR JSON_CONTAINS(user_role.ip_addresses, JSON_QUOTE(?userIp)))
                                 """;
 
         databaseConnection.AddParameter("itemId", itemId);
@@ -2070,9 +2071,10 @@ public class WiserItemsService(
         // Then check the permissions for the specific item, they overwrite permissions of the module.
         permissionsQuery = $"""
                             SELECT permission.permissions
-                                                            FROM {WiserTableNames.WiserUserRoles} AS user_role
-                                                            LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = ?itemId
-                                                            WHERE user_role.user_id = ?userId AND (user_role.ip_addresses IS NULL OR JSON_CONTAINS(user_role.ip_addresses, JSON_QUOTE(?userIp)))
+                            FROM {WiserTableNames.WiserUserRoles} AS user_role
+                            LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = ?itemId
+                            WHERE user_role.user_id = ?userId
+                            AND (user_role.ip_addresses IS NULL OR JSON_CONTAINS(user_role.ip_addresses, JSON_QUOTE(?userIp)))
                             """;
         dataTable = await databaseConnection.GetAsync(permissionsQuery, true);
 


### PR DESCRIPTION
# Describe your changes

Recently new functionality was added to connect roles to users based on their IP address. This caused the function `RolesService.GetRolesAsync` to return way too many results, because a JOIN was added in the wrong place.

I fixed this by removing the JOIN in that query and changing the correct query to get the roles.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
