### PR TITLE
Update for "unsafe source" replacements

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Enums/UnsafeSources.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Enums/UnsafeSources.cs
@@ -1,0 +1,9 @@
+﻿namespace GeeksCoreLibrary.Modules.GclReplacements.Enums;
+
+public enum UnsafeSources
+{
+    /// <summary>
+    /// The source is the HTTP request (query string, form body, etc.).
+    /// </summary>
+    HttpRequest
+}

--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using GeeksCoreLibrary.Modules.GclReplacements.Enums;
 using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
 using GeeksCoreLibrary.Modules.GclReplacements.Models;
 using Microsoft.AspNetCore.Http;
@@ -16,18 +17,18 @@ public interface IReplacementsMediator
 {
     /// <summary>
     /// Performs all replacements on a string using all data from a <see cref="DataSet"/>.
-    /// This will return an IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been done.
+    /// This will return an IEnumerable of IEnumerable of strings. So you will have a string for each row in each table where the replacements have been done.
     /// </summary>
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>An IEnumerable of IEnumerable of strings. So you will have a string for each row in each table, where the replacements have been performed.</returns>
-    IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using all data from a <see cref="DataTable"/>.
@@ -36,13 +37,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>An IEnumerable of strings. So you will have a string for each row in the table, where the replacements have been performed.</returns>
-    IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using the data from a DataRow.
@@ -50,13 +51,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.
@@ -65,13 +66,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, StringValues&gt;&gt; interface.
@@ -80,13 +81,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the ISession interface.
@@ -95,13 +96,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs replacements on a string using a JToken. This function is the most generic function, and all other replacement functions also use this function.
@@ -109,13 +110,13 @@ public interface IReplacementsMediator
     /// <param name="input">The string to do replacements on.</param>
     /// <param name="replaceData">The data that needs to be used for the replacements.</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
-    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case sensitive. Default is true.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
     /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs replacements on a string using a dictionary of some type. This function is the most generic function, and all other replacement functions also use this function.
@@ -126,9 +127,9 @@ public interface IReplacementsMediator
     /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
     /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
-    /// <param name="isFromUnsafeSource">Optional: The <see cref="replaceData"/> is from an untrusted source, e.g. user input.</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
-    string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false);
+    string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Evaluates logic snippets in a string. These are simple if/else statements that can be used to conditionally include or exclude parts of a template.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -6,10 +6,12 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
+using GeeksCoreLibrary.Modules.GclReplacements.Enums;
 using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.GclReplacements.Models;
@@ -49,7 +51,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     }
 
     /// <inheritdoc />
-    public IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public IEnumerable<IEnumerable<string>> DoReplacements(string input, DataSet replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null || replaceData.Tables.Count == 0)
         {
@@ -58,12 +60,12 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
         foreach (DataTable dataTable in replaceData.Tables)
         {
-            yield return DoReplacements(input, dataTable, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+            yield return DoReplacements(input, dataTable, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
         }
     }
 
     /// <inheritdoc />
-    public IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public IEnumerable<string> DoReplacements(string input, DataTable replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null || replaceData.Rows.Count == 0)
         {
@@ -72,12 +74,12 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
         foreach (DataRow dataRow in replaceData.Rows)
         {
-            yield return DoReplacements(input, dataRow, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+            yield return DoReplacements(input, dataRow, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
         }
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null)
         {
@@ -90,11 +92,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(column.ColumnName, replaceData[column]);
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, isFromUnsafeSource);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, string>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null)
         {
@@ -107,11 +109,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(key, value);
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, isFromUnsafeSource);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, IEnumerable<KeyValuePair<string, StringValues>> replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null)
         {
@@ -124,11 +126,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(key, value.ToString());
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, isFromUnsafeSource);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, ISession replaceData, bool forQuery = false, bool caseSensitive = false, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         var dataDictionary = new Dictionary<string, object>(caseSensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         foreach (var item in replaceData.Keys)
@@ -141,11 +143,11 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             dataDictionary.Add(item, Encoding.UTF8.GetString(rawValue));
         }
 
-        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, isFromUnsafeSource);
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, JToken replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null)
         {
@@ -167,7 +169,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         }
 
         // Do the replacements for the current level.
-        output = DoReplacements(output, dataDictionary, prefix, suffix, forQuery, defaultFormatter, isFromUnsafeSource);
+        output = DoReplacements(output, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
 
         // Repeat the process for each object in the current level until the bottom is reached.
         foreach (var jToken in replaceData)
@@ -178,7 +180,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                     switch (item.Value.Type)
                     {
                         case JTokenType.Object:
-                            output = DoReplacements(output, item.Value, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+                            output = DoReplacements(output, item.Value, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
                             break;
                         case JTokenType.Array:
                         {
@@ -189,7 +191,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                                     continue;
                                 }
 
-                                output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+                                output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
                             }
 
                             break;
@@ -198,7 +200,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
                     break;
                 case JObject jObject:
-                    output = DoReplacements(output, jObject, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+                    output = DoReplacements(output, jObject, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
                     break;
                 case JArray jArray:
                 {
@@ -209,7 +211,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                             continue;
                         }
 
-                        output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix, defaultFormatter, isFromUnsafeSource);
+                        output = DoReplacements(output, subItem, forQuery, caseSensitive, prefix, suffix, defaultFormatter, unsafeSource);
                     }
 
                     break;
@@ -221,7 +223,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     }
 
     /// <inheritdoc />
-    public string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode", bool isFromUnsafeSource = false)
+    public string DoReplacements(string input, IDictionary<string, object> replaceData, string prefix = "{", string suffix = "}", bool forQuery = false, string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         if (replaceData == null || replaceData.Count == 0)
         {
@@ -263,11 +265,16 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             var value = Convert.ToString(replaceData[variableName], new CultureInfo("en-US"));
 
             // If the value comes from un untrusted source (e.g. user input), we need to strip HTML tags to prevent XSS attacks.
-            if (isFromUnsafeSource)
+            if (unsafeSource.HasValue)
             {
                 value = value.StripHtml();
+                value = unsafeSource switch
+                {
+                    UnsafeSources.HttpRequest => HttpUtility.UrlEncode(value),
+                    _ => throw new ArgumentOutOfRangeException(nameof(unsafeSource), unsafeSource, null)
+                };
             }
-            
+
             if (String.IsNullOrWhiteSpace(value))
             {
                 if (!String.IsNullOrEmpty(variable.DefaultValue))
@@ -280,7 +287,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                 continue;
             }
 
-            if (skipFormatters || !variable.Formatters.Any())
+            if (skipFormatters || variable.Formatters.Count == 0)
             {
                 // Simply replace the variable if there are no formatters found.
                 if (forQuery)
@@ -578,7 +585,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
 
         var optionalParameterCount = methodParameters.Count(p => p.IsOptional);
 
-        // The reason for the -1 is because the first parameter of an extension method is always the value of the type it's extending.
+        // The reason for the -1 is that the first parameter of an extension method is always the value of the type it's extending.
         // Therefore, that parameter should not be added in the count.
         var totalParameterCount = methodParameters.Length - 1;
         var minimumParameterCount = totalParameterCount - optionalParameterCount;
@@ -634,7 +641,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
     }
 
     /// <summary>
-    /// Converts the type of a string value to the given <see cref="Type"/>.
+    /// Converts a string value to the given <see cref="Type"/>.
     /// </summary>
     /// <param name="input">The string that needs conversion.</param>
     /// <param name="type">The <see cref="Type"/> the string needs be converted to.</param>

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -10,6 +10,7 @@ using GeeksCoreLibrary.Components.Account.Interfaces;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.GclReplacements.Enums;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
@@ -232,21 +233,21 @@ public class StringReplacementsService(
         // GET variables.
         if (httpContextAccessor.HttpContext.Items.ContainsKey(Constants.WiserUriOverrideForReplacements) && httpContextAccessor.HttpContext.Items[Constants.WiserUriOverrideForReplacements] is Uri wiserUriOverride)
         {
-            input = replacementsMediator.DoReplacements(input, QueryHelpers.ParseQuery(wiserUriOverride.Query), forQuery, defaultFormatter: String.Empty, isFromUnsafeSource: true);
+            input = replacementsMediator.DoReplacements(input, QueryHelpers.ParseQuery(wiserUriOverride.Query), forQuery, defaultFormatter: String.Empty, unsafeSource: UnsafeSources.HttpRequest);
         }
         else
         {
-            input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Query, forQuery, defaultFormatter: String.Empty, isFromUnsafeSource: true);
+            input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Query, forQuery, defaultFormatter: String.Empty, unsafeSource: UnsafeSources.HttpRequest);
         }
 
         // POST variables.
         if (httpContextAccessor.HttpContext.Request.HasFormContentType)
         {
-            input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Form, forQuery, defaultFormatter: String.Empty, isFromUnsafeSource: true);
+            input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Form, forQuery, defaultFormatter: String.Empty, unsafeSource: UnsafeSources.HttpRequest);
         }
 
         // Cookies.
-        input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Cookies, forQuery, defaultFormatter: String.Empty, isFromUnsafeSource: true);
+        input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Request.Cookies, forQuery, defaultFormatter: String.Empty, unsafeSource: UnsafeSources.HttpRequest);
 
         // Request cache.
         input = replacementsMediator.DoReplacements(input, httpContextAccessor.HttpContext.Items.Select(x => new KeyValuePair<string, string>(x.Key?.ToString(), x.Value?.ToString())), forQuery, defaultFormatter: defaultFormatter);


### PR DESCRIPTION
# Describe your changes

A small update to the "unsafe source" functionality for the replacements so it knows what the exact source is for additional control over what kind of protection should be added (like protection against XSS). For now, only the HttpRequest is added as an unsafe source, which means that the values will be URL-encoded.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested to see if the additional protection fixes a few XSS vulnerabilities that were found.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira issue key

CON-918