### PR TITLE
Fix 0 vat rate percentage not being possible to set

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Models/Constants.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Models/Constants.cs
@@ -39,6 +39,8 @@ public static class Constants
     internal const string DefaultDiscountPropertyName = "discount";
     internal const string DefaultItemExcludedFromDiscountPropertyName = "no_discount";
     internal const int DefaultMaxItemQuantity = 100;
+    internal const decimal DefaultVatPercentage = 21M;
+    internal const int DefaultVatRate = 1;
 
     internal const string DefaultTemplate = """
                                             <!-- There must always be an element with ID GclShoppingBasketContainer{contentId}, all fields within are sent to the server via ajax, unless you also overwrite the TemplateJavascript. -->

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Models/VatRule.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Models/VatRule.cs
@@ -9,7 +9,7 @@ public class VatRule
     /// </summary>
     public int B2B { get; set; } = -1;
 
-    public int VatRate { get; set; } = 1;
+    public int VatRate { get; set; } = Constants.DefaultVatRate;
 
-    public decimal Percentage { get; set; } = 21M;
+    public decimal Percentage { get; set; } = Constants.DefaultVatPercentage;
 }


### PR DESCRIPTION
# Describe your changes

When getting the vatrules from the database when the a vatrule had a vatratepercentage of 0, the code assumed this meant no vateratepercentage was given and changed it to the default of 21 this meant vatrates of 0 didn't work.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Opened a basket in which multiple vatrates were used including 0. The price was incorrect before the change and it was correct after.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1209115089987721
