### PR TITLE
Fix bug with price basket detail not being handled well in basket replacements

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -1071,6 +1071,13 @@ public class ShoppingBasketsService(
                     }
 
                     var replaceData = line.GetSortedList(true);
+                    
+                    // Remove the variables that are handled by this method so they aren't handled by stringReplacementsService.DoReplacements
+                    replaceData.Remove("price");
+                    replaceData.Remove("singleprice");
+                    replaceData.Remove("pricewithoutfactor");
+                    replaceData.Remove("singlepricewithoutfactor");
+                    
                     replaceData["rowindex"] = index.ToString(CultureInfo.InvariantCulture);
 
                     var lineTemplate = subTemplate;


### PR DESCRIPTION
# Describe your changes

When the basket had a detail called `price` this would get used when doing the replacements in the basket instead of the value calculated by the ShoppingBasketService. To fix this those details are removed from the replacement data before calling doReplacements

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used the GenerateHtmlFromBasket function in a basket with a detail called price to generate a PDF.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1209151457501068
https://app.asana.com/0/1151477971646641/1209138204185196
