### PR TITLE
Fixed problem that background images in PDFs no longer worked

### DIFF
--- a/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/ShoppingBasket.cs
@@ -732,7 +732,7 @@ public class ShoppingBasket : CmsComponent<ShoppingBasketCmsSettingsModel, Shopp
 
         if (saveToDisk)
         {
-            FileSystemHelpers.SaveFileToContentFilesFolder(webHostEnvironment, filename, pdfFileResult.FileContents);
+            FileSystemHelpers.SaveToFileCacheDirectory(webHostEnvironment, filename, pdfFileResult.FileContents);
         }
         else
         {

--- a/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
@@ -34,7 +34,7 @@ public static class FileSystemHelpers
 
     /// <summary>
     /// Get the full path to the public files directory.
-    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// As the name indicates, this is for storing files that are public and can be accessed by anyone.
     /// So make sure you don't store any sensitive information in this directory.
     /// </summary>
     /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>
@@ -70,7 +70,7 @@ public static class FileSystemHelpers
 
     /// <summary>
     /// Save a file to the public files directory.
-    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// As the name indicates, this is for storing files that are public and can be accessed by anyone.
     /// So make sure you don't store any sensitive information in this directory.
     /// </summary>
     /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>
@@ -97,7 +97,7 @@ public static class FileSystemHelpers
 
     /// <summary>
     /// Save a file to the public files directory.
-    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// As the name indicates, this is for storing files that are public and can be accessed by anyone.
     /// So make sure you don't store any sensitive information in this directory.
     /// </summary>
     /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>

--- a/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/FileSystemHelpers.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Models;
 using Microsoft.AspNetCore.Hosting;
 
@@ -9,7 +10,7 @@ namespace GeeksCoreLibrary.Core.Helpers;
 
 public static class FileSystemHelpers
 {
-    public static string GetContentFilesFolderPath(IWebHostEnvironment webHostEnvironment)
+    public static string GetFileCacheDirectory(IWebHostEnvironment webHostEnvironment)
     {
         if (webHostEnvironment == null)
         {
@@ -31,16 +32,94 @@ public static class FileSystemHelpers
         return !Directory.Exists(result) ? null : result;
     }
 
-    public static string SaveFileToContentFilesFolder(IWebHostEnvironment webHostEnvironment, string filename, byte[] fileBytes)
+    /// <summary>
+    /// Get the full path to the public files directory.
+    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// So make sure you don't store any sensitive information in this directory.
+    /// </summary>
+    /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>
+    /// <returns>If the directory exists, it returns the absolute path to the directory. Otherwise, it returns <c>null</c>.</returns>
+    public static string GetPublicFilesDirectory(IWebHostEnvironment webHostEnvironment)
     {
         if (webHostEnvironment == null)
         {
             return null;
         }
 
-        var path = Path.Combine(GetContentFilesFolderPath(webHostEnvironment), Path.GetFileName(filename));
-        File.WriteAllBytes(Path.Combine(GetContentFilesFolderPath(webHostEnvironment), Path.GetFileName(filename)), fileBytes);
-        return path;
+        var result = Path.Combine(webHostEnvironment.WebRootPath, Constants.PublicFilesDirectoryName);
+        return !Directory.Exists(result) ? null : result;
+    }
+
+    public static string SaveToFileCacheDirectory(IWebHostEnvironment webHostEnvironment, string filename, byte[] fileBytes)
+    {
+        if (webHostEnvironment == null)
+        {
+            return null;
+        }
+
+        var directoryLocation = GetFileCacheDirectory(webHostEnvironment);
+        if (String.IsNullOrWhiteSpace(directoryLocation))
+        {
+            return null;
+        }
+
+        var fileLocation = Path.Combine(directoryLocation, Path.GetFileName(filename));
+        File.WriteAllBytes(fileLocation, fileBytes);
+        return fileLocation;
+    }
+
+    /// <summary>
+    /// Save a file to the public files directory.
+    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// So make sure you don't store any sensitive information in this directory.
+    /// </summary>
+    /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>
+    /// <param name="filename">The name of the file (including extension). Any directory or location information will be stripped, only the name of the file will be used.</param>
+    /// <param name="fileBytes">The byte array with the contents of the file.</param>
+    /// <returns>If the file was saved successfully, then the absolute path to the file will be returned. Otherwise, <c>null</c> will be returned.</returns>
+    public static string SaveToPublicFilesDirectory(IWebHostEnvironment webHostEnvironment, string filename, byte[] fileBytes)
+    {
+        if (webHostEnvironment == null)
+        {
+            return null;
+        }
+
+        var directoryLocation = GetPublicFilesDirectory(webHostEnvironment);
+        if (String.IsNullOrWhiteSpace(directoryLocation))
+        {
+            return null;
+        }
+
+        var fileLocation = Path.Combine(directoryLocation, Path.GetFileName(filename));
+        File.WriteAllBytes(fileLocation, fileBytes);
+        return fileLocation;
+    }
+
+    /// <summary>
+    /// Save a file to the public files directory.
+    /// As the name indicated, this is for storing files that are public and can be accessed by anyone.
+    /// So make sure you don't store any sensitive information in this directory.
+    /// </summary>
+    /// <param name="webHostEnvironment">The <see cref="IWebHostEnvironment"/> that provides information about the web hosting environment an application is running in.</param>
+    /// <param name="filename">The name of the file (including extension). Any directory or location information will be stripped, only the name of the file will be used.</param>
+    /// <param name="fileBytes">The byte array with the contents of the file.</param>
+    /// <returns>If the file was saved successfully, then the absolute path to the file will be returned. Otherwise, <c>null</c> will be returned.</returns>
+    public static async Task<string> SaveToPublicFilesDirectoryAsync(IWebHostEnvironment webHostEnvironment, string filename, byte[] fileBytes)
+    {
+        if (webHostEnvironment == null)
+        {
+            return null;
+        }
+
+        var directoryLocation = GetPublicFilesDirectory(webHostEnvironment);
+        if (String.IsNullOrWhiteSpace(directoryLocation))
+        {
+            return null;
+        }
+
+        var fileLocation = Path.Combine(directoryLocation, Path.GetFileName(filename));
+        await File.WriteAllBytesAsync(fileLocation, fileBytes);
+        return fileLocation;
     }
 
     public static string GetMediaTypeByMagicNumber(byte[] fileBytes)

--- a/GeeksCoreLibrary/Core/Models/Constants.cs
+++ b/GeeksCoreLibrary/Core/Models/Constants.cs
@@ -6,6 +6,7 @@ public class Constants
     public const string AppDataDirectoryName = "App_Data";
     public const string OutputCacheDirectoryName = "OutputCache";
     public const string FilesCacheDirectoryName = "FilesCache";
+    public const string PublicFilesDirectoryName = "PublicFiles";
 
     // Keys for the JSON object that we need to read, from the "options" column in the table "wiser_entityproperty".
     public const string FieldTypeKey = "_fieldType";

--- a/GeeksCoreLibrary/Core/Services/CacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/CacheService.cs
@@ -131,7 +131,7 @@ public class CacheService : ICacheService, ISingletonService
     /// <inheritdoc />
     public void ClearFilesCache()
     {
-        var contentFilesFolder = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var contentFilesFolder = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(contentFilesFolder))
         {
             return;

--- a/GeeksCoreLibrary/Modules/Barcodes/Services/CachedBarcodesService.cs
+++ b/GeeksCoreLibrary/Modules/Barcodes/Services/CachedBarcodesService.cs
@@ -35,7 +35,7 @@ public class CachedBarcodesService : IBarcodesService
         byte[] fileBytes;
 
         // Retrieve the path of the cache directory.
-        var cacheBasePath = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var cacheBasePath = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(cacheBasePath))
         {
             // Log a warning if the directory doesn't exist, and generate a new barcode.
@@ -55,7 +55,7 @@ public class CachedBarcodesService : IBarcodesService
 
         // Generate new barcode if it doesn't exist yet or if it's older than one hour.
         fileBytes = barcodesService.GenerateBarcode(input, format, width, height);
-        FileSystemHelpers.SaveFileToContentFilesFolder(webHostEnvironment, filename, fileBytes);
+        FileSystemHelpers.SaveToFileCacheDirectory(webHostEnvironment, filename, fileBytes);
         return fileBytes;
     }
 }

--- a/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
+++ b/GeeksCoreLibrary/Modules/GclConverters/Services/HtmlToPdfConverterService.cs
@@ -339,7 +339,6 @@ public class HtmlToPdfConverterService(
         databaseConnection.AddParameter("itemId", itemId);
         databaseConnection.AddParameter("propertyName", backgroundPropertyName);
         var getImageResult = await databaseConnection.GetAsync($"""
-                                                                
                                                                                 SELECT content, file_name
                                                                                 FROM `{WiserTableNames.WiserItemFile}`
                                                                                 WHERE item_id = ?itemId AND property_name = ?propertyName
@@ -361,7 +360,7 @@ public class HtmlToPdfConverterService(
             return null;
         }
 
-        var filePath = FileSystemHelpers.SaveFileToContentFilesFolder(webHostEnvironment, filename, content);
-        return filePath.Replace(webHostEnvironment.WebRootPath, "").Replace(@"\", "/");
+        var filePath = await FileSystemHelpers.SaveToPublicFilesDirectoryAsync(webHostEnvironment, filename, content);
+        return filePath?.Replace(webHostEnvironment.WebRootPath, "")?.Replace(@"\", "/");
     }
 }

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -118,7 +118,7 @@ public class CachedItemFilesService(IOptions<GclSettings> gclSettings, IItemFile
             return false;
         }
 
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (!Directory.Exists(localDirectory))
         {
             return false;
@@ -141,7 +141,7 @@ public class CachedItemFilesService(IOptions<GclSettings> gclSettings, IItemFile
             return (null, DateTime.MinValue);
         }
 
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);;
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);;
         var fileLocation = Path.Combine(localDirectory, localFilename);
 
         var fileBytes = await File.ReadAllBytesAsync(fileLocation);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -67,7 +67,7 @@ public class ItemFilesService(
         }
 
         var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve image because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -110,7 +110,7 @@ public class ItemFilesService(
         }
 
         var linkTypePart = linkType == 0 ? "" : $"_{linkType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve image because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -150,7 +150,7 @@ public class ItemFilesService(
         }
 
         var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve image because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -208,7 +208,7 @@ public class ItemFilesService(
         }
 
         var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve image because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -251,7 +251,7 @@ public class ItemFilesService(
         }
 
         var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve file because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -295,7 +295,7 @@ public class ItemFilesService(
         }
 
         var linkTypePart = linkType == 0 ? "" : $"_{linkType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve file because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -336,7 +336,7 @@ public class ItemFilesService(
         }
 
         var entityTypePart = String.IsNullOrWhiteSpace(entityType) ? "" : $"_{entityType}";
-        var localDirectory = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+        var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
         if (String.IsNullOrWhiteSpace(localDirectory))
         {
             logger.LogError($"Could not retrieve file because the directory '{localDirectory}' does not exist. Please create it and give it modify permissions to the user that is running the website.");
@@ -461,7 +461,7 @@ public class ItemFilesService(
                             var s3Bucket = contentUri.Host;
                             var s3Object = contentUri.LocalPath.TrimStart('/');
 
-                            var localPath = FileSystemHelpers.GetContentFilesFolderPath(webHostEnvironment);
+                            var localPath = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);
                             if (await amazonS3Service.DownloadObjectFromBucketAsync(s3Bucket, s3Object, localPath))
                             {
                                 fileBytes = await File.ReadAllBytesAsync(Path.Combine(localPath, s3Object));


### PR DESCRIPTION
# Describe your changes

There was a problem that background images in PDFs did not work anymore. This was caused by moving the FilesCache directory outside of the wwwroot, which made them no longer publicly available. That also meant that the PDF converted could no longer access the files.

To fix this, I created a new `PublicFiles` directory in the `wwwroot`, with corresponding helper functions for using this new directory. The HTML to PDF converted now saves the background images in this new directory, which fixes the problem.

I also renamed other helper functions that had strange names, so that the names make more sense.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I tested this in Wiser, by generating PDF files and testing if they have background images.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1182779092805226/1209312570707874
