### PR TITLE
Skip stripping and encoding sql parameters.

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -265,7 +265,8 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             var value = Convert.ToString(replaceData[variableName], new CultureInfo("en-US"));
 
             // If the value comes from un untrusted source (e.g. user input), we need to strip HTML tags to prevent XSS attacks.
-            if (unsafeSource.HasValue)
+            // If the replacements are for a query the inputs are protected using sql parameters so encoding can be skipped.
+            if (unsafeSource.HasValue && !forQuery)
             {
                 value = value.StripHtml();
                 value = unsafeSource switch


### PR DESCRIPTION
# Describe your changes

Recently it was added that replacements from unsafe sources would get url encoded. This caused problems in some queries were for example a `,` would get changed into `%2c`. Causing those queries to no longer produce the correct results.

For queries replacements are already done using sql parameters so further sanisation isn't needed in this context.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Ran a query in which comma seperated values were used. After the fix the correct results were returned.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1201394730777422/1209329181412568
