### PR TITLE
Fix easy objects from being loaded with no key

### DIFF
--- a/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
+++ b/GeeksCoreLibrary/Modules/Objects/Services/CachedObjectsService.cs
@@ -49,7 +49,7 @@ public class CachedObjectsService(
 
             var objects = new Dictionary<string, SettingObject>(StringComparer.OrdinalIgnoreCase);
 
-            await using var reader = await databaseConnection.GetReaderAsync(@"SELECT `key`, `value`, `description`, `typenr` FROM easy_objects WHERE active = 1");
+            await using var reader = await databaseConnection.GetReaderAsync("SELECT `key`, `value`, `description`, `typenr` FROM easy_objects WHERE active = 1 AND `key` IS NOT NULL");
             while (await reader.ReadAsync())
             {
                 objects.Add($"{reader.GetString(reader.GetOrdinal("key"))}{reader.GetInt32(reader.GetOrdinal("typenr"))}", reader.ToObjectModel());

--- a/GeeksCoreLibrary/Modules/Objects/Services/ObjectsService.cs
+++ b/GeeksCoreLibrary/Modules/Objects/Services/ObjectsService.cs
@@ -154,12 +154,12 @@ public class ObjectsService : IObjectsService, IScopedService
         string query;
         if (typeNumber == -100)
         {
-            query = @"SELECT `value` FROM easy_objects WHERE active = 1 AND `key` = ?key";
+            query = "SELECT `value` FROM easy_objects WHERE active = 1 AND `key` = ?key";
         }
         else
         {
             databaseConnection.AddParameter("typeNumber", typeNumber);
-            query = @"SELECT `value` FROM easy_objects WHERE active = 1 AND `key` = ?key AND typenr = ?typeNumber";
+            query = "SELECT `value` FROM easy_objects WHERE active = 1 AND `key` = ?key AND typenr = ?typeNumber";
         }
 
         var dataTable = await databaseConnection.GetAsync(query);


### PR DESCRIPTION
# Describe your changes

Easy objects were loaded with keys that were `null` to build the cache. If an invalid key was present the GCL would crash and prevent any page from being loaded.

During branch merges this can occur if an object has been added on both the branch as main database before the merge preventing the system to write the key to the main database.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by adding an item to `easy_objects` with the key as `null` and checked if the website launched after the fix.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1209377447755702
