### PR TITLE
File cache concurrency

### DIFF
--- a/GeeksCoreLibrary/Core/Interfaces/IFileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Interfaces/IFileCacheService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+
+namespace GeeksCoreLibrary.Core.Interfaces;
+
+/// <summary>
+/// Provides methods for managing file-based caching.
+/// </summary>
+public interface IFileCacheService
+{
+    /// <summary>
+    /// Retrieves content from a file if it is not expired; otherwise, regenerates and writes new content.
+    /// </summary>
+    /// <param name="filePath">The path of the file to read or write.</param>
+    /// <param name="generateContent">A function to generate string content if the file is expired.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    /// <returns>The content of the file as a string.</returns>
+    Task<string> GetOrAddAsync(string filePath, Func<Task<string>> generateContent, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Retrieves content from a file if it is not expired; otherwise, regenerates and writes new content.
+    /// </summary>
+    /// <param name="filePath">The path of the file to read or write.</param>
+    /// <param name="generateContent">A function to generate string content if the file is expired.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    /// <returns>The content of the file as a string.</returns>
+    Task<byte[]> GetOrAddAsync(string filePath, Func<Task<(byte[] Content, bool IsCachable)>> generateContent, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Retrieves the byte content from a file if it is not expired.
+    /// </summary>
+    /// <param name="filePath">The path of the file to read.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    /// <returns>The byte content of the file.</returns>
+    Task<byte[]> GetBytesAsync(string filePath, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Retrieves the text content from a file if it is not expired.
+    /// </summary>
+    /// <param name="filePath">The path of the file to read.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    /// <returns>The text content of the file as a string, or null if the file does not exist or is expired.</returns>
+    Task<string> GetTextAsync(string filePath, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Writes a file with string content if it does not exist or if the existing file has expired based on the specified caching time.
+    /// </summary>
+    /// <param name="filePath">The path of the file to write.</param>
+    /// <param name="content">The content to write to the file as a string.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    Task WriteFileIfNotExistsOrExpiredAsync(string filePath, string content, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Writes a file with byte[] content if it does not exist or if the existing file is older than the specified caching minutes.
+    /// </summary>
+    /// <param name="filePath">The path of the file to write.</param>
+    /// <param name="content">The byte array content to write to the file.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    Task WriteFileIfNotExistsOrExpiredAsync(string filePath, byte[] content, TimeSpan? cachingTime = null);
+}

--- a/GeeksCoreLibrary/Core/Services/FileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/FileCacheService.cs
@@ -13,6 +13,11 @@ namespace GeeksCoreLibrary.Core.Services;
 /// </summary>
 public class FileCacheService : IFileCacheService, ISingletonService
 {
+    /// <summary>
+    /// A thread-safe collection to manage active asynchronous write operations in the file caching service.
+    /// Maps file paths to lazily initialized tasks that handle the file write process.
+    /// Used to prevent concurrent file write operations for the same file path.
+    /// </summary>
     private readonly ConcurrentDictionary<string, Lazy<Task<byte[]>>> activeWrites = new();
     
     /// <inheritdoc />

--- a/GeeksCoreLibrary/Core/Services/FileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/FileCacheService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
+using GeeksCoreLibrary.Core.Interfaces;
+
+namespace GeeksCoreLibrary.Core.Services;
+
+/// <summary>
+/// Service for managing file-based caching.
+/// </summary>
+public class FileCacheService : IFileCacheService, ISingletonService
+{
+    private readonly ConcurrentDictionary<string, Lazy<Task<byte[]>>> activeWrites = new();
+    
+    /// <inheritdoc />
+    public async Task<byte[]> GetOrAddAsync(string filePath, Func<Task<(byte[] Content, bool IsCachable)>> generateContentAsync, TimeSpan? cachingTime = null)
+    {
+        var buffer = await GetBytesAsync(filePath, cachingTime);
+        if (buffer != null)
+        {
+            return buffer;
+        }
+
+        var lazyWriteTask = activeWrites.GetOrAdd(filePath, _ =>
+            new(async () =>
+            {
+                var (content, cachable) = await generateContentAsync();
+                if (cachable)
+                {
+                    await WriteFileInternalAsync(filePath, content, cachingTime);
+                }
+                return content;
+            }));
+        return await lazyWriteTask.Value;
+    }
+    
+    /// <inheritdoc />
+    public async Task<string> GetOrAddAsync(string filePath, Func<Task<string>> generateContentAsync, TimeSpan? cachingTime = null)
+    {
+        var contentBytes = await GetOrAddAsync(filePath, async () =>
+        {
+            var content = await generateContentAsync();
+            return (Encoding.UTF8.GetBytes(content), true);
+        }, cachingTime);
+        return Encoding.UTF8.GetString(contentBytes);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> GetBytesAsync(string filePath, TimeSpan? cachingTime = null)
+    {
+        var fileInfo = new FileInfo(filePath);
+        if (!CreateDirectoryIfNotExist(fileInfo) && !IsFileExpired(fileInfo, cachingTime))
+        {
+            if (activeWrites.TryGetValue(filePath, out var writeTask))
+            {
+                return await writeTask.Value;
+            }
+            
+            await using var fileStream = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
+            var buffer = new byte[fileStream.Length];
+            _ = await fileStream.ReadAsync(buffer);
+            return buffer;
+        }
+        return null;
+    }
+    
+    /// <inheritdoc />
+    public async Task<string> GetTextAsync(string filePath, TimeSpan? cachingTime = null)
+    {
+        var buffer = await GetBytesAsync(filePath, cachingTime);
+        return buffer != null ? Encoding.UTF8.GetString(buffer) : null;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteFileIfNotExistsOrExpiredAsync(string filePath, byte[] content, TimeSpan? cachingTime = null)
+    {
+        var lazyWriteTask = activeWrites.GetOrAdd(filePath, _ =>
+            new Lazy<Task<byte[]>>( async () =>
+            {
+                await WriteFileInternalAsync(filePath, content, cachingTime);
+                return content;
+            }));
+        
+        await lazyWriteTask.Value;
+    }
+    
+    /// <inheritdoc />
+    public async Task WriteFileIfNotExistsOrExpiredAsync(string filePath, string content, TimeSpan? cachingTime)
+    {
+        var contentBytes = Encoding.UTF8.GetBytes(content);
+        await WriteFileIfNotExistsOrExpiredAsync(filePath, contentBytes, cachingTime);
+    }
+
+    /// <summary>
+    /// Writes a file with byte[] content if it does not exist or is expired.
+    /// </summary>
+    private async Task WriteFileInternalAsync(string filePath, byte[] content, TimeSpan? cachingTime)
+    {
+        // if the caching time is zero then don't make the file.
+        if (cachingTime == TimeSpan.Zero)
+        {
+            return;
+        }
+        
+        try 
+        {
+            var fileInfo = new FileInfo(filePath);
+            if (IsFileExpired(fileInfo, cachingTime))
+            {
+                await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                await fileStream.WriteAsync(content);
+            }
+        }
+        finally
+        {
+            activeWrites.TryRemove(filePath, out _);
+        }
+    }
+
+    /// <summary>
+    /// Determines if a file is expired or does not exist based on its last write time and the specified caching duration.
+    /// </summary>
+    /// <param name="fileInfo">The <see cref="FileInfo"/> object representing the file to be checked.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    /// <returns><c>true</c> if the file is expired or does not exist; otherwise, <c>false</c>.</returns>
+    private static bool IsFileExpired(FileInfo fileInfo, TimeSpan? cachingTime)
+    {
+        return !fileInfo.Exists || (cachingTime is not null &&
+               DateTime.UtcNow - fileInfo.LastWriteTimeUtc > cachingTime);
+    }
+
+    /// <summary>
+    /// Ensures that the directory for the specified file path exists.
+    /// If the directory does not exist, it is created.
+    /// </summary>
+    /// <param name="fileInfo">The file information object that includes the directory to check or create.</param>
+    /// <returns>
+    /// Returns <c>true</c> if the directory did not exist and was successfully created;
+    /// otherwise, <c>false</c> if the directory already exists.
+    /// </returns>
+    private static bool CreateDirectoryIfNotExist(FileInfo fileInfo)
+    {
+        if (fileInfo.Directory is not { Exists: false })
+        {
+            return false;
+        }
+
+        fileInfo.Directory.Create();
+        return true;
+    }
+}

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Helpers;
+using GeeksCoreLibrary.Core.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.ItemFiles.Enums;
 using GeeksCoreLibrary.Modules.ItemFiles.Interfaces;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace GeeksCoreLibrary.Modules.ItemFiles.Services;
 
-public class CachedItemFilesService(IOptions<GclSettings> gclSettings, IItemFilesService itemFilesService, IWebHostEnvironment webHostEnvironment = null)
+public class CachedItemFilesService(IOptions<GclSettings> gclSettings, IItemFilesService itemFilesService, IFileCacheService fileCacheService, IWebHostEnvironment webHostEnvironment = null)
     : IItemFilesService
 {
     private readonly GclSettings gclSettings = gclSettings.Value;
@@ -144,7 +145,7 @@ public class CachedItemFilesService(IOptions<GclSettings> gclSettings, IItemFile
         var localDirectory = FileSystemHelpers.GetFileCacheDirectory(webHostEnvironment);;
         var fileLocation = Path.Combine(localDirectory, localFilename);
 
-        var fileBytes = await File.ReadAllBytesAsync(fileLocation);
+        var fileBytes = await fileCacheService.GetBytesAsync(fileLocation, gclSettings.DefaultItemFileCacheDuration);
         var lastModified = File.GetLastWriteTimeUtc(fileLocation);
 
         return (fileBytes, lastModified);


### PR DESCRIPTION
# Describe your changes

Adds a FileCacheService that can be used for concurrency and uses this for the caching of templates, dynamic content and item files. This helps to minimize the amount of IOExceptions that can currently fill up our logs, often getting in the way when trying to find issues of other types.

At the core of the implementation is a ConcurrentDictionary that is used to track to which file is currently being written.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

The FileCacheService itself was first tested in a console application in which a ParallelEnumerable was used create 2 files in multiple threads. First simply writing the file to make sure I consistently got file access exceptions and then adding the Service.

After that I added the implementation to the GCL and used the library in a project which used a lot of images and caching, to see whether they were all correctly added and read.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1206928887018719
