### PR TITLE
Execute preload query before HTML DoReplacesAsync & Add HTML only check for GetRenderedTemplateAsync

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -98,28 +98,26 @@ public class TemplatesController(
                 return Unauthorized();
             }
 
+            if (contentTemplate.Content == null && contentTemplate.ReturnNotFoundWhenPreLoadQueryHasNoData)
+            {
+                return NotFound();
+            }
+
             var useGeneralLayout = !String.Equals(HttpContextHelpers.GetRequestValue(context, "ombouw"), "false", StringComparison.OrdinalIgnoreCase) && !contentTemplate.IsPartial;
             switch (contentTemplate.Type)
             {
                 case TemplateTypes.Js:
-                    return Content(contentTemplate.Content, "application/javascript");
+                    return Content(contentTemplate.Content ?? "", "application/javascript");
                 case TemplateTypes.Scss:
                 case TemplateTypes.Css:
-                    return Content(contentTemplate.Content, "text/css");
+                    return Content(contentTemplate.Content ?? "", "text/css");
                 case TemplateTypes.Query:
                     var jsonResult = await templatesService.GetJsonResponseFromQueryAsync((QueryTemplate) contentTemplate);
                     return Content(JsonConvert.SerializeObject(jsonResult), "application/json");
                 case TemplateTypes.Normal:
                 case TemplateTypes.Unknown:
-                    return Content(contentTemplate.Content, "text/plain");
+                    return Content(contentTemplate.Content ?? "", "text/plain");
                 case TemplateTypes.Html:
-                    // Execute the pre load query before any replacements are being done and before any dynamic components are handled.
-                    var hasResults = await templatesService.ExecutePreLoadQueryAndRememberResultsAsync(contentTemplate);
-                    if (contentTemplate.ReturnNotFoundWhenPreLoadQueryHasNoData && !hasResults)
-                    {
-                        return NotFound();
-                    }
-
                     var noIndex = contentTemplate.RobotsNoIndex;
                     var noFollow = contentTemplate.RobotsNoFollow;
 


### PR DESCRIPTION
# Describe your changes

Execute preload query before HTML DoReplacesAsync & Add HTML only check for GetRenderedTemplateAsync.
* Fixes bug in which the GCL also does replacements on JS, which it shouldnt.
* Fixes GCL templates caching bug in which pre load queries got executed after the doReplacesAsync which caused unresolved template variables

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested an HTML template in a local project that uses a preload query, making it accessible both within the template and on dynamic content pages referencing the template variable.

Additionally, tested a local configurator project, which now opens successfully after being able to resolve the template variables.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1209339034569767
https://app.asana.com/0/1205090868730163/1203021850171653