### PR TITLE
Fix for entity type always being required

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -1068,7 +1068,7 @@ public class WiserItemsService(
                                     databaseConnection.AddParameter("destinationId", destinationId);
                                     await databaseConnection.ExecuteAsync($"""
                                                                            INSERT IGNORE INTO {linkTablePrefix}{WiserTableNames.WiserItemLink} ({(currentItemIsDestinationId ? "destination_item_id, item_id" : "item_id, destination_item_id")}, type)
-                                                                                                                                                   VALUES (?itemId, ?destinationId, ?linkTypeNumber);
+                                                                           VALUES (?itemId, ?destinationId, ?linkTypeNumber);
                                                                            """);
                                 }
 

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -1046,7 +1046,7 @@ public class WiserItemsService(
                                 }
 
                                 var currentItemIsDestinationId = fieldOptions[key].ContainsKey(Constants.CurrentItemIsDestinationIdKey) && (bool) fieldOptions[key][Constants.CurrentItemIsDestinationIdKey];
-                                var linkTablePrefix = await GetTablePrefixForLinkAsync(linkTypeNumber, currentItemIsDestinationId ? Convert.ToString(fieldOptions[key][Constants.EntityTypeKey]) : wiserItem.EntityType);
+                                var linkTablePrefix = await GetTablePrefixForLinkAsync(linkTypeNumber, currentItemIsDestinationId && fieldOptions[key].TryGetValue(Constants.EntityTypeKey, out var fieldOptionsEntityKey) ? Convert.ToString(fieldOptionsEntityKey) : wiserItem.EntityType);
 
                                 databaseConnection.AddParameter("linkTypeNumber", linkTypeNumber);
 


### PR DESCRIPTION
# Describe your changes

Updating an item with a custom query didn't work anymore due to the entity type always being required. Setting an entity type, however, causes the custom query to not be used. This checks if entity type is set before deciding to use it and falls back to the item's entity type if it isn't set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build and tested in Wiser if saving an item with a combobox and multiselect that use custom queries worked as intended, and saved the links as exepected.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/0/1205090868730163/1207511625868424)