### PR TITLE
Use Uri.EscapeDataString for encoding

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -279,7 +279,7 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
                     value = value.StripHtml();
                     value = unsafeSource switch
                     {
-                        UnsafeSources.HttpRequest => HttpUtility.UrlEncode(value),
+                        UnsafeSources.HttpRequest => Uri.EscapeDataString(value),
                         _ => throw new ArgumentOutOfRangeException(nameof(unsafeSource), unsafeSource, null)
                     };
                 }


### PR DESCRIPTION
# Describe your changes

Use Uri.EscapeDataString for encoding in ReplacementsMediator.cs.
This is the same used by the StringReplacementsExtensions. This way it is possible to reverse the encoding by using the UrlDecode formatter.

The difference is that HttpUtility.UrlEncode encoded spaces differently (into pluses) and Uri.UnescapeDataString doesn't reverse this.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested a template in which values were url encoded due to be gotten from a request (a webform). Before the change spaces were not being unencoded despite the use of UrlDecode formatter, after the change I saw spaces as expected.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1151477971646641/1209483497653720
https://app.asana.com/0/1151477971646641/1209483559517718
