### PR TITLE
Bugfix where pre load query was not executed in HTML includes

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -381,8 +381,7 @@ public class TemplatesService(
                          template.template_name,
                          template.template_id,
                          template.template_data_minified, 
-                         template.template_data,
-                         template.pre_load_query
+                         template.template_data
                      FROM {WiserTableNames.WiserTemplate} AS template
                      {joinPart}
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
@@ -404,8 +403,7 @@ public class TemplatesService(
         {
             Id = firstRow.Field<int>("template_id"),
             Name = firstRow.Field<string>("template_name"),
-            Content = String.IsNullOrEmpty(contentMinified) ? content : contentMinified,
-            PreLoadQuery = firstRow.Field<string>("pre_load_query")
+            Content = String.IsNullOrEmpty(contentMinified) ? content : contentMinified
         };
     }
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -381,7 +381,8 @@ public class TemplatesService(
                          template.template_name,
                          template.template_id,
                          template.template_data_minified, 
-                         template.template_data
+                         template.template_data,
+                         template.pre_load_query
                      FROM {WiserTableNames.WiserTemplate} AS template
                      {joinPart}
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
@@ -403,7 +404,8 @@ public class TemplatesService(
         {
             Id = firstRow.Field<int>("template_id"),
             Name = firstRow.Field<string>("template_name"),
-            Content = String.IsNullOrEmpty(contentMinified) ? content : contentMinified
+            Content = String.IsNullOrEmpty(contentMinified) ? content : contentMinified,
+            PreLoadQuery = firstRow.Field<string>("pre_load_query")
         };
     }
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1190,31 +1190,27 @@ public class TemplatesService(
                     templateName = await stringReplacementsService.DoAllReplacementsAsync(templateName, dataRow, handleRequest, forQuery: forQuery, handleVariableDefaults: handleVariableDefaults);
                 }
 
+                Template template;
+
                 // Replace templates (syntax is <[templateName]> or <[parentFolder\templateName]>
                 if (templateName.Contains("\\"))
                 {
                     // Contains a parent
                     var split = templateName.Split('\\');
-                    var template = await templatesService.GetTemplateContentAsync(name: split[1], type: templateType, parentName: split[0]);
-                    var templateContent = template.Content;
-                    if (handleStringReplacements)
-                    {
-                        templateContent = await stringReplacementsService.DoAllReplacementsAsync(templateContent, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
-                    }
-
-                    input = input.Replace(m.Groups[0].Value, templateContent, StringComparison.OrdinalIgnoreCase);
+                    template = await templatesService.GetTemplateContentAsync(name: split[1], type: templateType, parentName: split[0]);
                 }
                 else
                 {
-                    var template = await templatesService.GetTemplateContentAsync(name: templateName, type: templateType);
-                    var templateContent = template.Content;
-                    if (handleStringReplacements)
-                    {
-                        templateContent = await stringReplacementsService.DoAllReplacementsAsync(templateContent, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
-                    }
-
-                    input = input.Replace(m.Groups[0].Value, templateContent, StringComparison.OrdinalIgnoreCase);
+                    template = await templatesService.GetTemplateContentAsync(name: templateName, type: templateType);
                 }
+
+                var templateContent = template.Content;
+                if (handleStringReplacements)
+                {
+                    templateContent = await stringReplacementsService.DoAllReplacementsAsync(templateContent, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
+                }
+
+                input = input.Replace(m.Groups[0].Value, templateContent, StringComparison.OrdinalIgnoreCase);
             }
 
             inclusionsRegex = new Regex(@"\[include\[([^{?\]]*)(\?)?([^{?\]]*?)\]\]", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
@@ -1228,43 +1224,48 @@ public class TemplatesService(
                     templateName = await stringReplacementsService.DoAllReplacementsAsync(templateName, dataRow, handleRequest, forQuery: forQuery, handleVariableDefaults: handleVariableDefaults);
                 }
 
+                Template template;
+
                 // Replace templates (syntax is [include[templateName]] or [include[parentFolder\templateName]] or [include[templateName?x=y]]
                 if (templateName.Contains("\\"))
                 {
                     // Contains a parent
                     var split = templateName.Split('\\');
-                    var template = await templatesService.GetTemplateContentAsync(name: split[1], type: templateType, parentName: split[0]);
-                    var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
-                    var content = replacementsMediator.DoReplacements(template.Content, values, forQuery);
-                    if (handleStringReplacements)
-                    {
-                        content = await stringReplacementsService.DoAllReplacementsAsync(content, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
-                    }
-
-                    if (!String.IsNullOrWhiteSpace(queryString))
-                    {
-                        content = content.Replace("<div class=\"dynamic-content", $"<div data=\"{queryString}\" class=\"/dynamic-content");
-                    }
-
-                    input = input.Replace(m.Groups[0].Value, content, StringComparison.OrdinalIgnoreCase);
+                    template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
                 }
                 else
                 {
-                    var template = await templatesService.GetTemplateContentAsync(name: templateName, type: templateType);
-                    var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
-                    var content = replacementsMediator.DoReplacements(template.Content, values, forQuery);
-                    if (handleStringReplacements)
-                    {
-                        content = await stringReplacementsService.DoAllReplacementsAsync(content, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
-                    }
-
-                    if (!String.IsNullOrWhiteSpace(queryString))
-                    {
-                        content = content.Replace("<div class=\"dynamic-content", $"<div data=\"{queryString}\" class=\"/dynamic-content");
-                    }
-
-                    input = input.Replace(m.Groups[0].Value, content, StringComparison.OrdinalIgnoreCase);
+                    template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
                 }
+
+                var content = template.Content;
+
+                // Execute pre load query for html template includes if available
+                if (template.Type == TemplateTypes.Html && !String.IsNullOrWhiteSpace(template.PreLoadQuery))
+                {
+                    var query = await DoReplacesAsync(templatesService, template.PreLoadQuery, forQuery: true, templateType: TemplateTypes.Query);
+                    var dataTable = await databaseConnection.GetAsync(query);
+
+                    if (dataTable.Rows.Count > 0)
+                    {
+                        content = replacementsMediator.DoReplacements(content, dataTable.Rows[0], forQuery, prefix: "{template.");
+                    }
+                }
+
+                var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
+                content = replacementsMediator.DoReplacements(content, values, forQuery);
+
+                if (handleStringReplacements)
+                {
+                    content = await stringReplacementsService.DoAllReplacementsAsync(content, dataRow, handleRequest, false, false, forQuery, handleVariableDefaults: handleVariableDefaults);
+                }
+
+                if (!String.IsNullOrWhiteSpace(queryString))
+                {
+                    content = content.Replace("<div class=\"dynamic-content", $"<div data=\"{queryString}\" class=\"/dynamic-content");
+                }
+
+                input = input.Replace(m.Groups[0].Value, content, StringComparison.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
# Describe your changes

Fixed bug where pre-load query was not executed in HTML templates when being called via a [include]. Also merged some duplicate code together.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used template veriables in combination with several HTML templates with includes and different preload queries within a test project.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1203064463742150
