### PR TITLE
Made Amazon S3 service use file cache

### DIFF
--- a/GeeksCoreLibrary/Core/Interfaces/IFileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Interfaces/IFileCacheService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace GeeksCoreLibrary.Core.Interfaces;
@@ -57,4 +58,12 @@ public interface IFileCacheService
     /// <param name="content">The byte array content to write to the file.</param>
     /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
     Task WriteFileIfNotExistsOrExpiredAsync(string filePath, byte[] content, TimeSpan? cachingTime = null);
+
+    /// <summary>
+    /// Writes a file with content from a stream if it does not exist or if the existing file is older than the specified caching minutes.
+    /// </summary>
+    /// <param name="filePath">The path of the file to write.</param>
+    /// <param name="content">The stream to write to the file.</param>
+    /// <param name="cachingTime">The time span defining the expiration duration. If the file's age exceeds this, it will be overwritten.</param>
+    Task WriteFileIfNotExistsOrExpiredAsync(string filePath, Stream content, TimeSpan? cachingTime = null);
 }


### PR DESCRIPTION
# Describe your changes

The Amazon S3 service saves the downloaded objects to the file system, but didn't use the `FileCacheService` causing exceptions when multiple requests were attempting to download the same object. The `FileCacheService` is now used.

Also refactored the `FileCacheService` so it can work with streams as well and uses `SemaphoreSlim` to create locks to create thread safety.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build to test the changes in a scenario where the problems were occurring and confirmed that these changes fixed the issue. Also made sure that other images still loaded properly, ensuring that the switch to using `SemaphoreSlim` didn't break existing functionality.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Zero, zip, zilch, nada.

# Jira issue key

CON-1209