### PR TITLE
Added HTTP 2 and 3 support to `HttpClientService`

### DIFF
--- a/GeeksCoreLibrary/Core/Services/HttpClientService.cs
+++ b/GeeksCoreLibrary/Core/Services/HttpClientService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Interfaces;
@@ -13,8 +14,12 @@ public class HttpClientService : IHttpClientService, ISingletonService
     {
         var socketsHandler = new SocketsHttpHandler
         {
-            PooledConnectionLifetime = TimeSpan.FromMinutes(2)
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
         };
-        Client = new HttpClient(socketsHandler);
+        Client = new HttpClient(socketsHandler)
+        {
+            DefaultRequestVersion =  HttpVersion.Version30,
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower
+        };
     }
 }


### PR DESCRIPTION
# Describe your changes

I noticed that our `HttpClientService` would always use HTTP version 1.1. This version is very old, we have version 3 at the moment. I updated the default `HttpClient` settings to automatically use HTTP 3 when the server supports it, otherwise it will use the highest version that the server does support.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By doing some HTTP calls to servers that I know support HTTP 2 and HTTP 3 and some that don't, to test if the fallback and everything works.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No Asana ticket, noticed this myself and was a small fix.