### PR TITLE
Improved query string parsing by using .NET functions instead of custom code with Split().

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IReplacementsMediator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Data;
 using GeeksCoreLibrary.Modules.GclReplacements.Enums;
 using GeeksCoreLibrary.Modules.GclReplacements.Extensions;
@@ -58,6 +59,21 @@ public interface IReplacementsMediator
     /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
     /// <returns>The original string with all replacements done.</returns>
     string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
+
+    /// <summary>
+    /// Performs all replacements on a string using data that implements the <see cref="NameValueCollection"/> class (which comes from Request.QueryString and HttpUtility.ParseQueryString(), for example).
+    /// This function will typically be used to replace Query and Form replacements from the http context.
+    /// </summary>
+    /// <param name="input">The string to do replacements on.</param>
+    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
+    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
+    /// <returns>The original string with all replacements done.</returns>
+    string DoReplacements(string input, NameValueCollection replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Interfaces/IStringReplacementsService.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Data;
 using System.Threading.Tasks;
+using GeeksCoreLibrary.Modules.GclReplacements.Enums;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json.Linq;
@@ -81,6 +83,21 @@ public interface IStringReplacementsService
     /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
     /// <returns>The original string with all replacements done.</returns>
     string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode");
+
+    /// <summary>
+    /// Performs all replacements on a string using data that implements the <see cref="NameValueCollection"/> class (which comes from Request.QueryString and HttpUtility.ParseQueryString(), for example).
+    /// This function will typically be used to replace Query and Form replacements from the http context.
+    /// </summary>
+    /// <param name="input">The string to do replacements on.</param>
+    /// <param name="replaceData">The data that needs to be used for the replacements.</param>
+    /// <param name="forQuery">Optional: Set to true to make all replaced values safe against SQL injection. You should only set this to true for SQL queries. Default is false.</param>
+    /// <param name="caseSensitive">Optional: Whether the variable names in the replacement data dictionary should be case-sensitive. Default is true.</param>
+    /// <param name="prefix">Optional: The string that is used as the prefix for every variable that needs to be replaced. Default value is "{".</param>
+    /// <param name="suffix">Optional: The string that is used as the suffix for every variable that needs to be replaced. Default value is "}".</param>
+    /// <param name="defaultFormatter">Optional: The default formatter to use. This should be HtmlEncode for anything that gets output to the browser. Default value is "HtmlEncode".</param>
+    /// <param name="unsafeSource">Optional: The source type if the <paramref name="replaceData"/> is from an untrusted source, e.g. user input. Set to null if the source is not unsafe/untrusted.</param>
+    /// <returns>The original string with all replacements done.</returns>
+    string DoReplacements(string input, NameValueCollection replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null);
 
     /// <summary>
     /// Performs all replacements on a string using data that implements the IEnumerable&lt;KeyValuePair&lt;string, string&gt;&gt; interface.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Data;
 using System.Globalization;
 using System.Linq;
@@ -90,6 +91,23 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
         foreach (var column in replaceData.Table.Columns.Cast<DataColumn>())
         {
             dataDictionary.Add(column.ColumnName, replaceData[column]);
+        }
+
+        return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);
+    }
+
+    /// <inheritdoc />
+    public string DoReplacements(string input, NameValueCollection replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
+    {
+        if (replaceData == null)
+        {
+            return input;
+        }
+
+        var dataDictionary = new Dictionary<string, object>(caseSensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        foreach (var key in replaceData.AllKeys.Where(k => !String.IsNullOrWhiteSpace(k)))
+        {
+            dataDictionary.Add(key, replaceData[key]);
         }
 
         return DoReplacements(input, dataDictionary, prefix, suffix, forQuery, defaultFormatter, unsafeSource);

--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Data;
 using System.Linq;
 using System.Reflection;
@@ -280,6 +281,12 @@ public class StringReplacementsService(
 
     /// <inheritdoc />
     public string DoReplacements(string input, DataRow replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode")
+    {
+        return replacementsMediator.DoReplacements(input, replaceData, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
+    }
+
+    /// <inheritdoc />
+    public string DoReplacements(string input, NameValueCollection replaceData, bool forQuery = false, bool caseSensitive = true, string prefix = "{", string suffix = "}", string defaultFormatter = "HtmlEncode", UnsafeSources? unsafeSource = null)
     {
         return replacementsMediator.DoReplacements(input, replaceData, forQuery, caseSensitive, prefix, suffix, defaultFormatter);
     }

--- a/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/LegacyTemplatesService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using GeeksCoreLibrary.Components.Account.Interfaces;
 using GeeksCoreLibrary.Components.Filter.Interfaces;
 using GeeksCoreLibrary.Core.Enums;
@@ -1053,7 +1054,7 @@ public class LegacyTemplatesService : ITemplatesService
                     // Contains a parent
                     var split = templateName.Split('\\');
                     var template = await templatesService.GetTemplateAsync(name: split[1], type: templateType, parentName: split[0]);
-                    var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
+                    var values = HttpUtility.ParseQueryString(queryString);
                     var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                     if (handleStringReplacements)
                     {
@@ -1070,7 +1071,7 @@ public class LegacyTemplatesService : ITemplatesService
                 else
                 {
                     var template = await templatesService.GetTemplateAsync(name: templateName, type: templateType);
-                    var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
+                    var values = HttpUtility.ParseQueryString(queryString);
                     var content = stringReplacementsService.DoReplacements(template.Content, values, forQuery);
                     if (handleStringReplacements)
                     {

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using GeeksCoreLibrary.Components.Account.Interfaces;
 using GeeksCoreLibrary.Components.Filter.Interfaces;
 using GeeksCoreLibrary.Core.Enums;
@@ -1250,7 +1251,7 @@ public class TemplatesService(
                     }
                 }
 
-                var values = queryString.Split('&', StringSplitOptions.RemoveEmptyEntries).Select(x => new KeyValuePair<string, string>(x.Split('=')[0], x.Split('=')[1]));
+                var values = HttpUtility.ParseQueryString(queryString);
                 content = replacementsMediator.DoReplacements(content, values, forQuery);
 
                 if (handleStringReplacements)


### PR DESCRIPTION
# Describe your changes

When checking PR https://github.com/happy-geeks/geeks-core-library/pull/802, I noticed that we have a very ugly way of parsing the query string from includes. But this was not the fault of the creator of that PR, because he just moved the code, it already was like that. So I fixed it myself in this PR.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I made a test controller in a test project to do some tests if the includes still work properly after my changes.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/geeks-core-library/pull/802

# Link to Asana ticket

N/A
