### PR TITLE
Bugfix/file activewrites remove

### DIFF
--- a/GeeksCoreLibrary/Core/Services/FileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/FileCacheService.cs
@@ -72,6 +72,9 @@ public class FileCacheService : IFileCacheService, ISingletonService
         if (activeWrites.TryGetValue(filePath, out var fileLock))
         {
             await fileLock.WaitAsync();
+            // if we had to wait for a filewrite then the file was just refreshed
+            // so we can release immediately.
+            fileLock.Release();
         }
 
         await using var fileStream = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/GeeksCoreLibrary/Core/Services/FileCacheService.cs
+++ b/GeeksCoreLibrary/Core/Services/FileCacheService.cs
@@ -137,11 +137,19 @@ public class FileCacheService : IFileCacheService, ISingletonService
             return;
         }
 
-        var fileInfo = new FileInfo(filePath);
-        if (IsFileExpired(fileInfo, cachingTime))
+        try
         {
-            await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
-            await fileStream.WriteAsync(content);
+            var fileInfo = new FileInfo(filePath);
+            if (IsFileExpired(fileInfo, cachingTime))
+            {
+                await using var fileStream =
+                    new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                await fileStream.WriteAsync(content);
+            }
+        }
+        finally
+        {
+            activeWrites.TryRemove(filePath, out _);
         }
     }
 
@@ -156,16 +164,23 @@ public class FileCacheService : IFileCacheService, ISingletonService
             return;
         }
 
-        var fileInfo = new FileInfo(filePath);
-        if (IsFileExpired(fileInfo, cachingTime))
+        try
         {
-            await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 8192);
-            var buffer = new byte[8192];
-            int read;
-            while ((read = await content.ReadAsync(buffer)) > 0)
+            var fileInfo = new FileInfo(filePath);
+            if (IsFileExpired(fileInfo, cachingTime))
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, read));
+                await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 8192);
+                var buffer = new byte[8192];
+                int read;
+                while ((read = await content.ReadAsync(buffer)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read));
+                }
             }
+        }
+        finally
+        {
+            activeWrites.TryRemove(filePath, out _);
         }
     }
 


### PR DESCRIPTION
# Describe your changes

In https://github.com/happy-geeks/geeks-core-library/pull/803 the removal of the items in activeWrites wasn't taken over in the new implementation and after waiting on the semaphore in GetBytesAsync, it didn't release the Semaphore.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Clicked around in a GCL website.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
