### PR TITLE
Add option to enable DTD processing to DeserializeXml

### DIFF
--- a/GeeksCoreLibrary/Core/Helpers/XmlHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/XmlHelpers.cs
@@ -12,9 +12,10 @@ public static class XmlHelpers
     /// Deserialize an XML string to an object.
     /// </summary>
     /// <param name="xml">The XML string to deserialize.</param>
+    /// <param name="enableDtdProcessing">Whether to allow DTD processing. Defaults to off because DTDs can potentially be exploited by attackers.</param>
     /// <typeparam name="T">The class to deserialize to.</typeparam>
     /// <returns>The deserialized value of <see cref="T"/>.</returns>
-    public static T DeserializeXml<T>(string xml)
+    public static T DeserializeXml<T>(string xml, bool enableDtdProcessing = false)
     {
         if (String.IsNullOrWhiteSpace(xml))
         {
@@ -25,7 +26,11 @@ public static class XmlHelpers
         using var stringReader = new StringReader(xml);
 
         // Prevents the XmlSerializer from resolving external resources, to mitigate XML External Entity (XXE) vulnerabilities.
-        using var xmlReader = XmlReader.Create(stringReader, new XmlReaderSettings { XmlResolver = null });
+        using var xmlReader = XmlReader.Create(stringReader, new XmlReaderSettings
+        {
+            XmlResolver = null,
+            DtdProcessing = enableDtdProcessing ? DtdProcessing.Parse : DtdProcessing.Ignore
+        });
         return (T) serializer.Deserialize(xmlReader);
     }
 


### PR DESCRIPTION
# Describe your changes

Add option to enable DTD processing. Sets the DtdProcessing to DtdProcessing if the passed boolean is true. The default of DtdProcessing is prohibited which gives an exception when a DTD is present. This is done for security reasons.

This change adds support for DTD if the XML comes from a trusted source and otherwise ignores the DTD.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Passed an XML with a DTD into the method. Before the change I got an exception, after the change it went through without a problem.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1151477971646641/task/1209639471354164
