### PR TITLE
Fixed call to `GetRenderedTemplateAsync`

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedPagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedPagesService.cs
@@ -131,7 +131,7 @@ public class CachedPagesService(
             await languagesService.GetLanguageCodeAsync();
         }
 
-        template = await pagesService.GetRenderedTemplateAsync(id, name, type, parentId, parentName, skipPermissions, content);
+        template = await pagesService.GetRenderedTemplateAsync(id, name, type, parentId, parentName, skipPermissions, content, useAbsoluteImageUrls, removeSvgUrlsFromIcons);
 
         if (content != null)
         {

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -80,7 +80,6 @@ public class PagesService(
                 stopWatch.Start();
             }
 
-
             // Execute the pre load query before any replacements are being done and before any dynamic components are handled.
             var hasResults = await templatesService.ExecutePreLoadQueryAndRememberResultsAsync(template);
             if (template.ReturnNotFoundWhenPreLoadQueryHasNoData && !hasResults)


### PR DESCRIPTION
# Describe your changes

The call to `GetRenderedTemplateAsync` in the `CachedPagesService` didn't pass the `useAbsoluteImageUrls` and `removeSvgUrlsFromIcons` parameters, causing that functionality to no longer work unless the template has caching enabled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build and tested my changes in a situation where I knew there was a problem and confirmed that these changes fixed the issue.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

[Asana ticket](https://app.asana.com/1/5038780173035/project/1200346761113317/task/1209666684409090)