### PR TITLE
Refactor ReplacementsMediator for improved performance and clarity.

### DIFF
--- a/GeeksCoreLibrary.Tests/Modules/GclReplacements/Services/ReplacementsMediatorTests.cs
+++ b/GeeksCoreLibrary.Tests/Modules/GclReplacements/Services/ReplacementsMediatorTests.cs
@@ -8,6 +8,7 @@ using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using GeeksCoreLibrary.Modules.GclReplacements.Services;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -63,6 +64,7 @@ public class ReplacementsMediatorTests
     [UsedImplicitly]
     private IOptions<GclSettings> gclSettingsMock;
     private IReplacementsMediator replacementsMediator;
+    private Mock<ILogger<ReplacementsMediator>> loggerMock;
     private Mock<IDatabaseConnection> databaseConnectionMock;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -71,10 +73,11 @@ public class ReplacementsMediatorTests
     {
         // Create mocks.
         gclSettingsMock = Options.Create(new GclSettings());
-        databaseConnectionMock = new Mock<IDatabaseConnection>();
+        databaseConnectionMock = new();
+        loggerMock = new();
 
         // Create the service that we're testing.
-        replacementsMediator = new ReplacementsMediator(databaseConnectionMock.Object);
+        replacementsMediator = new ReplacementsMediator(databaseConnectionMock.Object, loggerMock.Object);
     }
 
     [Test]
@@ -354,7 +357,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(input, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(input);
     }
 
     [Test]
@@ -379,7 +382,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(expected, "because we're testing strings with a single if statement");
     }
 
     [Test]
@@ -394,7 +397,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(expected, "because we're testing strings with multiple if statements");
     }
 
     [Test]
@@ -419,7 +422,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -431,7 +434,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -443,7 +446,7 @@ public class ReplacementsMediatorTests
 
         // Assert
         actual.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        actual.Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        actual.Should().Be(expected);
     }
 
     [Test]
@@ -458,7 +461,7 @@ public class ReplacementsMediatorTests
         enumerable.Should().NotBeNull("because we're testing specific strings that should always return a value");
         enumerable.Should().HaveCount(1, "because we're testing a DataSet with only one table");
         enumerable.Single().Should().HaveCount(1, "because we're testing a DataSet with only one table and one row");
-        enumerable.First().First().Should().Be(expected, "because we're testing strings that don't contain any if statements");
+        enumerable.First().First().Should().Be(expected);
     }
 
     [Test]
@@ -497,7 +500,7 @@ public class ReplacementsMediatorTests
         // Assert
         var enumerable = actual.Select(x => x.ToList()).ToList();
         enumerable.Should().NotBeNull("because we're testing specific strings that should always return a value");
-        enumerable.Should().BeEquivalentTo(expected, "because we're testing strings that don't contain any if statements");
+        enumerable.Should().BeEquivalentTo(expected);
     }
 
     /// <summary>

--- a/GeeksCoreLibrary.Tests/Modules/GclReplacements/Services/StringReplacementsServiceTests.cs
+++ b/GeeksCoreLibrary.Tests/Modules/GclReplacements/Services/StringReplacementsServiceTests.cs
@@ -10,6 +10,7 @@ using GeeksCoreLibrary.Modules.GclReplacements.Services;
 using GeeksCoreLibrary.Modules.Languages.Interfaces;
 using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
@@ -25,6 +26,7 @@ public class StringReplacementsServiceTests
     private Mock<IAccountsService> accountsServiceMock;
     private Mock<IHttpContextAccessor> httpContextAccessorMock;
     private Mock<IDatabaseConnection> databaseConnectionMock;
+    private Mock<ILogger<ReplacementsMediator>> loggerMock;
 
     private IOptions<GclSettings> gclSettingsMock;
     private IReplacementsMediator replacementsMediator;
@@ -35,14 +37,15 @@ public class StringReplacementsServiceTests
     {
         // Create mocks.
         gclSettingsMock = Options.Create(new GclSettings());
-        objectsServiceMock = new Mock<IObjectsService>();
-        languagesServiceMock = new Mock<ILanguagesService>();
-        accountsServiceMock = new Mock<IAccountsService>();
-        httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-        databaseConnectionMock = new Mock<IDatabaseConnection>();
+        objectsServiceMock = new();
+        languagesServiceMock = new();
+        accountsServiceMock = new();
+        httpContextAccessorMock = new();
+        databaseConnectionMock = new();
+        loggerMock = new();
 
         // Create the service that we're testing.
-        replacementsMediator = new ReplacementsMediator(databaseConnectionMock.Object);
+        replacementsMediator = new ReplacementsMediator(databaseConnectionMock.Object, loggerMock.Object);
         stringReplacementsService = new StringReplacementsService(gclSettingsMock, objectsServiceMock.Object, languagesServiceMock.Object, accountsServiceMock.Object, replacementsMediator, httpContextAccessorMock.Object);
 
         // Setup the mocks.

--- a/GeeksCoreLibrary/Modules/GclReplacements/Helpers/PrecompiledRegexes.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Helpers/PrecompiledRegexes.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace GeeksCoreLibrary.Modules.GclReplacements.Helpers;
+
+public static partial class PrecompiledRegexes
+{
+    [GeneratedRegex(@"\[(?:if\(|else\]|endif\])", RegexOptions.None, 200)]
+    public static partial Regex ConditionalParts { get; }
+
+    [GeneratedRegex(@"(?<methodname>[^\(\)]+)(?:\((?<parameters>[^\)]+)\))?", RegexOptions.IgnoreCase, 3_000, "nl-NL")]
+    public static partial Regex Formatters { get; }
+}

--- a/GeeksCoreLibrary/Modules/GclReplacements/Models/IfStatementParts.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Models/IfStatementParts.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GeeksCoreLibrary.Modules.GclReplacements.Models;
+
+public ref struct IfStatementParts()
+{
+    public ReadOnlySpan<char> Operator { get; set; } = default;
+    public ReadOnlySpan<char> LeftOperand { get; set; } = default;
+    public ReadOnlySpan<char> RightOperand { get; set; } = default;
+    public ReadOnlySpan<char> TrueBranchValue { get; set; } = default;
+    public ReadOnlySpan<char> FalseBranchValue { get; set; } = default;
+    public int ScannedUntil { get; set; } = 0;
+    public int NextFoundTrueBranchIfIndex { get; set; } = -1;
+    public int NextFoundFalseBranchIfIndex { get; set; } = -1;
+}


### PR DESCRIPTION
# Describe your changes

Refactor template evaluation code in replacementsmediator to improve its performance. It also adds invalid if statement detection. Now when invalid if statements are detected a warning is logged and the statement is ignored, this is done to keep the changes backwards-compatible.

The old implementation used a regex to find all parts of the if statement (starting with the inner ones) and then did string replacement. Which is inefficient both because all if statements were always evaluated and because it didn't use a StringBuilder causing a lot of unnecesarry allocations. The regex also needs to do a lot of backtracking.

The new implementation scans through the string sequentially and handles the if statements as it finds them. By using StringBuilder and ReadOnlySpans the amount of memory used is minimized.

I've also changes the GetFormatterMethod to use a dictionary for getting the right MethodInfo. This lookup is more efficient than using an array and improves readability. The OrdinalIgnoreCase comparison is preserved using the StringComparer passed into the ToFrozenDictionary call. The formatter field is also changed into a static field. The formatters will always stay the same so there is no need to recreate it for every request, since FrozenDictionary is readonly this fields can be freely shared across requests.

The Regexes were also changed to make use of GeneratedRegex which uses Source generator to create the Regex code at build time instead of during run time.

## Type of change

Please check only ONE option.

- [x] Refactor (change that doesn't change the behavior of the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I did a variety of tests. 

Firstly the most simple: running the unit tests. All of them pass.

I also ran a GCL website locally and stepped through to see if everything looked correctly.

I've also ran benchmarks to see how much of a difference my changes made:

The dense and sparse templates refer to the amount of if statements in the template.
Both templates are of a similar size.

![image](https://github.com/user-attachments/assets/24d08fc6-73f2-4d89-96bd-f44c7207f069)

As can be seen from the results is the new implementation much faster and also uses much less memory, because of the usage of ReadOnlySpans the only heap allocated object is the StringBuilder.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
