### PR TITLE
Fixing error logs regarding big file names and file extensions

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -3513,12 +3513,15 @@ public class WiserItemsService(
             }
         }
 
+        //Setting a standardized file name to avoid it breaking the system limit.
+        var fileName = $"{tablePrefix}{wiserItemFile.ItemId}";
+
         databaseConnection.AddParameter("itemId", wiserItemFile.ItemId);
         databaseConnection.AddParameter("itemLinkId", wiserItemFile.ItemLinkId);
         databaseConnection.AddParameter("content", wiserItemFile.Content);
         databaseConnection.AddParameter("contentType", wiserItemFile.ContentType);
         databaseConnection.AddParameter("contentUrl", wiserItemFile.ContentUrl);
-        databaseConnection.AddParameter("fileName", Path.GetFileNameWithoutExtension(wiserItemFile.FileName).ConvertToSeo() + Path.GetExtension(wiserItemFile.FileName)?.ToLowerInvariant());
+        databaseConnection.AddParameter("fileName", fileName.ConvertToSeo() + Path.GetExtension(wiserItemFile.FileName)?.ToLowerInvariant());
         databaseConnection.AddParameter("extension", wiserItemFile.Extension);
         databaseConnection.AddParameter("title", wiserItemFile.Title);
         databaseConnection.AddParameter("propertyName", wiserItemFile.PropertyName);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -461,6 +461,7 @@ public class ItemFilesService(
         switch (extension?.ToLowerInvariant())
         {
             case ".jpg":
+            case ".jfif":
             case ".jpeg":
                 imageFormat = MagickFormat.Jpg;
                 imageQuality = 75;
@@ -491,6 +492,9 @@ public class ItemFilesService(
             case ".avif":
             case ".avifs":
                 imageFormat = MagickFormat.Avif;
+                break;
+            case ".bmp":
+                imageFormat = MagickFormat.Bmp;
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(extension), extension, null);


### PR DESCRIPTION
# Describe your changes

This is a fix to standardize file names and also to deal with unsupported file extensions. In the file names case we were getting an error while caching them due to some files being saved in the database with more characters than the system allows.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Using a GCL test template and Wiser Demo, files with the previously unsupported extensions were uploaded and the names were checked.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1209653638314379/f
