### PR TITLE
Fixing previous edition on the file name saving

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -3512,16 +3512,13 @@ public class WiserItemsService(
                 }
             }
         }
-
-        //Setting a standardized file name to avoid it breaking the system limit.
-        var fileName = $"{tablePrefix}{wiserItemFile.ItemId}";
-
+        
         databaseConnection.AddParameter("itemId", wiserItemFile.ItemId);
         databaseConnection.AddParameter("itemLinkId", wiserItemFile.ItemLinkId);
         databaseConnection.AddParameter("content", wiserItemFile.Content);
         databaseConnection.AddParameter("contentType", wiserItemFile.ContentType);
         databaseConnection.AddParameter("contentUrl", wiserItemFile.ContentUrl);
-        databaseConnection.AddParameter("fileName", fileName.ConvertToSeo() + Path.GetExtension(wiserItemFile.FileName)?.ToLowerInvariant());
+        databaseConnection.AddParameter("fileName", Path.GetFileNameWithoutExtension(wiserItemFile.FileName).ConvertToSeo() + Path.GetExtension(wiserItemFile.FileName)?.ToLowerInvariant());
         databaseConnection.AddParameter("extension", wiserItemFile.Extension);
         databaseConnection.AddParameter("title", wiserItemFile.Title);
         databaseConnection.AddParameter("propertyName", wiserItemFile.PropertyName);

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -80,7 +80,8 @@ public class CachedItemFilesService(
         fileNameParts.Add(preferredWidth.ToString());
         fileNameParts.Add(preferredHeight.ToString());
 
-        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts));
+        var extension = Path.GetExtension(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName);
+        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts) + extension);
 
         var (fileBytes, lastModifiedDate) = await fileCacheService.GetOrAddAsync(fileLocation, async () =>
         {
@@ -155,8 +156,9 @@ public class CachedItemFilesService(
         }
         fileNameParts.Add(file.Id.ToString());
         fileNameParts.Add(fileNumber.ToString());
-
-        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts));
+        
+        var extension = Path.GetExtension(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName);
+        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts) + extension);
 
         var (fileBytes, lastModifiedDate) = await fileCacheService.GetOrAddAsync(fileLocation, async () =>
         {

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -70,13 +70,15 @@ public class CachedItemFilesService(
         {
             fileNameParts.Add(entityType);
         }
+        if (linkType > 0)
+        {
+            fileNameParts.Add(linkType.ToString());
+        }
         fileNameParts.Add(file.Id.ToString());
-        fileNameParts.Add(file.PropertyName);
         fileNameParts.Add(resizeMode.ToString("G"));
         fileNameParts.Add(anchorPosition.ToString("G"));
         fileNameParts.Add(preferredWidth.ToString());
         fileNameParts.Add(preferredHeight.ToString());
-        fileNameParts.Add(Path.GetFileName(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName));
 
         var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts));
 
@@ -147,10 +149,12 @@ public class CachedItemFilesService(
         {
             fileNameParts.Add(entityType);
         }
+        if (linkType > 0)
+        {
+            fileNameParts.Add(linkType.ToString());
+        }
         fileNameParts.Add(file.Id.ToString());
-        fileNameParts.Add(file.PropertyName);
         fileNameParts.Add(fileNumber.ToString());
-        fileNameParts.Add(Path.GetFileName(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName));
 
         var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts));
 


### PR DESCRIPTION
# Describe your changes

This change is a fix to a previous one that was made wrongly. Previously the change was made standardizing the file names in the wrong database, this fix now removes that and adds some details to the caching functionallity, where it was supposed to be in the first place.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Locally running the GCL with an internal project and checking the cached files.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1209653638314379/f
