### PR TITLE
Fixed regression in image lookup by file name

### DIFF
--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -160,10 +160,16 @@ public class ItemFilesService(
                 var file = WiserFileHelpers.DataRowToItemFile(dataRow);
 
                 // If the lookup type is by file name, we need to find the file with the correct name.
-                if (lookupType is FileLookupTypes.ItemFileName or FileLookupTypes.ItemLinkFileName && String.Equals(Path.GetFileNameWithoutExtension(file.FileName), Path.GetFileNameWithoutExtension(fileName), StringComparison.OrdinalIgnoreCase))
+                if (lookupType is FileLookupTypes.ItemFileName or FileLookupTypes.ItemLinkFileName)
                 {
-                    result = file;
-                    break;
+                    if (String.Equals(Path.GetFileNameWithoutExtension(file.FileName), Path.GetFileNameWithoutExtension(fileName), StringComparison.OrdinalIgnoreCase))
+                    {
+                        result = file;
+                        break;
+                    }
+
+                    // No match found yet, continue to the next file. Ignore the index, because we are looking for the first file with the correct name.
+                    continue;
                 }
 
                 // If the lookup type is by file number, we need to find the file with the correct number.
@@ -176,7 +182,6 @@ public class ItemFilesService(
                 break;
             }
         }
-
 
         // If the file is protected, but no encrypted ID was used, return null.
         return result == null || (result.Protected && !hasValidEncryptedId) ? null : result;


### PR DESCRIPTION
# Describe your changes

Fixed a regression that caused looking up images by file name to no longer work unless you used a high index/file number.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested to see if my fixes allowed to look up images by file name correctly again, and that image lookups using other lookup types still worked correctly as well.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

None

# Jira issue key

CON-1454