### PR TITLE
Enhance payment method rendering to include selected method state

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCheckoutSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCheckoutSettingsModel.cs
@@ -146,7 +146,7 @@ internal class OrderProcessCheckoutSettingsModel
     [DefaultValue("""
                   <li>
                       <label>
-                          <input type='radio' id='paymentMethod_{id}' value='{id}' name='{paymentMethodFieldName}' required />
+                          <input type='radio' id='paymentMethod_{id}' value='{id}' {checked} name='{paymentMethodFieldName}' required />
                           <img class='logo' src='/image/wiser2/{id}/{logoPropertyName}/crop/32/32/{title:Seo}.png' alt='{title}' />
                           <span class='label'>{title}</span>
                       </label>

--- a/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Models/OrderProcessCmsSettingsModel.cs
@@ -403,6 +403,7 @@ public class OrderProcessCmsSettingsModel : CmsSettings
                           <li><strong>{title}</strong> This name of the payment method.</li>
                           <li><strong>{logoPropertyName}</strong> The name of the field in wiser where the logo is saved for the payment method.</li>
                           <li><strong>{paymentMethodFieldName}</strong> The name of the input element for the selected payment method. Don't use any other name, otherwise the GCL will not know which payment method the user selected and throw an exception.</li>
+                          <li><strong>{checked}</strong> Whether this option should be checked, retrieved from the basket or logged in user, or POST variables. This will be replaced with the 'checked' attribute if it should, or an empty string if it shouldn't.</li>
                       </ul>
                       """,
         DeveloperRemarks = "",

--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -861,7 +861,7 @@ public class OrderProcess : CmsComponent<OrderProcessCmsSettingsModel, OrderProc
     /// Renders the HTML for a single payment method.
     /// </summary>
     /// <param name="paymentMethod">The payment method to generate the HTML for.</param>
-    /// <param name="selectedMethodId"></param>
+    /// <param name="selectedMethodId">The ID of the currently selected payment method.</param>
     /// <returns>The HTML for the payment method.</returns>
     private async Task<string> RenderPaymentMethodAsync(PaymentMethodSettingsModel paymentMethod, ulong selectedMethodId)
     {


### PR DESCRIPTION
# Describe your changes

The chosen payment method would not be remembered from the point of view of the user when going back to the step in which the paymentMethod was chosen. Requiring them to re-select the payment method. This fixes that be selecting the payment method recorded in the basket.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Stepped through checkout process. Trying different selections.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1203956850515021
