### PR TITLE
Fixed an issue with link table prefixes

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -1132,7 +1132,7 @@ public class WiserItemsService(
                     databaseConnection.AddParameter($"key{counter}", itemDetail.Key);
                     databaseConnection.AddParameter($"key{Constants.SeoPropertySuffix}{counter}", $"{itemDetail.Key}{Constants.SeoPropertySuffix}");
 
-                    var (_, valueChanged, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, previousItemDetails, encryptionKey, alwaysSaveValues, isNewlyCreatedItem, tablePrefix);
+                    var (_, valueChanged, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, previousItemDetails, encryptionKey, alwaysSaveValues, isNewlyCreatedItem, tablePrefix, String.Empty);
                     databaseConnection.AddParameter($"itemDetailId{counter}", itemDetail.Id);
                     databaseConnection.AddParameter($"itemDetailId{Constants.SeoPropertySuffix}{counter}", seoValueItemDetailId);
 
@@ -1271,7 +1271,7 @@ public class WiserItemsService(
                         databaseConnection.AddParameter($"key{counter}", itemDetail.Key);
                         databaseConnection.AddParameter($"key{Constants.SeoPropertySuffix}{counter}", $"{itemDetail.Key}{Constants.SeoPropertySuffix}");
 
-                        var (_, valueChanged, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, new List<WiserItemDetailModel>(), encryptionKey, alwaysSaveValues, isNewlyCreatedItem, tablePrefix);
+                        var (_, valueChanged, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, new List<WiserItemDetailModel>(), encryptionKey, alwaysSaveValues, isNewlyCreatedItem, tablePrefix, linkTablePrefix);
                         databaseConnection.AddParameter($"itemDetailId{counter}", itemDetail.Id);
                         databaseConnection.AddParameter($"itemDetailId{Constants.SeoPropertySuffix}{counter}", seoValueItemDetailId);
 
@@ -4238,7 +4238,7 @@ public class WiserItemsService(
             databaseConnection.AddParameter($"groupName{counter}", itemDetail.GroupName ?? "");
             databaseConnection.AddParameter($"key{counter}", itemDetail.Key);
             databaseConnection.AddParameter($"key{Constants.SeoPropertySuffix}{counter}", $"{itemDetail.Key}{Constants.SeoPropertySuffix}");
-            var (useLongValueColumn, _, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, new List<WiserItemDetailModel>(), encryptionKey, true, true, "");
+            var (useLongValueColumn, _, deleteValue, alsoSaveSeoValue, seoValueItemDetailId) = await AddValueParameterToConnectionAsync(counter, itemDetail, fieldOptions, new List<WiserItemDetailModel>(), encryptionKey, true, true, String.Empty, String.Empty);
             databaseConnection.AddParameter($"itemDetailId{counter}", itemDetail.Id);
             databaseConnection.AddParameter($"itemDetailId{Constants.SeoPropertySuffix}{counter}", seoValueItemDetailId);
             parametersForQuery[setting.TableName].Add(deleteValue ? "NULL" : $"?{(useLongValueColumn ? "longValue" : "value")}{counter}");
@@ -4679,9 +4679,10 @@ public class WiserItemsService(
     /// <param name="encryptionKey">The encryption key used for encrypting values for secure-input fields.</param>
     /// <param name="alwaysSaveValues">This function gets the current values in the database and only saves values that have been changed. Set this parameter to true to disable that functionality and force the function to always save all values (except read only fields).</param>
     /// <param name="isNewlyCreatedItem">Whether this item has just been created in code and contains no details yet. If this is set to true, then this function will just insert all the details without checking if they already exist.</param>
-    /// <param name="tablePrefix">If the entity uses dedicated tables, then enter the prefix for those tables here. Enter empty string is not.</param>
+    /// <param name="tablePrefix">If the entity uses dedicated tables, then enter the prefix for those tables here. Enter empty string if not.</param>
+    /// <param name="linkTablePrefix">If the entity uses dedicated link tables, then enter the prefix for those tables here. Enter empty string if not.</param>
     /// <returns></returns>
-    private async Task<(bool useLongValueColumn, bool valueChanged, bool deleteValue, bool alsoSaveSeoValue, ulong seoValueItemDetailId)> AddValueParameterToConnectionAsync(int counter, WiserItemDetailModel wiserItemDetail, IReadOnlyDictionary<string, Dictionary<string, object>> fieldOptions, IEnumerable<WiserItemDetailModel> previousItemDetails, string encryptionKey, bool alwaysSaveValues, bool isNewlyCreatedItem, string tablePrefix)
+    private async Task<(bool useLongValueColumn, bool valueChanged, bool deleteValue, bool alsoSaveSeoValue, ulong seoValueItemDetailId)> AddValueParameterToConnectionAsync(int counter, WiserItemDetailModel wiserItemDetail, IReadOnlyDictionary<string, Dictionary<string, object>> fieldOptions, IEnumerable<WiserItemDetailModel> previousItemDetails, string encryptionKey, bool alwaysSaveValues, bool isNewlyCreatedItem, string tablePrefix, string linkTablePrefix)
     {
         var useLongValueColumn = false;
         var deleteValue = false;
@@ -4756,7 +4757,7 @@ public class WiserItemsService(
             {
                 queryResult = await databaseConnection.GetAsync($"""
                     SELECT id 
-                    FROM {WiserTableNames.WiserItemLinkDetail} 
+                    FROM {linkTablePrefix}{WiserTableNames.WiserItemLinkDetail} 
                     WHERE itemlink_id = ?itemLinkId{counter} 
                         AND `key` = ?key{counter} 
                         AND language_code = ?languageCode{counter}
@@ -4945,7 +4946,7 @@ public class WiserItemsService(
             {
                 queryResult = await databaseConnection.GetAsync($"""
                                                                  SELECT id 
-                                                                 FROM {WiserTableNames.WiserItemLinkDetail} 
+                                                                 FROM {linkTablePrefix}{WiserTableNames.WiserItemLinkDetail} 
                                                                  WHERE itemlink_id = ?itemLinkId{counter} 
                                                                  AND `key` = ?key{Constants.SeoPropertySuffix}{counter}
                                                                  AND language_code = ?languageCode{counter}


### PR DESCRIPTION
# Describe your changes

The method `AddValueParameterToConnectionAsync` in the `WiserItemsService` did not take link table prefixes into account, causing itemlink details to always be inserted/updated in the regular itemlink detail table instead of the prefix one. This fixes that by adding a new parameter for the link table prefix which is used by the query's determining the ID of the record to check for an existing record.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug version to check if updating values through Wiser 3 that belong to a prefixed itemlink detail table would properly get added/updated there instead of in the regular itemlink table.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

None

# Link to Asana ticket

[Asana ticket](https://app.asana.com/1/5038780173035/project/1205090868730163/task/1206822059200908)