### PR TITLE
Add precompiled regexes for image and file URL matching

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MySqlConnector;
 using Constants = GeeksCoreLibrary.Core.Models.Constants;
+using PrecompiledRegexes = GeeksCoreLibrary.Core.Helpers.PrecompiledRegexes;
 
 namespace GeeksCoreLibrary.Core.Services;
 

--- a/GeeksCoreLibrary/Modules/ItemFiles/Helpers/PrecompiledRegexes.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Helpers/PrecompiledRegexes.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.RegularExpressions;
+using GeeksCoreLibrary.Core.Models;
+
+namespace GeeksCoreLibrary.Modules.ItemFiles.Helpers;
+
+public partial class PrecompiledRegexes
+{
+    [GeneratedRegex(@"^\/(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct|name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, Constants.DefaultRegexTimeoutInMilliseconds)]
+    public static partial Regex ImageUrlRegex { get; }
+    
+    [GeneratedRegex(@"^\/(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<encryptedId>.+?)(?:\/(?<fileType>itemlink|direct|name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, Constants.DefaultRegexTimeoutInMilliseconds)]
+    public static partial Regex EncryptedImageUrlRegex { get; }
+    
+    [GeneratedRegex(@"^\/(?:file\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>.+?)(?:\/(?<fileNumber>\d+))?(?:\/)(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, Constants.DefaultRegexTimeoutInMilliseconds)]
+    public static partial Regex FileUrlRegex { get; }
+
+    [GeneratedRegex(@"^\/(?:file\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<encryptedId>.+?)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>.+?)(?:\/(?<fileNumber>\d+))?(?:\/)(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, Constants.DefaultRegexTimeoutInMilliseconds)]
+    public static partial Regex EncryptedFileUrlRegex { get; }
+}

--- a/GeeksCoreLibrary/Modules/ItemFiles/Middlewares/WiserItemFilesMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Middlewares/WiserItemFilesMiddleware.cs
@@ -6,6 +6,7 @@ using GeeksCoreLibrary.Core.Helpers;
 using GeeksCoreLibrary.Modules.Templates.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using PrecompiledRegexes = GeeksCoreLibrary.Modules.ItemFiles.Helpers.PrecompiledRegexes;
 
 namespace GeeksCoreLibrary.Modules.ItemFiles.Middlewares;
 
@@ -58,20 +59,17 @@ public class WiserItemFilesMiddleware(RequestDelegate next, ILogger<RewriteUrlTo
     private void HandleRewrites(HttpContext context, string path, QueryString queryStringFromUrl)
     {
         // Check if the current URL is that of an image or a file.
-        var urlRegex = new Regex(@"(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct|name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
-        var matchResult = urlRegex.Match(path);
+        // If it is, we need to rewrite the URL to the correct GCL page.
+        var matchResult = PrecompiledRegexes.ImageUrlRegex.Match(path);
         if (!matchResult.Success)
         {
-            urlRegex = new Regex(@"(?:image\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<encryptedId>.+?)(?:\/(?<fileType>itemlink|direct|name))?\/(?<propertyName>[^\/]+)(?:\/(?<resizeMode>normal|stretch|crop|fill)(?:-(?<anchorPosition>center|top|bottom|left|right|topleft|topright|bottomright|bottomleft))?)?(?:\/(?<preferredWidth>\d+)\/(?<preferredHeight>\d+))?(?:\/(?<fileNumber>\d+))?\/(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
-            matchResult = urlRegex.Match(path);
+            matchResult = PrecompiledRegexes.EncryptedImageUrlRegex.Match(path);
             if (!matchResult.Success)
             {
-                urlRegex = new Regex(@"(?:file\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<itemId>\d+)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>.+?)(?:\/(?<fileNumber>\d+))?(?:\/)(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
-                matchResult = urlRegex.Match(path);
+                matchResult = PrecompiledRegexes.FileUrlRegex.Match(path);
                 if (!matchResult.Success)
                 {
-                    urlRegex = new Regex(@"(?:file\/wiser[0-9]?\/)(?:(?<type>[^\/]+)\/)?(?<encryptedId>.+?)(?:\/(?<fileType>itemlink|direct))?\/(?<propertyName>.+?)(?:\/(?<fileNumber>\d+))?(?:\/)(?<fileName>.+?\..+)", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(2000));
-                    matchResult = urlRegex.Match(path);
+                    matchResult = PrecompiledRegexes.EncryptedFileUrlRegex.Match(path);
                     if (!matchResult.Success)
                     {
                         return;


### PR DESCRIPTION
# Describe your changes

Turn the regexes used to match file and image urls into generated regexes. This is an performance improvement.

These were missed when doing https://github.com/happy-geeks/geeks-core-library/pull/834 because these didn't have RegexOption.Compiled but there is no reason to leave these uncompiled.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Opened a website and checked whether all images where shown correctly and then manually tried several file urls.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
