### PR TITLE
Fixed problem that creating items with a parentId, would not link them correctly in certain situations.

### DIFF
--- a/GeeksCoreLibrary/Core/Interfaces/IWiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Interfaces/IWiserItemsService.cs
@@ -60,9 +60,10 @@ public interface IWiserItemsService
     /// <param name="createNewTransaction">Optional: Set to false if you don't want this function to try and create a new database transaction. Be warned that this will then also not rollback any changes if an error occurred. It's recommended to only set this to false if you already created a transaction in your code, before calling this function. Default value is true.</param>
     /// <param name="skipPermissionsCheck">Optional: Whether to skip the check for permissions. Only do this for things that should always be possible by anyone, such as creating a basket.</param>
     /// <param name="storeTypeOverride">Optional: Override the storeType of the item.</param>
+    /// <param name="parentEntityType">Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.</param>
     /// <returns>The same <see cref="WiserItemModel"/> again, with the new ID.</returns>
     /// <exception cref="System.ArgumentNullException">If wiserItem or entityType is <see langword="null"/>.</exception>
-    Task<WiserItemModel> CreateAsync(WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null);
+    Task<WiserItemModel> CreateAsync(WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null, string parentEntityType = null);
 
     /// <summary>
     /// Creates an item.
@@ -79,9 +80,10 @@ public interface IWiserItemsService
     /// <param name="createNewTransaction">Optional: Set to false if you don't want this function to try and create a new database transaction. Be warned that this will then also not rollback any changes if an error occurred. It's recommended to only set this to false if you already created a transaction in your code, before calling this function. Default value is true.</param>
     /// <param name="skipPermissionsCheck">Optional: Whether to skip the check for permissions. Only do this for things that should always be possible by anyone, such as creating a basket.</param>
     /// <param name="storeTypeOverride">Optional: Override the storeType of the item.</param>
+    /// <param name="parentEntityType">Optional: The entity type of the parent item. We need this to determine where and how to save the parent link.</param>
     /// <returns>The same <see cref="WiserItemModel"/> again, with the new ID.</returns>
     /// <exception cref="System.ArgumentNullException">If wiserItem or entityType is <see langword="null"/>.</exception>
-    Task<WiserItemModel> CreateAsync(IWiserItemsService wiserItemsService, WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null);
+    Task<WiserItemModel> CreateAsync(IWiserItemsService wiserItemsService, WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null, string parentEntityType = null);
 
     /// <summary>
     /// Duplicate an item. This could also duplicate links and linked items, depending on the settings in wiser_link.

--- a/GeeksCoreLibrary/Core/Services/CachedWiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/CachedWiserItemsService.cs
@@ -14,8 +14,7 @@ using Microsoft.Extensions.Options;
 namespace GeeksCoreLibrary.Core.Services;
 
 /// <inheritdoc />
-public class CachedWiserItemsService(IOptions<GclSettings> gclSettings, IAppCache cache, IWiserItemsService wiserItemsService, IDatabaseConnection databaseConnection, ICacheService cacheService, IBranchesService branchesService)
-    : IWiserItemsService
+public class CachedWiserItemsService(IOptions<GclSettings> gclSettings, IAppCache cache, IWiserItemsService wiserItemsService, IDatabaseConnection databaseConnection, ICacheService cacheService, IBranchesService branchesService) : IWiserItemsService
 {
     private readonly GclSettings gclSettings = gclSettings.Value;
 
@@ -32,15 +31,15 @@ public class CachedWiserItemsService(IOptions<GclSettings> gclSettings, IAppCach
     }
 
     /// <inheritdoc />
-    public async Task<WiserItemModel> CreateAsync(WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null)
+    public async Task<WiserItemModel> CreateAsync(WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null, string parentEntityType = null)
     {
-        return await CreateAsync(this, wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, createNewTransaction, skipPermissionsCheck, storeTypeOverride);
+        return await CreateAsync(this, wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, createNewTransaction, skipPermissionsCheck, storeTypeOverride, parentEntityType);
     }
 
     /// <inheritdoc />
-    public async Task<WiserItemModel> CreateAsync(IWiserItemsService service, WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null)
+    public async Task<WiserItemModel> CreateAsync(IWiserItemsService service, WiserItemModel wiserItem, ulong? parentId = null, int linkTypeNumber = 1, ulong userId = 0, string username = "GCL", string encryptionKey = "", bool saveHistory = true, bool createNewTransaction = true, bool skipPermissionsCheck = false, StoreType? storeTypeOverride = null, string parentEntityType = null)
     {
-        return await wiserItemsService.CreateAsync(service, wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, createNewTransaction, skipPermissionsCheck, storeTypeOverride);
+        return await wiserItemsService.CreateAsync(service, wiserItem, parentId, linkTypeNumber, userId, username, encryptionKey, saveHistory, createNewTransaction, skipPermissionsCheck, storeTypeOverride, parentEntityType);
     }
 
     /// <inheritdoc />

--- a/GeeksCoreLibrary/Core/Services/LinkTypesService.cs
+++ b/GeeksCoreLibrary/Core/Services/LinkTypesService.cs
@@ -51,7 +51,7 @@ public class LinkTypesService : ILinkTypesService, IScopedService
             whereClause.Add("destination_entity_type = ?destinationEntityType");
         }
 
-        var query = $@"SELECT * FROM {WiserTableNames.WiserLink} WHERE {String.Join(" AND ", whereClause)}";
+        var query = $"SELECT * FROM {WiserTableNames.WiserLink} WHERE {String.Join(" AND ", whereClause)}";
 
         var dataTable = await databaseConnection.GetAsync(query);
         return dataTable.Rows.Count == 0 ? new LinkSettingsModel() : DataRowToLinkSettingsModel(dataTable.Rows[0]);


### PR DESCRIPTION
# Describe your changes

If the source and destination items use different table prefixes, then it would not find the correct link settings and not use `parent_item_id`. This happened most often with link type `1`, because that one is used for multiple entities.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By creating new items with a parent id and checking if correct links are created.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser/pull/916

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1206957555415824
