### PR TITLE
Refactor caching logic to use hashed file names

### DIFF
--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/CachedItemFilesService.cs
@@ -65,7 +65,15 @@ public class CachedItemFilesService(
         }
 
         // Generate the file name for caching.
-        var fileNameParts = new List<string> { "wiser_image" };
+        var fileNameParts = new List<string>(8)
+        {
+            "wiser_image",
+            file.Id.ToString(),
+            resizeMode.ToString("G"),
+            anchorPosition.ToString("G"),
+            preferredWidth.ToString(),
+            preferredHeight.ToString()
+        };
         if (!String.IsNullOrWhiteSpace(entityType))
         {
             fileNameParts.Add(entityType);
@@ -74,14 +82,10 @@ public class CachedItemFilesService(
         {
             fileNameParts.Add(linkType.ToString());
         }
-        fileNameParts.Add(file.Id.ToString());
-        fileNameParts.Add(resizeMode.ToString("G"));
-        fileNameParts.Add(anchorPosition.ToString("G"));
-        fileNameParts.Add(preferredWidth.ToString());
-        fileNameParts.Add(preferredHeight.ToString());
 
         var extension = Path.GetExtension(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName);
-        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts) + extension);
+        var cachedFileName = FileSystemHelpers.HashFileName(String.Join("_", fileNameParts), false);
+        var fileLocation = Path.Combine(cacheDirectory, cachedFileName + extension);
 
         var (fileBytes, lastModifiedDate) = await fileCacheService.GetOrAddAsync(fileLocation, async () =>
         {
@@ -157,8 +161,11 @@ public class CachedItemFilesService(
         fileNameParts.Add(file.Id.ToString());
         fileNameParts.Add(fileNumber.ToString());
 
+        
         var extension = Path.GetExtension(String.IsNullOrWhiteSpace(fileName) ? file.FileName : fileName);
-        var fileLocation = Path.Combine(cacheDirectory, String.Join("_", fileNameParts) + extension);
+
+        var cachedFileName = FileSystemHelpers.HashFileName(String.Join("_", fileNameParts), false);
+        var fileLocation = Path.Combine(cacheDirectory, cachedFileName + extension);
 
         var (fileBytes, lastModifiedDate) = await fileCacheService.GetOrAddAsync(fileLocation, async () =>
         {

--- a/GeeksCoreLibrary/Modules/Templates/Services/CachedPagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/CachedPagesService.cs
@@ -98,10 +98,11 @@ public class CachedPagesService(
                     }
                     else
                     {
+                        var hashedCacheFileName = FileSystemHelpers.HashFileName(cacheFileName);
                         // Build the cache directory, based on template type and name.
                         fullCachePath = Path.Combine(cacheFolder, Constants.TemplateCacheRootDirectoryName,
                             cacheSettings.Type.ToString(),
-                            $"{cacheSettings.Name.StripIllegalPathCharacters()} ({cacheSettings.Id})", cacheFileName);
+                            $"{cacheSettings.Name.StripIllegalPathCharacters()} ({cacheSettings.Id})", hashedCacheFileName);
                         logger.LogDebug(
                             $"Content cache enabled for template '{cacheSettings.Id}', cache file location: {fullCachePath}.");
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1427,8 +1427,15 @@ public class TemplatesService(
             {
                 var extraData = match.Groups["data"].Value.ToDictionary("&", "=");
                 var dynamicContentData = componentOverrides?.FirstOrDefault(d => d.Id == contentId);
-                var html = dynamicContentData == null ? await templatesService.GenerateDynamicContentHtmlAsync(contentId, extraData: extraData) : await templatesService.GenerateDynamicContentHtmlAsync(dynamicContentData, extraData: extraData);
-                template = template.Replace(match.Value, $"<!-- Start component {contentId} -->{(string) html}<!-- End component {contentId} -->");
+                var content = dynamicContentData == null ? await templatesService.GenerateDynamicContentHtmlAsync(contentId, extraData: extraData) : await templatesService.GenerateDynamicContentHtmlAsync(dynamicContentData, extraData: extraData);
+                if (content is string html)
+                {
+                    template = template.Replace(match.Value, $"<!-- Start component {contentId} -->{html}<!-- End component {contentId} -->");
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Component {contentId} did not return a string, but a {content.GetType()}");
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
# Describe your changes

Because all parameters of the cache gets added to the filename we had the issue that file names got too long, this caused IO Exceptions for certain files, templates or dynamic components.

The solution this proposed is to hash the file names that are above a certain length and then truncate it. Since any additional parameter completely changed the result of a hash this still keeps every file unique while not needing to have all those parameters in the file name.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Set environment to Acceptance tested to see whether images, templates and dynamic content were correctly cached as file. For this I used a GCL site that uses a lot of caching.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

None, I think the Asana ticket that was made for this already got marked as completed.
