### PR TITLE
Pass link ID of new created item back.

### DIFF
--- a/GeeksCoreLibrary/Core/Models/WiserItemModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemModel.cs
@@ -388,6 +388,12 @@ public class WiserItemModel
     }
 
     /// <summary>
+    /// Gets or sets the link ID when the item has been created. This is only used internally during the creation phase and is therefore ignored in the JSON.
+    /// </summary>
+    [JsonIgnore]
+    public long NewLinkId { get; set; }
+
+    /// <summary>
     /// Gets or sets the item details.
     /// </summary>
     public List<WiserItemDetailModel> Details { get; set; } = [];

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -305,10 +305,10 @@ public class WiserItemsService(
 
                     databaseConnection.AddParameter("newId", wiserItem.Id);
                     databaseConnection.AddParameter("newOrderNumber", newOrderNumber);
-                    await databaseConnection.ExecuteAsync($"""
-                                                           INSERT INTO {linkTablePrefix}{WiserTableNames.WiserItemLink} (item_id, destination_item_id, ordering, type)
-                                                           VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber)
-                                                           """);
+                    wiserItem.NewLinkId = await databaseConnection.InsertRecordAsync($"""
+                                                                                INSERT INTO {linkTablePrefix}{WiserTableNames.WiserItemLink} (item_id, destination_item_id, ordering, type)
+                                                                                VALUES (?newId, ?parentId, ?newOrderNumber, ?linkTypeNumber);
+                                                                                """);
                 }
 
                 if (createNewTransaction && !alreadyHadTransaction)


### PR DESCRIPTION
# Describe your changes

When an item has been created on a link the link ID is passed along. This will be used in Wiser to use it correctly for the API response.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating a new item and checking if the value is set when creating on a link without a parent and that it stays empty when creating on a parent item ID link.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1205529420472876
