### PR TITLE
Allow permissions for items to be set to specific entity

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -2532,7 +2532,7 @@ public class WiserItemsService(
             permissionsQueryPart = $"""
                                     # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                     LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                    LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                                    LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
                                     """;
             where.Add("(permission.id IS NULL OR (permission.permissions & 1) > 0)");
         }
@@ -2711,7 +2711,7 @@ public class WiserItemsService(
             permissionsQueryPart = $"""
                                     # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                     LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                    LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                                    LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
                                     """;
             where.Add("(permission.id IS NULL OR (permission.permissions & 1) > 0)");
         }
@@ -3261,12 +3261,12 @@ public class WiserItemsService(
             wiserItemLinkQueryBuilder.Append($"""
                                                # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                               	                                                LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                              	                                                LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                                              	                                                LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
                                               """);
             parentItemIdQueryBuilder.Append($"""
                                               # Check permissions. Default permissions are everything enabled, so if the user has no role or the role has no permissions on this item, they are allowed everything.
                                              	                                                LEFT JOIN {WiserTableNames.WiserUserRoles} user_role ON user_role.user_id = ?userId
-                                             	                                                LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id
+                                             	                                                LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.item_id = item.id AND (permission.entity_name = item.entity_type OR permission.entity_name = '')
                                              """);
         }
 

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -2131,10 +2131,11 @@ public class WiserItemsService(
         }
 
         // Then check the permissions for the specific item, they overwrite permissions of the module.
+        databaseConnection.AddParameter("entityName", entityType);
         permissionsQuery = $"""
                             SELECT permission.permissions
                             FROM {WiserTableNames.WiserUserRoles} AS user_role
-                            LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = ?itemId
+                            LEFT JOIN {WiserTableNames.WiserPermission} AS permission ON permission.role_id = user_role.role_id AND permission.item_id = ?itemId AND (permission.entity_name = ?entityName OR permission.entity_name = '')
                             WHERE user_role.user_id = ?userId
                             AND (user_role.ip_addresses IS NULL OR JSON_CONTAINS(user_role.ip_addresses, JSON_QUOTE(?userIp)))
                             """;


### PR DESCRIPTION
# Describe your changes

Allow permissions for items to be applied to specific entities. This fixes the problem that if permissions are set this is applied to entities in wiser_item and any prefix table with the same ID.

For backwards compatibility, if no entity type is provided with the permission it still applies to all items with the same ID.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by adding a permission for an item and validated the correct behavior if no entity type has been provided, if the entity type of the item in `wiser_item` was provided and the entity type of the item in the prefix table.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser/pull/922

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209869916047907
