### PR TITLE
Added some new functionality for working with databases and improved some existing functionality

### DIFF
--- a/GeeksCoreLibrary/Core/Models/WiserTableNames.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserTableNames.cs
@@ -264,7 +264,7 @@ public class WiserTableNames
     /// This table is used by the RequestLoggingMiddleware to log all incoming requests, if enabled.
     /// </summary>
     public const string GclRequestLog = "gcl_request_log";
-    
+
     /// <summary>
     /// This table is used by the products api to store all the product api results
     /// </summary>

--- a/GeeksCoreLibrary/Core/Services/EntityTypesService.cs
+++ b/GeeksCoreLibrary/Core/Services/EntityTypesService.cs
@@ -42,7 +42,6 @@ public class EntityTypesService : IEntityTypesService, IScopedService
         {
             var tablePrefix = dataRow.Field<string>("dedicated_table_prefix");
             if (!tablePrefix!.EndsWith('_'))
-
             {
                 tablePrefix += "_";
             }

--- a/GeeksCoreLibrary/Core/Services/EntityTypesService.cs
+++ b/GeeksCoreLibrary/Core/Services/EntityTypesService.cs
@@ -30,7 +30,7 @@ public class EntityTypesService : IEntityTypesService, IScopedService
     {
         var prefixes = new List<string>();
 
-        var query = $"SELECT DISTINCT dedicated_table_prefix FROM {WiserTableNames.WiserEntity} WHERE dedicated_table_prefix IS NOT NULL AND dedicated_table_prefix != ''";
+        const string query = $"SELECT DISTINCT dedicated_table_prefix FROM {WiserTableNames.WiserEntity} WHERE dedicated_table_prefix IS NOT NULL AND dedicated_table_prefix != ''";
         var dataTable = await databaseConnection.GetAsync(query);
 
         if (dataTable.Rows.Count <= 0)
@@ -41,7 +41,8 @@ public class EntityTypesService : IEntityTypesService, IScopedService
         foreach (DataRow dataRow in dataTable.Rows)
         {
             var tablePrefix = dataRow.Field<string>("dedicated_table_prefix");
-            if (!tablePrefix!.EndsWith("_"))
+            if (!tablePrefix!.EndsWith('_'))
+
             {
                 tablePrefix += "_";
             }

--- a/GeeksCoreLibrary/Modules/Branches/Helpers/BranchesHelpers.cs
+++ b/GeeksCoreLibrary/Modules/Branches/Helpers/BranchesHelpers.cs
@@ -74,6 +74,7 @@ public static class BranchesHelpers
             case "INSERT_LINK_SETTING":
             case "INSERT_API_CONNECTION":
             case "INSERT_ROLE":
+            case "CREATE_EASY_OBJECT":
                 if (wiserObject == null)
                 {
                     trackedObjects.Add(new ObjectCreatedInBranchModel {ObjectId = objectId, TableName = tableName});
@@ -94,6 +95,7 @@ public static class BranchesHelpers
             case "DELETE_LINK_SETTING":
             case "DELETE_API_CONNECTION":
             case "DELETE_ROLE":
+            case "DELETE_EASY_OBJECT":
                 if (wiserObject != null)
                 {
                     wiserObject.AlsoDeleted = true;

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -155,8 +155,8 @@ public class WiserTableDefinitions
                 new ColumnSettingsModel("id", MySqlDbType.Int32, notNull: true, isPrimaryKey: true, autoIncrement: true),
                 new ColumnSettingsModel("selector", MySqlDbType.VarChar, 32, notNull: true),
                 new ColumnSettingsModel("hashed_validator", MySqlDbType.VarChar, 150, notNull: true),
-                new ColumnSettingsModel("user_id", MySqlDbType.Int64, notNull: true),
-                new ColumnSettingsModel("main_user_id", MySqlDbType.Int64, notNull: true),
+                new ColumnSettingsModel("user_id", MySqlDbType.UInt64, notNull: true),
+                new ColumnSettingsModel("main_user_id", MySqlDbType.UInt64, notNull: true),
                 new ColumnSettingsModel("entity_type", MySqlDbType.VarChar, 255, notNull: true),
                 new ColumnSettingsModel("main_user_entity_type", MySqlDbType.VarChar, 255, notNull: true),
                 new ColumnSettingsModel("role", MySqlDbType.VarChar, 255),
@@ -434,10 +434,10 @@ public class WiserTableDefinitions
                 new ColumnSettingsModel("id", MySqlDbType.Int32, notNull: true, isPrimaryKey: true, autoIncrement: true),
                 new ColumnSettingsModel("commit_id", MySqlDbType.Int32, notNull: true),
                 new ColumnSettingsModel("requested_on", MySqlDbType.DateTime, notNull: true, defaultValue: "CURRENT_TIMESTAMP"),
-                new ColumnSettingsModel("requested_by", MySqlDbType.Int64, notNull: true, comment: "Negative numbers are IDs of admins"),
+                new ColumnSettingsModel("requested_by", MySqlDbType.UInt64, notNull: true, comment: "Negative numbers are IDs of admins"),
                 new ColumnSettingsModel("requested_by_name", MySqlDbType.VarChar, 255),
                 new ColumnSettingsModel("reviewed_on", MySqlDbType.DateTime, notNull: true, defaultValue: "CURRENT_TIMESTAMP"),
-                new ColumnSettingsModel("reviewed_by", MySqlDbType.Int64, notNull: true, defaultValue: "0", comment: "Negative numbers are IDs of admins"),
+                new ColumnSettingsModel("reviewed_by", MySqlDbType.UInt64, notNull: true, defaultValue: "0", comment: "Negative numbers are IDs of admins"),
                 new ColumnSettingsModel("reviewed_by_name", MySqlDbType.VarChar, 255),
                 new ColumnSettingsModel("status", MySqlDbType.Enum, enumValues: new List<string> {"Pending", "Approved", "RequestChanges"})
             ],
@@ -459,7 +459,7 @@ public class WiserTableDefinitions
                 new ColumnSettingsModel("id", MySqlDbType.Int32, notNull: true, isPrimaryKey: true, autoIncrement: true),
                 new ColumnSettingsModel("review_id", MySqlDbType.Int32, notNull: true),
                 new ColumnSettingsModel("added_on", MySqlDbType.DateTime, notNull: true, defaultValue: "CURRENT_TIMESTAMP"),
-                new ColumnSettingsModel("added_by", MySqlDbType.Int64, notNull: true, comment: "Negative numbers are IDs of admins"),
+                new ColumnSettingsModel("added_by", MySqlDbType.UInt64, notNull: true, comment: "Negative numbers are IDs of admins"),
                 new ColumnSettingsModel("added_by_name", MySqlDbType.VarChar, 255),
                 new ColumnSettingsModel("text", MySqlDbType.MediumText)
             ],
@@ -478,7 +478,7 @@ public class WiserTableDefinitions
             Columns =
             [
                 new ColumnSettingsModel("review_id", MySqlDbType.Int32, notNull: true, isPrimaryKey: true),
-                new ColumnSettingsModel("requested_user", MySqlDbType.Int64, notNull: true, isPrimaryKey: true, comment: "Negative numbers are IDs of admins")
+                new ColumnSettingsModel("requested_user", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, comment: "Negative numbers are IDs of admins")
             ]
         },
 
@@ -794,7 +794,7 @@ public class WiserTableDefinitions
             [
                 new ColumnSettingsModel("id", MySqlDbType.UInt64, notNull: true, isPrimaryKey: true, autoIncrement: true),
                 new ColumnSettingsModel("user_id", MySqlDbType.UInt64, notNull: true),
-                new ColumnSettingsModel("time_active_in_seconds", MySqlDbType.Int64, notNull: true, defaultValue: "0"),
+                new ColumnSettingsModel("time_active_in_seconds", MySqlDbType.UInt64, notNull: true, defaultValue: "0"),
                 new ColumnSettingsModel("added_on", MySqlDbType.DateTime, notNull: true),
                 new ColumnSettingsModel("time_active_changed_on", MySqlDbType.DateTime, notNull: true)
             ],

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
@@ -26,6 +26,26 @@ public interface IDatabaseConnection : IAsyncDisposable, IDisposable
     Task<DbDataReader> GetReaderAsync(string query);
 
     /// <summary>
+    /// Executes the query, and returns the first column of the first row in the resultset returned by the query. Extra columns or rows are ignored.
+    /// </summary>
+    /// <param name="query">The query to execute and get the result of.</param>
+    /// <param name="skipCache">Optional: Set to true to skip the query cache. Queries that get data, will get cached by default, based on a hash of the query and all parameters.</param>
+    /// <param name="cleanUp">Optional: Clean up after the query has been completed.</param>
+    /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
+    /// <returns>The first column of the first row in the resultset.</returns>
+    Task<T> ExecuteScalarAsync<T>(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false);
+
+    /// <summary>
+    /// Executes the query, and returns the first column of the first row in the resultset returned by the query. Extra columns or rows are ignored.
+    /// </summary>
+    /// <param name="query">The query to execute and get the result of.</param>
+    /// <param name="skipCache">Optional: Set to true to skip the query cache. Queries that get data, will get cached by default, based on a hash of the query and all parameters.</param>
+    /// <param name="cleanUp">Optional: Clean up after the query has been completed.</param>
+    /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
+    /// <returns>The first column of the first row in the resultset.</returns>
+    Task<object> ExecuteScalarAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false);
+
+    /// <summary>
     /// Gets results from a query as a DataTable.
     /// </summary>
     /// <param name="query">The query to execute and get the results of.</param>
@@ -139,7 +159,6 @@ public interface IDatabaseConnection : IAsyncDisposable, IDisposable
     /// <param name="newConnectionStringForWriting">The new connection string to use for writing.</param>
     /// <param name="sshSettingsForReading">Optional: If the new connection for reading requires SSH, enter the SSH details here.</param>
     /// <param name="sshSettingsForWriting">Optional: If the new connection for writing requires SSH, enter the SSH details here.</param>
-    /// <returns></returns>
     Task ChangeConnectionStringsAsync(string newConnectionStringForReading, string newConnectionStringForWriting = null, SshSettings sshSettingsForReading = null, SshSettings sshSettingsForWriting = null);
 
     /// <summary>

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
@@ -130,7 +130,7 @@ public interface IDatabaseHelpersService
     /// <summary>
     /// Get all indexes for a specific table.
     /// </summary>
-    /// <param name="tableName">The name if the table to get the indexes for.</param>
+    /// <param name="tableName">The name of the table to get the indexes for.</param>
     /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
     /// <returns>A <see cref="List{T}"/> of <see cref="IndexSettingsModel"/> with all indexes of that table.</returns>
     Task<List<IndexSettingsModel>> GetIndexesAsync(string tableName, string databaseName = null);
@@ -139,7 +139,7 @@ public interface IDatabaseHelpersService
     /// Get all indexes for a specific table.
     /// </summary>
     /// <param name="databaseHelpersService">The <see cref="IDatabaseHelpersService"/> to use, to prevent duplicate code while using caching with the decorator pattern, while still being able to use caching in calls to other methods of the same service.</param>
-    /// <param name="tableName">The name if the table to get the indexes for.</param>
+    /// <param name="tableName">The name of the table to get the indexes for.</param>
     /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
     /// <returns>A <see cref="List{T}"/> of <see cref="IndexSettingsModel"/> with all indexes of that table.</returns>
     Task<List<IndexSettingsModel>> GetIndexesAsync(IDatabaseHelpersService databaseHelpersService, string tableName, string databaseName = null);

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
@@ -120,6 +120,31 @@ public interface IDatabaseHelpersService
     Task DuplicateTableAsync(string tableToDuplicate, string newTableName, bool includeData = true, string sourceDatabaseName = null, string destinationDatabaseName = null);
 
     /// <summary>
+    /// Get all indexes for specific tables.
+    /// </summary>
+    /// <param name="tableNames">The tables to get the indexes for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="Dictionary{T,T}"/> where the key is the name of the table and the value is a <see cref="List{t}"/> of <see cref="IndexSettingsModel"/> with all indexes of that table.</returns>
+    Task<Dictionary<string, List<IndexSettingsModel>>> GetIndexesAsync(List<string> tableNames, string databaseName = null);
+
+    /// <summary>
+    /// Get all indexes for a specific table.
+    /// </summary>
+    /// <param name="tableName">The name if the table to get the indexes for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="List{T}"/> of <see cref="IndexSettingsModel"/> with all indexes of that table.</returns>
+    Task<List<IndexSettingsModel>> GetIndexesAsync(string tableName, string databaseName = null);
+
+    /// <summary>
+    /// Get all indexes for a specific table.
+    /// </summary>
+    /// <param name="databaseHelpersService">The <see cref="IDatabaseHelpersService"/> to use, to prevent duplicate code while using caching with the decorator pattern, while still being able to use caching in calls to other methods of the same service.</param>
+    /// <param name="tableName">The name if the table to get the indexes for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="List{T}"/> of <see cref="IndexSettingsModel"/> with all indexes of that table.</returns>
+    Task<List<IndexSettingsModel>> GetIndexesAsync(IDatabaseHelpersService databaseHelpersService, string tableName, string databaseName = null);
+
+    /// <summary>
     /// Creates or updates one or more indexes. This method will check if an index with the given name already exists,
     /// if it doesn't it will create that index, otherwise it will check if the index has been changed.
     /// If it has been changed, then the index will be dropped and recreated.
@@ -127,6 +152,16 @@ public interface IDatabaseHelpersService
     /// <param name="indexes">A list with one or more <see cref="IndexSettingsModel"/>.</param>
     /// <param name="databaseName">Optional: The name of the database schema. Leave empty to use the database from the connection string. Default value is <see langword="null"/>.</param>
     Task CreateOrUpdateIndexesAsync(List<IndexSettingsModel> indexes, string databaseName = null);
+
+    /// <summary>
+    /// Creates or updates one or more indexes. This method will check if an index with the given name already exists,
+    /// if it doesn't it will create that index, otherwise it will check if the index has been changed.
+    /// If it has been changed, then the index will be dropped and recreated.
+    /// </summary>
+    /// <param name="databaseHelpersService">The <see cref="IDatabaseHelpersService"/> to use, to prevent duplicate code while using caching with the decorator pattern, while still being able to use caching in calls to other methods of the same service.</param>
+    /// <param name="indexes">A list with one or more <see cref="IndexSettingsModel"/>.</param>
+    /// <param name="databaseName">Optional: The name of the database schema. Leave empty to use the database from the connection string. Default value is <see langword="null"/>.</param>
+    Task CreateOrUpdateIndexesAsync(IDatabaseHelpersService databaseHelpersService, List<IndexSettingsModel> indexes, string databaseName = null);
 
     /// <summary>
     /// Create a new database if it doesn't exist yet.

--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseHelpersService.cs
@@ -16,6 +16,31 @@ public interface IDatabaseHelpersService
     List<WiserTableDefinitionModel> ExtraWiserTableDefinitions { get; set; }
 
     /// <summary>
+    /// Get all columns for specific tables.
+    /// </summary>
+    /// <param name="tableNames">The tables to get the columns for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="Dictionary{T,T}"/> where the key is the name of the table and the value is a <see cref="List{t}"/> of <see cref="ColumnSettingsModel"/> with all columns of that table.</returns>
+    Task<Dictionary<string, List<ColumnSettingsModel>>> GetColumnsAsync(List<string> tableNames, string databaseName = null);
+
+    /// <summary>
+    /// Get all columns for a specific table.
+    /// </summary>
+    /// <param name="tableName">The name of the table to get the columns for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="List{T}"/> of <see cref="ColumnSettingsModel"/> with all columns of that table.</returns>
+    Task<List<ColumnSettingsModel>> GetColumnsAsync(string tableName, string databaseName = null);
+
+    /// <summary>
+    /// Get all columns for a specific table.
+    /// </summary>
+    /// <param name="databaseHelpersService">The <see cref="IDatabaseHelpersService"/> to use, to prevent duplicate code while using caching with the decorator pattern, while still being able to use caching in calls to other methods of the same service.</param>
+    /// <param name="tableName">The name of the table to get the columns for.</param>
+    /// <param name="databaseName">Optional: The name of the database schema that the tables belong to. Leave empty to use the database schema from the connection string.</param>
+    /// <returns>A <see cref="List{T}"/> of <see cref="ColumnSettingsModel"/> with all columns of that table.</returns>
+    Task<List<ColumnSettingsModel>> GetColumnsAsync(IDatabaseHelpersService databaseHelpersService, string tableName, string databaseName = null);
+
+    /// <summary>
     /// Check whether or not a column exists in a specific table.
     /// </summary>
     /// <param name="tableName">The name of the table.</param>

--- a/GeeksCoreLibrary/Modules/Databases/Models/IndexColumnModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/IndexColumnModel.cs
@@ -1,0 +1,22 @@
+﻿namespace GeeksCoreLibrary.Modules.Databases.Models;
+
+/// <summary>
+/// A model for a database index column.
+/// </summary>
+public class IndexColumnModel
+{
+    /// <summary>
+    /// The name of the column in the database table.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The length of the column, if applicable. This is used for string columns to specify the maximum length of the index.
+    /// </summary>
+    public long? Length { get; set; }
+
+    /// <summary>
+    /// The sequence order of the column in the index. This is used to determine the order of the columns in the index.
+    /// </summary>
+    public uint Sequence { get; set; }
+}

--- a/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Models/IndexSettingsModel.cs
@@ -1,21 +1,89 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GeeksCoreLibrary.Modules.Databases.Enums;
 
 namespace GeeksCoreLibrary.Modules.Databases.Models;
 
+/// <summary>
+/// A model for an index in a database.
+/// </summary>
 public class IndexSettingsModel
 {
+    /// <summary>
+    /// Creates a new instance of the <see cref="IndexSettingsModel"/> class, without setting any properties.
+    /// </summary>
     public IndexSettingsModel()
     {
     }
 
-    public IndexSettingsModel(string tableName, string name, IndexTypes type = IndexTypes.Normal, List<string> fields = null, string comment = null)
+    /// <summary>
+    /// Creates a new instance of the <see cref="IndexSettingsModel"/> class with the specified parameters.
+    /// </summary>
+    /// <param name="tableName">The name of the table that the index belongs to.</param>
+    /// <param name="name">The name of the index itself.</param>
+    /// <param name="type">The type of index (normal/unique/fulltext).</param>
+    /// <param name="columns">The list of database columns that the index is for.</param>
+    /// <param name="comment">Optional: A comment to describe what the index is for.</param>
+    public IndexSettingsModel(string tableName, string name, IndexTypes type = IndexTypes.Normal, List<IndexColumnModel> columns = null, string comment = null)
     {
         Name = name;
         Type = type;
         TableName = tableName;
-        Fields = fields ?? [];
+        Columns = columns ?? [];
         Comment = comment;
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="IndexSettingsModel"/> class with the specified parameters.
+    /// </summary>
+    /// <param name="tableName">The name of the table that the index belongs to.</param>
+    /// <param name="name">The name of the index itself.</param>
+    /// <param name="type">The type of index (normal/unique/fulltext).</param>
+    /// <param name="columns">The list of database columns that the index is for.</param>
+    /// <param name="comment">Optional: A comment to describe what the index is for.</param>
+    public IndexSettingsModel(string tableName, string name, IndexTypes type = IndexTypes.Normal, List<string> columns = null, string comment = null)
+    {
+        Name = name;
+        Type = type;
+        TableName = tableName;
+        Comment = comment;
+
+        Columns = [];
+        if (columns == null)
+        {
+            return;
+        }
+
+        // Iterate through the list of column names and create IndexColumnModel instances for each one.
+        for (var index = 0; index < columns.Count; index++)
+        {
+            var indexColumn = columns[index];
+            var columnName = indexColumn;
+            long? length = null;
+
+            // Check if the column name contains a length specification (e.g., "column_name(10)").
+            var subPartStart = indexColumn.LastIndexOf('(');
+            var subPartEnd = indexColumn.LastIndexOf(')');
+
+            // Check if the field contains both opening and closing parentheses and if the closing parenthesis comes after the opening parenthesis.
+            if (subPartStart != -1 && subPartEnd != -1 && subPartStart <= subPartEnd)
+            {
+                columnName = indexColumn[..subPartStart].Trim();
+
+                // Try to parse the length from the substring between the parentheses, ignore the value if it's not a valid number.
+                if (Int64.TryParse(indexColumn[(subPartStart + 1)..subPartEnd], out var parsedLength))
+                {
+                    length = parsedLength;
+                }
+            }
+
+            Columns.Add(new IndexColumnModel
+            {
+                Name = columnName,
+                Length = length,
+                Sequence = Convert.ToUInt32(index + 1)
+            });
+        }
     }
 
     /// <summary>
@@ -34,12 +102,18 @@ public class IndexSettingsModel
     public string TableName { get; set; }
 
     /// <summary>
-    /// Gets or sets the fields that are part of this index.
+    /// Gets or sets the table columns that are part of this index.
     /// </summary>
-    public List<string> Fields { get; set; } = [];
+    public List<IndexColumnModel> Columns { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the comment describing the index.
     /// </summary>
     public string Comment { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the index is visible in the database.
+    /// See the following article for more information: https://dev.mysql.com/doc/refman/8.4/en/invisible-indexes.html
+    /// </summary>
+    public bool IsVisible { get; set; } = true;
 }

--- a/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseHelpersService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.Enums;
 using GeeksCoreLibrary.Core.Interfaces;
@@ -13,7 +14,13 @@ using Microsoft.Extensions.Options;
 namespace GeeksCoreLibrary.Modules.Databases.Services;
 
 /// <inheritdoc cref="IDatabaseHelpersService" />.
-public class CachedDatabaseHelpersService(IDatabaseHelpersService databaseHelpersService, IAppCache cache, IOptions<GclSettings> gclSettings, ICacheService cacheService, IDatabaseConnection databaseConnection, IBranchesService branchesService)
+public class CachedDatabaseHelpersService(
+    IDatabaseHelpersService databaseHelpersService,
+    IAppCache cache,
+    IOptions<GclSettings> gclSettings,
+    ICacheService cacheService,
+    IDatabaseConnection databaseConnection,
+    IBranchesService branchesService)
     : IDatabaseHelpersService
 {
     private readonly GclSettings gclSettings = gclSettings.Value;
@@ -139,9 +146,40 @@ public class CachedDatabaseHelpersService(IDatabaseHelpersService databaseHelper
     }
 
     /// <inheritdoc />
+    public async Task<Dictionary<string, List<IndexSettingsModel>>> GetIndexesAsync(List<string> tableNames, string databaseName = null)
+    {
+        var cacheName = $"CachedDatabaseHelpersService_GetIndexesAsync_{String.Join("_", tableNames.Order())}_{databaseName}_{branchesService.GetDatabaseNameFromCookie()}";
+        return await cache.GetOrAddAsync(cacheName,
+            async cacheEntry =>
+            {
+                cacheEntry.AbsoluteExpirationRelativeToNow = gclSettings.DefaultQueryCacheDuration;
+                return await databaseHelpersService.GetIndexesAsync(tableNames, databaseName);
+            }, cacheService.CreateMemoryCacheEntryOptions(CacheAreas.Database));
+    }
+
+    /// <inheritdoc />
+    public async Task<List<IndexSettingsModel>> GetIndexesAsync(string tableName, string databaseName = null)
+    {
+        return await GetIndexesAsync(this, tableName, databaseName);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<IndexSettingsModel>> GetIndexesAsync(IDatabaseHelpersService service, string tableName, string databaseName = null)
+    {
+        // Caching is not needed here, because we are already caching the indexes for all tables in the GetIndexesAsync(List<string> tableNames) method.
+        return await databaseHelpersService.GetIndexesAsync(service, tableName, databaseName);
+    }
+
+    /// <inheritdoc />
     public async Task CreateOrUpdateIndexesAsync(List<IndexSettingsModel> indexes, string databaseName = null)
     {
         await databaseHelpersService.CreateOrUpdateIndexesAsync(indexes, databaseName);
+    }
+
+    /// <inheritdoc />
+    public async Task CreateOrUpdateIndexesAsync(IDatabaseHelpersService service, List<IndexSettingsModel> indexes, string databaseName = null)
+    {
+        await databaseHelpersService.CreateOrUpdateIndexesAsync(service, indexes, databaseName);
     }
 
     /// <inheritdoc />

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -138,6 +138,84 @@ public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
     }
 
     /// <inheritdoc />
+    public async Task<T> ExecuteScalarAsync<T>(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
+    {
+        var result = await ExecuteScalarAsync(query, skipCache, cleanUp, useWritingConnectionIfAvailable);
+        return result == null ? default : (T)Convert.ChangeType(result, typeof(T));
+    }
+
+    /// <inheritdoc />
+    public async Task<object> ExecuteScalarAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
+    {
+        return await ExecuteScalarAsync(query, 0, cleanUp, useWritingConnectionIfAvailable);
+    }
+
+    private async Task<object> ExecuteScalarAsync(string query, int retryCount, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
+    {
+        MySqlCommand commandToUse = null;
+        try
+        {
+            if ((useWritingConnectionIfAvailable || QueryHelpers.IsWriteQuery(query)) && !String.IsNullOrWhiteSpace(connectionStringForWriting?.ConnectionString))
+            {
+                await EnsureOpenConnectionForWritingAsync();
+                commandToUse = new MySqlCommand(query, ConnectionForWriting);
+            }
+            else
+            {
+                await EnsureOpenConnectionForReadingAsync();
+                commandToUse = new MySqlCommand(query, ConnectionForReading);
+            }
+
+            await SetupMySqlCommandAsync(commandToUse);
+
+            commandToUse.CommandText = query;
+
+            logger.LogDebug("Query: {query}", query);
+
+            return await commandToUse.ExecuteScalarAsync();
+        }
+        catch (InvalidOperationException invalidOperationException)
+        {
+            if (retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(invalidOperationException))
+            {
+                logger.LogError(invalidOperationException, "Error trying to run this query: {query}", query);
+                throw new GclQueryException("Error trying to run query", query, invalidOperationException);
+            }
+
+            await Task.Delay(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+            return await ExecuteScalarAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
+        }
+        catch (MySqlException mySqlException)
+        {
+            // Never retry single queries if we're in a transaction, because transactions will get rolled back when a deadlock occurs,
+            // so retrying a single query in a transaction is not very useful on most/all cases.
+            // Also, if we've reached the maximum number of retries, don't retry anymore.
+            if (HasActiveTransaction() || retryCount >= gclSettings.MaximumRetryCountForQueries || !MySqlHelpers.IsErrorToRetry(mySqlException))
+            {
+                logger.LogError(mySqlException, "Error trying to run this query: {query}", query);
+                throw new GclQueryException("Error trying to run query", query, mySqlException);
+            }
+
+            // If we're not in a transaction, retry the query if it's a deadlock.
+            await Task.Delay(gclSettings.TimeToWaitBeforeRetryingQueryInMilliseconds);
+            return await ExecuteScalarAsync(query, retryCount + 1, cleanUp, useWritingConnectionIfAvailable);
+        }
+        finally
+        {
+            if (commandToUse != null)
+            {
+                await commandToUse.DisposeAsync();
+            }
+
+            // If we're not using transactions, dispose everything here. Otherwise we will dispose it when the transaction gets committed or roll backed.
+            if (!HasActiveTransaction() && cleanUp)
+            {
+                await CleanUpAsync();
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public Task<DataTable> GetAsync(string query, bool skipCache = false, bool cleanUp = true, bool useWritingConnectionIfAvailable = false)
     {
         return GetAsync(query, 0, cleanUp, useWritingConnectionIfAvailable);
@@ -642,13 +720,19 @@ public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
     /// <inheritdoc />
     public async Task ChangeConnectionStringsAsync(string newConnectionStringForReading, string newConnectionStringForWriting = null, SshSettings newSshSettingsForReading = null, SshSettings newSshSettingsForWriting = null)
     {
-        connectionStringForReading ??= new MySqlConnectionStringBuilder();
-        connectionStringForWriting ??= new MySqlConnectionStringBuilder();
+        connectionStringForReading = String.IsNullOrWhiteSpace(newConnectionStringForReading) ? null : new MySqlConnectionStringBuilder(newConnectionStringForReading);
+        connectionStringForWriting = String.IsNullOrWhiteSpace(newConnectionStringForWriting) ? null : new MySqlConnectionStringBuilder(newConnectionStringForWriting);
 
-        connectionStringForReading.ConnectionString = newConnectionStringForReading;
-        connectionStringForWriting.ConnectionString = String.IsNullOrWhiteSpace(newConnectionStringForWriting) ? newConnectionStringForReading : newConnectionStringForWriting;
-        connectionStringForReading.IgnoreCommandTransaction = true;
-        connectionStringForWriting.IgnoreCommandTransaction = true;
+        if (connectionStringForReading != null)
+        {
+            connectionStringForReading.IgnoreCommandTransaction = true;
+        }
+
+        if (connectionStringForWriting != null)
+        {
+            connectionStringForWriting.IgnoreCommandTransaction = true;
+        }
+
         sshSettingsForReading = newSshSettingsForReading;
         sshSettingsForWriting = newSshSettingsForWriting;
 

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseHelpersService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Extensions;
 using GeeksCoreLibrary.Core.Models;
+using GeeksCoreLibrary.Modules.Databases.Enums;
 using GeeksCoreLibrary.Modules.Databases.Exceptions;
 using GeeksCoreLibrary.Modules.Databases.Extensions;
 using GeeksCoreLibrary.Modules.Databases.Helpers;
@@ -287,9 +288,111 @@ public class MySqlDatabaseHelpersService : IDatabaseHelpersService, IScopedServi
     }
 
     /// <inheritdoc />
+    public async Task<Dictionary<string, List<IndexSettingsModel>>> GetIndexesAsync(List<string> tableNames, string databaseName = null)
+    {
+        if (tableNames == null || tableNames.Count == 0)
+        {
+            throw new ArgumentNullException(nameof(tableNames));
+        }
+
+        await databaseConnection.EnsureOpenConnectionForReadingAsync();
+        if (String.IsNullOrWhiteSpace(databaseName))
+        {
+            databaseName = databaseConnection.ConnectedDatabase;
+        }
+
+        // Add parameters for the database name and all table names.
+        databaseConnection.AddParameter("databaseName", databaseName);
+        for (var index = 0; index < tableNames.Count; index++)
+        {
+            databaseConnection.AddParameter($"tableName{index}", tableNames[index]);
+        }
+
+        // Get the indexes of all specified tables from the database.
+        var query = $"""
+                     SELECT
+                         TABLE_NAME,
+                         INDEX_NAME,
+                         NON_UNIQUE,
+                         SEQ_IN_INDEX,
+                         COLUMN_NAME,
+                         SUB_PART,
+                         INDEX_COMMENT,
+                         IS_VISIBLE
+                     FROM INFORMATION_SCHEMA.STATISTICS
+                     WHERE TABLE_SCHEMA = ?databaseName
+                     AND TABLE_NAME IN ({String.Join(",", tableNames.Select((_, index) => $"?tableName{index}"))})
+                     ORDER BY TABLE_NAME ASC, INDEX_NAME ASC, SEQ_IN_INDEX ASC
+                     """;
+
+        var results = new Dictionary<string, List<IndexSettingsModel>>();
+        var dataTable = await databaseConnection.GetAsync(query);
+        foreach (DataRow dataRow in dataTable.Rows)
+        {
+            var tableName = dataRow.Field<string>("TABLE_NAME");
+            var indexName = dataRow.Field<string>("INDEX_NAME");
+
+            // Add the table to the dictionary, if it doesn't exist yet.
+            if (!results.TryGetValue(tableName, out var indexes))
+            {
+                indexes = [];
+                results.Add(tableName, indexes);
+            }
+
+            // Add the index to the list of indexes for this table, if it doesn't exist yet.
+            var existingIndex = indexes.FirstOrDefault(i => i.Name == indexName);
+            if (existingIndex == null)
+            {
+                existingIndex = new IndexSettingsModel
+                {
+                    TableName = tableName,
+                    Name = indexName,
+                    Type = Convert.ToInt32(dataRow["NON_UNIQUE"]) > 0 ? IndexTypes.Normal : IndexTypes.Unique,
+                    Columns = [],
+                    Comment = dataRow.Field<string>("INDEX_COMMENT"),
+                    IsVisible = String.Equals(dataRow.Field<string>("IS_VISIBLE"), "YES", StringComparison.OrdinalIgnoreCase)
+                };
+
+                indexes.Add(existingIndex);
+            }
+
+            // Add the column to the index.
+            var indexColumn = new IndexColumnModel
+            {
+                Name = dataRow.Field<string>("COLUMN_NAME"),
+                Length = dataRow.Field<long?>("SUB_PART"),
+                Sequence = dataRow.Field<uint>("SEQ_IN_INDEX")
+            };
+
+            existingIndex.Columns.Add(indexColumn);
+        }
+
+        return results;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<IndexSettingsModel>> GetIndexesAsync(string tableName, string databaseName = null)
+    {
+        return await GetIndexesAsync(this, tableName, databaseName);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<IndexSettingsModel>> GetIndexesAsync(IDatabaseHelpersService databaseHelpersService, string tableName, string databaseName = null)
+    {
+        var results = await databaseHelpersService.GetIndexesAsync([tableName], databaseName);
+        return results.SingleOrDefault().Value ?? [];
+    }
+
+    /// <inheritdoc />
     public async Task CreateOrUpdateIndexesAsync(List<IndexSettingsModel> indexes, string databaseName = null)
     {
-        if (indexes == null || !indexes.Any())
+        await CreateOrUpdateIndexesAsync(this, indexes, databaseName);
+    }
+
+    /// <inheritdoc />
+    public async Task CreateOrUpdateIndexesAsync(IDatabaseHelpersService databaseHelpersService, List<IndexSettingsModel> indexes, string databaseName = null)
+    {
+        if (indexes == null || indexes.Count == 0)
         {
             throw new ArgumentNullException(nameof(indexes));
         }
@@ -300,66 +403,48 @@ public class MySqlDatabaseHelpersService : IDatabaseHelpersService, IScopedServi
             databaseName = databaseConnection.ConnectedDatabase;
         }
 
-        var oldIndexes = new Dictionary<string, List<(string Name, List<string> Columns)>>();
+        var tableNames = indexes.Select(index => index.TableName).Distinct().ToList();
+        var existingIndexes = await databaseHelpersService.GetIndexesAsync(tableNames, databaseName);
 
-        foreach (var index in indexes.Where(index => !String.IsNullOrWhiteSpace(index.Name) && index.Fields != null && index.Fields.Any()))
+        foreach (var index in indexes.Where(index => !String.IsNullOrWhiteSpace(index.Name) && index.Columns is {Count: > 0}))
         {
-            // Create a list of the fields. This is to ensure the sub-part (length or expression) is handled correctly and not considered as part of the field's name.
-            var fields = new List<string>(index.Fields.Count);
-            foreach (var field in index.Fields)
-            {
-                var subPartStart = field.LastIndexOf('(');
-                var subPartEnd = field.LastIndexOf(')');
-                // Check if the field contains both opening and closing parentheses and if the closing parenthesis comes after the opening parenthesis.
-                if (subPartStart == -1 || subPartEnd == -1 || subPartStart > subPartEnd)
-                {
-                    // Either the '(' or ')' is missing, or '(' comes after ')'.
-                    fields.Add($"`{field.ToMySqlSafeValue(false)}`");
-                    continue;
-                }
-
-                fields.Add($"`{field[..subPartStart].ToMySqlSafeValue(false)}`{field[subPartStart..].ToMySqlSafeValue(false)}");
-            }
-
-            var commentPart = String.IsNullOrWhiteSpace(index.Comment) ? String.Empty : $" COMMENT '{index.Comment.ToMySqlSafeValue(false)}'";
-            var createIndexQuery = $"ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{index.TableName.ToMySqlSafeValue(false)}` ADD {index.Type.ToMySqlString()} INDEX `{index.Name.ToMySqlSafeValue(false)}` ({String.Join(",", fields)}){commentPart}";
-
             databaseConnection.AddParameter("indexName", index.Name);
 
-            if (!oldIndexes.ContainsKey(index.TableName))
+            var recreateIndex = true;
+            IndexSettingsModel existingIndex = null;
+            if (existingIndexes.TryGetValue(index.TableName, out var indexesForTable))
             {
-                oldIndexes.Add(index.TableName, []);
-                var dataTable = await databaseConnection.GetAsync($"SHOW INDEX FROM `{databaseName.ToMySqlSafeValue(false)}`.`{index.TableName.ToMySqlSafeValue(false)}`", true);
-                foreach (var dataRow in dataTable.Rows.Cast<DataRow>().OrderBy(row => row.Field<string>("key_name")).ThenBy(row => Convert.ToInt32(row["seq_in_index"])))
-                {
-                    var indexName = dataRow.Field<string>("key_name");
-                    var oldIndex = oldIndexes[index.TableName].FirstOrDefault(i => i.Name == indexName);
-                    if (oldIndex.Name == null)
-                    {
-                        oldIndex = (indexName, []);
-                        oldIndexes[index.TableName].Add(oldIndex);
-                    }
+                // Check if an index with the same name or the same columns already exists.
+                existingIndex = indexesForTable.FirstOrDefault(i => String.Equals(i.Name, index.Name, StringComparison.OrdinalIgnoreCase) || String.Equals(String.Join(",", i.Columns.Select(c => c.Name).Order()), String.Join(",", index.Columns.Select(c => c.Name).Order()), StringComparison.OrdinalIgnoreCase));
 
-                    var columnName = dataRow.Field<string>("column_name");
-                    oldIndex.Columns.Add(columnName);
-                }
+                // Check if the index is still the same, or if we have to recreate it.
+                recreateIndex = existingIndex?.Name == null || existingIndex.Type != index.Type || !String.Equals(String.Join(",", existingIndex.Columns.OrderBy(c => c.Sequence).Select(c => $"{c.Name}({c.Length ?? 0})")), String.Join(",", index.Columns.OrderBy(c => c.Sequence).Select(c => $"{c.Name}({c.Length ?? 0})")), StringComparison.OrdinalIgnoreCase);
             }
 
-            var existingIndex = oldIndexes[index.TableName].FirstOrDefault(i => String.Equals(i.Name, index.Name, StringComparison.OrdinalIgnoreCase) || String.Equals(String.Join(",", i.Columns.OrderBy(c => c)), String.Join(",", index.Fields.OrderBy(f => f)), StringComparison.OrdinalIgnoreCase));
-            var recreateIndex = existingIndex.Name == null || String.Join(",", existingIndex.Columns) != String.Join(",", index.Fields);
             if (!recreateIndex)
             {
                 // Index has not been changed, so do nothing.
                 continue;
             }
 
-            if (existingIndex.Name != null)
+            if (existingIndex?.Name != null)
             {
-                // If an index with this name already exists, but the new one if different, drop the old index first.
-                await databaseConnection.ExecuteAsync($"ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{index.TableName.ToMySqlSafeValue(false)}` DROP INDEX `{existingIndex.Name.ToMySqlSafeValue(false)}`");
+                // If an index with this name already exists, but the new one is different, drop the old index first.
+                var dropIndexQuery = $"""
+                                      ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{index.TableName.ToMySqlSafeValue(false)}`
+                                      DROP INDEX `{existingIndex.Name.ToMySqlSafeValue(false)}`
+                                      """;
+                await databaseConnection.ExecuteAsync(dropIndexQuery);
             }
 
             // Create the new index.
+            var createIndexQuery = $"""
+                                    ALTER TABLE `{databaseName.ToMySqlSafeValue(false)}`.`{index.TableName.ToMySqlSafeValue(false)}`
+                                    ADD {index.Type.ToMySqlString()} INDEX `{index.Name.ToMySqlSafeValue(false)}`
+                                    ({String.Join(",", index.Columns.Select(c => $"`{c.Name.ToMySqlSafeValue(false)}`{(!c.Length.HasValue ? String.Empty : $"({c.Length.Value})")}"))})
+                                    {(index.IsVisible ?  " VISIBLE" : "INVISIBLE")}
+                                    {(String.IsNullOrWhiteSpace(index.Comment) ? String.Empty : $" COMMENT '{index.Comment.ToMySqlSafeValue(false)}'")}
+                                    """;
             await databaseConnection.ExecuteAsync(createIndexQuery);
         }
     }
@@ -532,7 +617,7 @@ public class MySqlDatabaseHelpersService : IDatabaseHelpersService, IScopedServi
 
                     // Archive tables.
                     await CreateOrUpdateTableAsync($"{tablePrefix}{tableName}{WiserTableNames.ArchiveSuffix}", tableDefinition.Columns, tableDefinition.CharacterSet, tableDefinition.Collation, databaseName);
-                    if (tableDefinition.Indexes != null && tableDefinition.Indexes.Any())
+                    if (tableDefinition.Indexes != null && tableDefinition.Indexes.Count != 0)
                     {
                         tableDefinition.Indexes.ForEach(index => index.TableName = $"{tablePrefix}{index.TableName}{WiserTableNames.ArchiveSuffix}");
                         await CreateOrUpdateIndexesAsync(tableDefinition.Indexes, databaseName);
@@ -816,7 +901,7 @@ public class MySqlDatabaseHelpersService : IDatabaseHelpersService, IScopedServi
         {
             return;
         }
-        
+
         await databaseConnection.ExecuteAsync($"OPTIMIZE TABLE {String.Join(',', tableNames.Select(tableName => $"`{tableName.ToMySqlSafeValue(false)}`"))}");
     }
 }


### PR DESCRIPTION
# Describe your changes

Added some new functionality for working with databases and improved some existing functionality:

- Added new function `ExecuteScalarAsync` to `IDatabaseConnection`, this function is very useful when doing queries that return only a single row with a single column, then you don't have to store that in a `DataTable` first. This is a minor breaking change, because if other projects have their own implementation for `IDatabaseConnection`, they will have to also add an implementation for this new method. As far as I know, only Wiser does this and I already have a commit ready to implement it there.
- Added new functions to `IDatabaseHelpersService` for getting a list of indexes of one or more database tables.
- Added new functions to `IDatabaseHelpersService` for getting a list of columns of one or more database tables.
- Improved the way we work with indexes and the functions from `IDatabaseHelpersService` that create/update indexes. They now work better with lengths (sub parts) and it's now possible to change the type of index.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I use this method in the WTS branch functionality, for more easily getting single results from a database, so that I don't have to create a `DataTable`, then get the first row and first column of that row. This works perfectly in the WTS where I used/tested this.

I also created some test cases in a local test project to test these changes on a test table in a test database.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser-task-scheduler/pull/322

# Link to Asana ticket

There is no specific ticket for this, but I have used this functionality in the following tickets:
- [Transactions committed too early](https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209895231644200)
- [Fallback for missing link configuration](https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209921173095221)
- [Merging of `wiser_itemlinkdetail` did not use `target_id`](https://app.asana.com/1/5038780173035/project/1205090868730163/task/1210223116323868)
- [Improvements for merging configuration tables](https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209921173095223)
