### PR TITLE
Fixes for retrieving Wiser files

### DIFF
--- a/GeeksCoreLibrary.Tests/Modules/ItemFiles/Services/ItemFilesServiceTests.cs
+++ b/GeeksCoreLibrary.Tests/Modules/ItemFiles/Services/ItemFilesServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using GeeksCoreLibrary.Core.Interfaces;

--- a/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
+++ b/GeeksCoreLibrary/Modules/ItemFiles/Services/ItemFilesService.cs
@@ -247,13 +247,13 @@ public class ItemFilesService(
     /// <inheritdoc />
     public async Task<FileResultModel> GetWiserItemFileAsync(ulong itemId, string propertyName, string fileName, int fileNumber, string encryptedItemId = null, string entityType = null)
     {
-        return await GetParsedFileAsync(FileLookupTypes.ItemId, String.IsNullOrWhiteSpace(encryptedItemId) ? itemId : encryptedItemId, fileName: fileName, entityType: entityType);
+        return await GetParsedFileAsync(FileLookupTypes.ItemId, String.IsNullOrWhiteSpace(encryptedItemId) ? itemId : encryptedItemId, fileName: fileName, propertyName: propertyName, entityType: entityType);
     }
 
     /// <inheritdoc />
     public async Task<FileResultModel> GetWiserItemLinkFileAsync(ulong itemLinkId, string propertyName, string fileName, int fileNumber, string encryptedItemLinkId = null, int linkType = 0)
     {
-        return await GetParsedFileAsync(FileLookupTypes.ItemLinkId, String.IsNullOrWhiteSpace(encryptedItemLinkId) ? itemLinkId : encryptedItemLinkId, fileName: fileName, linkType: linkType);
+        return await GetParsedFileAsync(FileLookupTypes.ItemLinkId, String.IsNullOrWhiteSpace(encryptedItemLinkId) ? itemLinkId : encryptedItemLinkId, fileName: fileName, propertyName: propertyName, linkType: linkType);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
# Describe your changes

Two methods for retrieving files from `wiser_itemfile` didn't pass the `propertyName` parameter to the `GetParsedFileAsync` method causing those methods to always throw an exception.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Used a debug build and unit tests to confirm that the methods no longer throw an exception due to the `propertyName` parameter being `null`.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

None.

# Link to Asana ticket

[Asana ticket](https://app.asana.com/1/5038780173035/project/29553867016121/task/1209959062320600)