### PR TITLE
Fixed problem that accounts created via order process were not usable

### DIFF
--- a/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/OrderProcess.cs
@@ -1137,7 +1137,7 @@ public class OrderProcess : CmsComponent<OrderProcessCmsSettingsModel, OrderProc
                                     if (itemsOfEntityType.Count != 0)
                                     {
                                         // If we already have item(s) of the given entity type, save the value there.
-                                        itemsOfEntityType.ForEach(item => item.Item.SetDetail(saveLocation.PropertyName, valueForDatabase));
+                                        itemsOfEntityType.ForEach(item => item.Item.SetDetail(saveLocation.PropertyName, valueForDatabase, saveAsIs: true));
                                     }
                                     else
                                     {

--- a/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
+++ b/GeeksCoreLibrary/Components/ShoppingBasket/Services/ShoppingBasketsService.cs
@@ -156,6 +156,11 @@ public class ShoppingBasketsService(
         var result = new List<(WiserItemModel Main, List<WiserItemModel> Lines)>();
 
         var cookieValue = HttpContextHelpers.ReadCookie(httpContextAccessor?.HttpContext, cookieName);
+        if (String.IsNullOrWhiteSpace(cookieValue))
+        {
+            return result;
+        }
+
         var basketIds = cookieValue.DecryptWithAesWithSalt(gclSettings.ShoppingBasketEncryptionKey).Split(',', StringSplitOptions.RemoveEmptyEntries).Select(id => Convert.ToUInt64(id)).ToArray();
 
         foreach (var basketId in basketIds)

--- a/GeeksCoreLibrary/Core/Models/WiserItemDetailModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemDetailModel.cs
@@ -182,6 +182,12 @@ public class WiserItemDetailModel
         }
     }
 
+    /// <summary>
+    /// Gets or sets whether this detail should be saved as is, without any modifications.
+    /// This is useful for when you already hashed a password for example, then the GCL won't hash it again when saving to database.
+    /// </summary>
+    public bool SaveAsIs { get; set; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/GeeksCoreLibrary/Core/Models/WiserItemModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemModel.cs
@@ -492,7 +492,8 @@ public class WiserItemModel
     /// <param name="languageCode">Optional: The language code of the detail. Default is null.</param>
     /// <param name="markChangedAsFalse">Optional: Whether or not to mark the Changed property to false, so that it won't be saved if you save this item without changing this value after calling this function.</param>
     /// <param name="format">Optional: Formatting for converting certain types (such as numbers and dates) to string. Default is null.</param>
-    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, bool markChangedAsFalse = false, string format = null)
+    /// <param name="saveAsIs">Optional: Set to <c>true</c> to skip any conversion or hashing that the GCL might do when saving this value to the database. Such as for passwords, when you already hashed them yourself.</param>
+    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false)
     {
         // TODO: Add a check for read only, so that we can't use this function to update read only values?
         var detail = Details.FirstOrDefault(d => String.Equals(d.Key, key, StringComparison.OrdinalIgnoreCase) && String.Equals(d.GroupName ?? "", groupName ?? "", StringComparison.OrdinalIgnoreCase) && String.Equals(d.LanguageCode ?? "", languageCode ?? "", StringComparison.OrdinalIgnoreCase));
@@ -556,6 +557,8 @@ public class WiserItemModel
         {
             detail.Changed = false;
         }
+
+        detail.SaveAsIs = saveAsIs;
     }
 
     /// <summary>

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -4850,7 +4850,7 @@ public class WiserItemsService(
                 useLongValueColumn = wiserItemDetail.Value?.ToString()?.Length > 1000;
 
                 // Check if we need to adjust the value that gets saved in the database, such as encrypting or hashing it.
-                if ((valueChanged || alwaysSaveValues) && options.Count > 0)
+                if ((valueChanged || alwaysSaveValues) && !wiserItemDetail.SaveAsIs && options.Count > 0)
                 {
                     switch (options[Constants.FieldTypeKey].ToString().ToLowerInvariant())
                     {


### PR DESCRIPTION
# Describe your changes

Fixed problem that when creating an account via the order process, the password was hashed twice, which in turn caused users to not be able to log in after.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I set up an order process on Wiser Playground, to test this.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1203956850515015
