### PR TITLE
Fixed issue with data selectors having clause generation

### DIFF
--- a/GeeksCoreLibrary/Modules/DataSelector/Services/DataSelectorsService.cs
+++ b/GeeksCoreLibrary/Modules/DataSelector/Services/DataSelectorsService.cs
@@ -751,7 +751,8 @@ public class DataSelectorsService(IOptions<GclSettings> gclSettings, IDatabaseCo
                         queryPart.Append(" OR ");
                     }
 
-                    queryPart.Append(await CreateHavingRowQueryPart(row, row.Key.FieldName));
+                    var selectAlias = GetFullSelectAlias(itemsRequest, row.Key.FieldName);
+                    queryPart.Append(await CreateHavingRowQueryPart(row, selectAlias));
                 }
 
                 // Add group to having part.
@@ -1759,7 +1760,7 @@ public class DataSelectorsService(IOptions<GclSettings> gclSettings, IDatabaseCo
 
     private async Task<string> CreateHavingRowQueryPart(HavingRow havingRow, string selectAlias)
     {
-        var formattedField = GetFormattedField(havingRow.Key, $"`{selectAlias}`");
+        var formattedField = GetFormattedField(havingRow.Key, selectAlias);
 
         if (havingRow.Value is JArray array)
         {


### PR DESCRIPTION
# Describe your changes

When adding a `having` clause for a linked item, the query would cause an error because the data selector added an alias to the `having` clause that doesn't exist in the query.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I first reproduced this problem in a customer's environment, then fixed the problem and tested in that same environment if it works.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1206129973083296
