### PR TITLE
Fixed problem with permissions check on queries

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -2262,9 +2262,9 @@ public class WiserItemsService(
         // First check permissions based on module ID.
         var permissionsQuery = $"""
                                 SELECT permission.permissions
-                                                                    FROM {WiserTableNames.WiserUserRoles} user_role
-                                                                    LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.query_id = ?queryId
-                                                                    WHERE user_role.user_id = ?userId
+                                FROM {WiserTableNames.WiserUserRoles} user_role
+                                LEFT JOIN {WiserTableNames.WiserPermission} permission ON permission.role_id = user_role.role_id AND permission.query_id = ?queryId
+                                WHERE user_role.user_id = ?userId
                                 """;
 
         databaseConnection.AddParameter("userId", userId);
@@ -2280,13 +2280,7 @@ public class WiserItemsService(
 
         foreach (DataRow dataRow in dataTable.Rows)
         {
-            if (dataRow.IsNull("permissions"))
-            {
-                userItemPermissions = AccessRights.Nothing;
-                break;
-            }
-
-            var currentPermissions = (AccessRights) dataRow.Field<int>("permissions");
+            var currentPermissions = dataRow.IsNull("permissions") ? AccessRights.Nothing : (AccessRights) dataRow.Field<int>("permissions");
             if ((currentPermissions & AccessRights.Read) == AccessRights.Read)
             {
                 userItemPermissions |= AccessRights.Read;


### PR DESCRIPTION
# Describe your changes

Fixed problem that if a user has multiple roles and not all roles have permissions set for a query, the user would not be allowed to execute the query, even if another role does give them permissions.

Because of this bug, there was a difference between having no permissions and having the permissions set to `0`, which should be the same.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I created 2 roles in Wiser demo and a user. Then I gave different permissions to the same query to both roles and gave that user both roles. I was able to reproduce the problem this way and verify that it was fixed.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1204870143368512
