### PR TITLE
Improvements for the Repeater component.

### DIFF
--- a/GeeksCoreLibrary/Components/Repeater/Models/Constants.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/Constants.cs
@@ -1,0 +1,18 @@
+﻿namespace GeeksCoreLibrary.Components.Repeater.Models;
+
+public class Constants
+{
+    // Legacy placeholders for Repeater templates.
+    public const string LegacyRowNumberPlaceholder = "{volgnr}";
+    public const string LegacyResultCountPlaceholder = "{ResultCount}";
+    public const string LegacyUniqueResultCountPlaceholder = "{UniqueResultCount}";
+
+    // Placeholders used in Repeater templates.
+    public const string SubLayerPlaceholder = "{SubLayer}";
+    public const string RowNumberPlaceholder = "{RowNumber}";
+    public const string RowIndexPlaceholder = "{RowIndex}";
+    public const string RowCountPlaceholder = "{RowCount}";
+    public const string DistinctRowCountPlaceholder = "{DistinctRowCount}";
+    public const string FiltersPlaceholder = "{Filters}";
+    public const string PageLimitPlaceholder = "{page_limit}";
+}

--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterRepeaterSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterRepeaterSettingsModel.cs
@@ -2,8 +2,8 @@
 
 namespace GeeksCoreLibrary.Components.Repeater.Models;
 
-class RepeaterRepeaterSettingsModel
+internal class RepeaterRepeaterSettingsModel
 {
     [DefaultValue(true)]
-    internal string bannerBannerUsesProductBlockSpace { get; set; }
+    internal string BannerUsesProductBlockSpace { get; set; }
 }

--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterTemplateModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterTemplateModel.cs
@@ -23,7 +23,7 @@ public class RepeaterTemplateModel
     [CmsProperty(
         PrettyName = "Item template",
         Description = "This template will be rendered for every item/row of this layer.",
-        DeveloperRemarks = "",
+        DeveloperRemarks = "You can use the {subLayer} placeholder to render the next layer of this item on that location. If you don't use this placeholder, the next layer will be rendered right after the ItemTemplate.",
         DisplayOrder = 20,
         ComponentMode = "NonLegacy",
         TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor


### PR DESCRIPTION
# Describe your changes

Added a new placeholder / replacement `{SubLayer}`. This can be used in the `ItemTemplate` of any layer in the Repeater settings. With this you can render the next layer in a specific location. Before, the Repeater would always render the next layer immediately after the `ItemTemplate`, which meant you couldn't load the next layer inside another HTML-element. With this change you can.

Besides that, I also fixed a bug that caused the `NoDataTemplate` to not always be rendered.

Lastly, I moved some hard-coded string to constants and fixed a typo in a property name.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested this in a new project that I'm working on, where I need this functionality to not have to set up the Repeater in a very illogical and confusing way.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

There is no specific Asana ticket for this functionality, but I used/needed it for this ticket: https://app.asana.com/1/5038780173035/project/1209629106123881/task/1209908919484105
