### PR TITLE
Fixed problem that saving item link details no longer worked in Wiser

### DIFF
--- a/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
@@ -120,7 +120,7 @@ public abstract class WiserItemBaseModel
     /// <param name="saveAsIs">Optional: Set to <c>true</c> to skip any conversion or hashing that the GCL might do when saving this value to the database. Such as for passwords, when you already hashed them yourself.</param>
     public void SetDetail(WiserItemDetailModel detail, bool append = false, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false)
     {
-        SetDetail(detail.Key, detail.Value, append, detail.ReadOnly, detail.GroupName, detail.LanguageCode, markChangedAsFalse, format, saveAsIs);
+        SetDetail(detail.Key, detail.Value, append, detail.ReadOnly, detail.GroupName, detail.LanguageCode, markChangedAsFalse, format, saveAsIs, detail.IsLinkProperty, detail.LinkType, detail.ItemLinkId);
     }
 
     /// <summary>
@@ -133,13 +133,21 @@ public abstract class WiserItemBaseModel
     /// <param name="enableReadOnly">Optional: Make the new value read only. Default is false.</param>
     /// <param name="groupName">Optional: The group name of the detail. Default is null.</param>
     /// <param name="languageCode">Optional: The language code of the detail. Default is null.</param>
-    /// <param name="markChangedAsFalse">Optional: Whether or not to mark the Changed property to false, so that it won't be saved if you save this item without changing this value after calling this function.</param>
+    /// <param name="markChangedAsFalse">Optional: Whether to mark the Changed property to false, so that it won't be saved if you save this item without changing this value after calling this function.</param>
     /// <param name="format">Optional: Formatting for converting certain types (such as numbers and dates) to string. Default is null.</param>
     /// <param name="saveAsIs">Optional: Set to <c>true</c> to skip any conversion or hashing that the GCL might do when saving this value to the database. Such as for passwords, when you already hashed them yourself.</param>
-    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false)
+    /// <param name="isLinkProperty">Optional: Whether the detail is for wiser_itemlinkdetail, instead of wiser_itemdetail. If this is <c>true</c>, then <see cref="linkType"/> and  <see cref="itemLinkId"/> must also be specified. Default is <c>false</c>.</param>
+    /// <param name="linkType">The link type number, must be specified if <see cref="isLinkProperty"/> is set to <c>true</c>.</param>
+    /// <param name="itemLinkId">The ID of the link between two items, must be specified if <see cref="isLinkProperty"/> is set to <c>true</c>.</param>
+    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false, bool isLinkProperty = false, int linkType = 0, ulong itemLinkId = 0)
     {
         // TODO: Add a check for read only, so that we can't use this function to update read only values?
-        var detail = details.FirstOrDefault(d => String.Equals(d.Key, key, StringComparison.OrdinalIgnoreCase) && String.Equals(d.GroupName ?? "", groupName ?? "", StringComparison.OrdinalIgnoreCase) && String.Equals(d.LanguageCode ?? "", languageCode ?? "", StringComparison.OrdinalIgnoreCase));
+        var detail = details.FirstOrDefault(d => String.Equals(d.Key, key, StringComparison.OrdinalIgnoreCase) &&
+                                                 String.Equals(d.GroupName ?? "", groupName ?? "", StringComparison.OrdinalIgnoreCase) &&
+                                                 String.Equals(d.LanguageCode ?? "", languageCode ?? "", StringComparison.OrdinalIgnoreCase) &&
+                                                 d.IsLinkProperty == isLinkProperty &&
+                                                 d.LinkType == linkType &&
+                                                 d.ItemLinkId == itemLinkId);
         if (detail == null)
         {
             // Add new item if key doesn't exist
@@ -147,7 +155,10 @@ public abstract class WiserItemBaseModel
             {
                 Key = key,
                 GroupName = groupName,
-                LanguageCode = languageCode
+                LanguageCode = languageCode,
+                IsLinkProperty = isLinkProperty,
+                LinkType = linkType,
+                ItemLinkId = itemLinkId
             };
 
             details.Add(detail);


### PR DESCRIPTION
# Describe your changes

When changing values of fields in Wiser, that are stored in `wiser_itemlinkdetail` instead of `wiser_itemdetail`, any changes you made were ignored. This PR fixes that.

This problem was caused by https://github.com/happy-geeks/geeks-core-library/pull/877, because this change made it so that the `Details` property of `WiserItemModel` can no longer be updated directly. Instead, the `SetDetail` method needs to be used. This also goes for deserializing JSON to `WiserItemModel`, that also calls `SetDetail` now. But the `SetDetail` method always ignored the properties `IsLinkProperty`, `ItemLinkId` and `LinkType`.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested this in Wiser, in the tenant where I also first noticed this problem.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1210694583947499
