### PR TITLE
Added debug function for queries

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Interfaces/IDatabaseConnection.cs
@@ -194,4 +194,15 @@ public interface IDatabaseConnection : IAsyncDisposable, IDisposable
     /// <param name="useWritingConnectionIfAvailable">Optional: Use the writing connection to get information, if there is one available. If we detect that your query contains a database modification, then we will always use the write connection string, no matter what you enter here.</param>
     /// <param name="useInsertIgnore">Optional: Whether to use INSERT IGNORE instead of INSERT, to ignore errors such as duplicate keys.</param>
     Task<int> BulkInsertAsync(DataTable dataTable, string tableName, bool useWritingConnectionIfAvailable = true, bool useInsertIgnore = false);
+
+#if DEBUG
+    /// <summary>
+    /// Replace all variables in the query with their values, for debugging purposes.
+    /// This will replace all parameters in the query starting with the '?' character with their values, so you can see the actual query that is executed and debug it.
+    /// <br /><b><i>Never call this method in production code, as it will expose the query to SQL injection attacks.</i></b>
+    /// </summary>
+    /// <param name="query">The query that you want to debug.</param>
+    /// <returns>The query with all known values clearly visible.</returns>
+    string ReplaceVariablesInQueryForDebugging(string query);
+#endif
 }

--- a/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/CachedDatabaseConnection.cs
@@ -281,4 +281,12 @@ public class CachedDatabaseConnection(
     {
         return await databaseConnection.BulkInsertAsync(dataTable, tableName, useWritingConnectionIfAvailable, useInsertIgnore);
     }
+
+#if DEBUG
+    /// <inheritdoc />
+    public string ReplaceVariablesInQueryForDebugging(string query)
+    {
+        return databaseConnection.ReplaceVariablesInQueryForDebugging(query);
+    }
+#endif
 }

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -856,7 +856,7 @@ public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
                 long longValue => query.Replace($"?{key}", longValue.ToString()),
                 ulong ulongValue => query.Replace($"?{key}", ulongValue.ToString()),
                 decimal decimalValue => query.Replace($"?{key}", decimalValue.ToString(CultureInfo.InvariantCulture)),
-                _ => query.Replace($"?{key}", value?.ToString().ToMySqlSafeValue(true))
+                _ => query.Replace($"?{key}", value.ToString().ToMySqlSafeValue(true))
             };
         }
 

--- a/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Services/MySqlDatabaseConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -834,6 +835,34 @@ public class MySqlDatabaseConnection : IDatabaseConnection, IScopedService
 
         return await ExecuteAsync(query.ToString(), useWritingConnectionIfAvailable);
     }
+
+#if DEBUG
+    /// <inheritdoc />
+    public string ReplaceVariablesInQueryForDebugging(string query)
+    {
+        if (String.IsNullOrWhiteSpace(query))
+        {
+            return query;
+        }
+
+        foreach (var (key, value) in parameters)
+        {
+            query = value switch
+            {
+                null => query.Replace($"?{key}", "NULL"),
+                DateTime dateTimeValue => query.Replace($"?{key}", $"'{dateTimeValue:yyyy-MM-dd HH:mm:ss}'"),
+                string stringValue => query.Replace($"?{key}", $"'{stringValue}'"),
+                int intValue => query.Replace($"?{key}", intValue.ToString()),
+                long longValue => query.Replace($"?{key}", longValue.ToString()),
+                ulong ulongValue => query.Replace($"?{key}", ulongValue.ToString()),
+                decimal decimalValue => query.Replace($"?{key}", decimalValue.ToString(CultureInfo.InvariantCulture)),
+                _ => query.Replace($"?{key}", value?.ToString().ToMySqlSafeValue(true))
+            };
+        }
+
+        return query;
+    }
+#endif
 
     /// <summary>
     /// Checks whether the log table (for logging the opening and closing of database connections) exists.


### PR DESCRIPTION
# Describe your changes

Added the function `ReplaceVariablesInQueryForDebugging` to `IDatabaseConnection` for a quicker and easier way to debug queries. You can just call this method in the debugger to get a query that you can directly execute in other software, such as Navicat. Then you don't need to replace all the variables in the query manually anymore, before you can execute it.

Obviously, this function should never be called in production code. So to prevent that, I added an `#if DEBUG` statement around it.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I was kinda tired of always having to replace a whole bunch of variables in queries to be able to test the query in Navicat. Then I got the idea to make a function for this, so I did that and immediately used/tested it. It worked fine for the queries that I needed it for. It might cause invalid queries when other types are used as variables, but people can easily added cases for that to the switch, when they run into that.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

N/A
