### PR TITLE
query used for redirect

### DIFF
--- a/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/WiserTableDefinitions.cs
@@ -323,6 +323,7 @@ public class WiserTableDefinitions
                 new ColumnSettingsModel("grouping_key", MySqlDbType.VarChar, 50),
                 new ColumnSettingsModel("grouping_key_column_name", MySqlDbType.VarChar, 50),
                 new ColumnSettingsModel("grouping_value_column_name", MySqlDbType.VarChar, 50),
+                new ColumnSettingsModel("query_used_for_redirect", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),
                 new ColumnSettingsModel("removed", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),
                 new ColumnSettingsModel("is_scss_include_template", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),
                 new ColumnSettingsModel("use_in_wiser_html_editors", MySqlDbType.Int16, 1, notNull: true, defaultValue: "0"),

--- a/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Extensions/DbDataReaderExtensions.cs
@@ -190,6 +190,7 @@ public static class DbDataReaderExtensions
                 GroupingValueColumnName = reader.GetStringHandleNull("grouping_value_column_name"),
                 GroupingKeyColumnName = reader.GetStringHandleNull("grouping_key_column_name")
             };
+            queryTemplate.UsedForRedirect = reader.GetBoolean("query_used_for_redirect");
 
             return queryTemplate;
         }

--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
@@ -335,8 +335,7 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
 
         var dataTable = await databaseConnection.GetAsync(query);
         if (dataTable.Rows.Count != 1)
-            // TODO: log error
-            return null;
+            throw new Exception($"Redirect query (id {template.Id}) returned {dataTable.Rows.Count} results, expected one!");
 
         var dataRow = dataTable.Rows[0];
         string result = null;

--- a/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Middlewares/RewriteUrlToTemplateMiddleware.cs
@@ -10,6 +10,7 @@ using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Enums;
 using GeeksCoreLibrary.Modules.Templates.Interfaces;
 using GeeksCoreLibrary.Modules.Templates.Models;
+using GeeksCoreLibrary.Modules.GclReplacements.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -26,7 +27,7 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
     /// Invoke the middleware.
     /// Services are added here instead of the constructor, because the constructor of a middleware can only contain Singleton services.
     /// </summary>
-    public async Task Invoke(HttpContext context, IObjectsService objectsService, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
+    public async Task Invoke(HttpContext context, IObjectsService objectsService, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IActionDescriptorCollectionProvider actionDescriptorCollectionProvider, IReplacementsMediator replacementsMediator)
     {
         logger.LogDebug("Invoked RewriteUrlToTemplateMiddleware");
 
@@ -90,7 +91,7 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
             context.Items.Add(Constants.OriginalPathAndQueryStringKey, $"{path}{queryString.Value}");
         }
 
-        await HandleRewritesAsync(context, path, queryString, templatesService, objectsService, databaseConnection);
+        await HandleRewritesAsync(context, path, queryString, templatesService, objectsService, databaseConnection, replacementsMediator);
 
         await next.Invoke(context);
     }
@@ -105,7 +106,7 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
     /// <param name="templatesService">The templates service.</param>
     /// <param name="objectsService">The objects service.</param>
     /// <param name="databaseConnection">The database connection.</param>
-    private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, ITemplatesService templatesService, IObjectsService objectsService, IDatabaseConnection databaseConnection)
+    private async Task HandleRewritesAsync(HttpContext context, string path, QueryString queryStringFromUrl, ITemplatesService templatesService, IObjectsService objectsService, IDatabaseConnection databaseConnection, IReplacementsMediator replacementsMediator)
     {
         logger.LogDebug($"Start HandleRewrites, path: {path}");
 
@@ -127,15 +128,30 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
                 queryString = queryString.Add(matchGroup.Name, matchGroup.Value);
             }
 
-            // Extra query string in the template.
-            queryString = CombineQueryString(queryString, $"?templateId={template.Id}");
-            queryString = CombineQueryString(queryString, queryStringFromUrl.Value);
-
             // Redirect to the correct controller.
             switch (template.Type)
             {
                 case TemplateTypes.Html:
                     context.Request.Path = "/template.gcl";
+                    break;
+                case TemplateTypes.Query when template is QueryTemplate{ UsedForRedirect: true }:
+                    var redirectTo = await RunRedirectQuery(template, queryString, databaseConnection, templatesService, replacementsMediator);
+                    if (redirectTo is null)
+                    {
+                        context.Response.StatusCode = StatusCodes.Status404NotFound;
+                        return;
+                    }
+
+                    if (Int32.TryParse(redirectTo, out Int32 templateId))
+                    {
+                        template.Id = templateId;
+                        context.Request.Path = "/template.gcl";
+                    }
+                    else
+                    {
+                        context.Request.Path = redirectTo;
+                        return;
+                    }
                     break;
                 case TemplateTypes.Query:
                     context.Request.Path = "/json.gcl";
@@ -146,6 +162,10 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
                 default:
                     throw new ArgumentOutOfRangeException(nameof(template.Type), template.Type.ToString(), null);
             }
+
+            // Extra query string in the template.
+            queryString = CombineQueryString(queryString, $"?templateId={template.Id}");
+            queryString = CombineQueryString(queryString, queryStringFromUrl.Value);
 
             context.Request.QueryString = queryString;
 
@@ -268,8 +288,32 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
                 continue;
             }
 
+            var template = await templatesService.GetTemplateAsync(number);
+            if (template is QueryTemplate { UsedForRedirect: true })
+            {
+                var redirectTo = await RunRedirectQuery(template, queryString, databaseConnection, templatesService, replacementsMediator);
+                if (redirectTo is null)
+                {
+                    context.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return;
+                }
+
+                if (Int32.TryParse(redirectTo, out Int32 templateId))
+                {
+                    queryString = CombineQueryString(queryString, $"?templateid={templateId}");
+                }
+                else
+                {
+                    context.Request.Path = redirectTo;
+                    return;
+                }
+            }
+            else
+            {
+                queryString = CombineQueryString(queryString, $"?templateid={urlMatchLastPart.Replace("?", "&")}");
+            }
+
             // Extra query string in the template.
-            queryString = CombineQueryString(queryString, $"?templateid={urlMatchLastPart.Replace("?", "&")}");
             queryString = CombineQueryString(queryString, queryStringFromUrl.Value);
 
             // It is a template.
@@ -279,6 +323,44 @@ public class RewriteUrlToTemplateMiddleware(RequestDelegate next, ILogger<Rewrit
             // We found a template that matches the URL, so we can exit the function here.
             return;
         }
+    }
+
+    private async Task<string> RunRedirectQuery(Template template, QueryString queryString, IDatabaseConnection databaseConnection, ITemplatesService templatesService, IReplacementsMediator replacementsMediator)
+    {
+        var queryStringCollection = System.Web.HttpUtility.ParseQueryString(queryString.ToString());
+        var query = template.Content;
+
+        query = replacementsMediator.DoReplacements(query, queryStringCollection, forQuery: true);
+        query = await templatesService.DoReplacesAsync(query, forQuery: true, templateType: TemplateTypes.Query);
+
+        var dataTable = await databaseConnection.GetAsync(query);
+        if (dataTable.Rows.Count != 1)
+            // TODO: log error
+            return null;
+
+        var dataRow = dataTable.Rows[0];
+        string result = null;
+        foreach (DataColumn column in dataTable.Columns)
+        {
+            switch (column.ColumnName.ToLower())
+            {
+                case "templateid":
+                    var id = dataRow.Field<long>(column);
+                    if (id > 0)
+                        result = id.ToString();
+                    break;
+                case "redirecturl":
+                    var url = dataRow.Field<string>(column);
+                    if (!String.IsNullOrWhiteSpace(url))
+                        result = url;
+                    break;
+                default:
+                    queryString = queryString.Add(column.ColumnName, dataRow.Field<string>(column));
+                    break;
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/GeeksCoreLibrary/Modules/Templates/Models/QueryTemplate.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/QueryTemplate.cs
@@ -3,4 +3,9 @@
 public class QueryTemplate : Template
 {
     public QueryGroupingSettings GroupingSettings { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets if this query template is used for URL rewrites or redirects.
+    /// </summary>
+    public bool UsedForRedirect { get; set; } = false;
 }

--- a/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Models/Template.cs
@@ -181,7 +181,7 @@ public class Template
     public string LoginRedirectUrl { get; set; }
 
     /// <summary>
-    /// Gets or sets whether thie template can be used as the default header.
+    /// Gets or sets whether the template can be used as the default header.
     /// </summary>
     public bool IsDefaultHeader { get; set; }
 

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -152,6 +152,7 @@ public class TemplatesService(
                          template.grouping_value_column_name,
                          template.grouping_key,
                          template.grouping_prefix,
+                         template.query_used_for_redirect,
                          template.pre_load_query,
                          template.return_not_found_when_pre_load_query_has_no_data,
                          template.login_required,
@@ -630,6 +631,7 @@ public class TemplatesService(
                          template.grouping_value_column_name,
                          template.grouping_key,
                          template.grouping_prefix,
+                         template.query_used_for_redirect,
                          template.pre_load_query,
                          template.return_not_found_when_pre_load_query_has_no_data,
                          template.version
@@ -1740,7 +1742,8 @@ public class TemplatesService(
                      SELECT
                      	template.template_id,
                      	template.template_type,
-                     	template.url_regex
+                     	template.url_regex,
+                     	template.query_used_for_redirect
                      FROM {WiserTableNames.WiserTemplate} AS template
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS otherVersion ON otherVersion.template_id = template.template_id AND otherVersion.version > template.version
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
@@ -1767,7 +1770,8 @@ public class TemplatesService(
                      SELECT 
                      	template.template_id,
                      	template.template_type,
-                     	template.url_regex
+                     	template.url_regex,
+                     	template.query_used_for_redirect
                      FROM {WiserTableNames.WiserTemplate} AS template
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS parent1 ON parent1.template_id = template.parent_id AND parent1.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = template.parent_id)
                      LEFT JOIN {WiserTableNames.WiserTemplate} AS parent2 ON parent2.template_id = parent1.parent_id AND parent2.version = (SELECT MAX(version) FROM {WiserTableNames.WiserTemplate} WHERE template_id = parent1.parent_id)
@@ -1792,12 +1796,27 @@ public class TemplatesService(
         var results = new List<Template>();
         foreach (DataRow dataRow in dataTable.Rows)
         {
-            results.Add(new Template
+            var type = dataRow.Field<TemplateTypes>("template_type");
+            switch (type)
             {
-                Id = dataRow.Field<int>("template_id"),
-                Type = dataRow.Field<TemplateTypes>("template_type"),
-                UrlRegex = dataRow.Field<string>("url_regex")
-            });
+                case TemplateTypes.Query:
+                    results.Add(new QueryTemplate
+                    {
+                        Id = dataRow.Field<int>("template_id"),
+                        Type = type,
+                        UrlRegex = dataRow.Field<string>("url_regex"),
+                        UsedForRedirect = dataRow.Field<bool>("query_used_for_redirect")
+                    });
+                    break;
+                default:
+                    results.Add(new Template
+                    {
+                        Id = dataRow.Field<int>("template_id"),
+                        Type = type,
+                        UrlRegex = dataRow.Field<string>("url_regex")
+                    });
+                    break;
+            }
         }
 
         return results;


### PR DESCRIPTION
# Describe your changes

Added new setting for (query) templates called "Used for redirect". If this is set, the query needs to return a TemplateId or RedirectUrl in a single result and the template controller can redirect to that template or url. Useful for a catch-all template that needs context-sensitive redirection.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Gamecards project needed this catch all, and the query used would check the database for the url regex parameters whether the entered url would match a product, faq or news page.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

x

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1206726301569963/task/1208745703146325
