### PR TITLE
Changed string replacements to work with (always used) JToken input

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/StringReplacementsService.cs
@@ -540,14 +540,7 @@ public class StringReplacementsService(
 
         if (propertyName.Contains('.') && !propertyName.Split('.')[0].Contains('('))
         {
-            var propertyInfo = input.GetType().GetProperty(propertyName.Split('.')[0], BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (propertyInfo == null)
-            {
-                return null;
-            }
-
-            var newPropertyName = propertyName.Replace($"{propertyName.Split('.')[0]}.", "");
-            var value = GetPropertyValue((JToken) propertyInfo.GetValue(input, null), newPropertyName);
+            var value = input.SelectToken(propertyName);
             return value != null ? value.ToString() : $"{{{propertyName}}}";
         }
 


### PR DESCRIPTION
# Describe your changes

Old code checked the input type if it could find the requested child. This is useless because the input is always a JToken based on the original model.

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Fetim Retailplatform has a PDF template that uses {child.property} replacements. This fix makes that work.
Also tested with {template.blabla} in templates that have a pre-load query. Those still work.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [X] I added new unit tests for my changes if applicable

# Related pull requests

n/a

# Link to Asana ticket

none
