### PR TITLE
Extend check to include if the transaction was started outside the function

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -1760,7 +1760,7 @@ public class WiserItemsService(
             }
             catch (GclQueryException queryException)
             {
-                if (!createNewTransaction)
+                if (!createNewTransaction || alreadyHadTransaction)
                 {
                     throw;
                 }


### PR DESCRIPTION
# Describe your changes

When an exception was thrown handling a query while deleting an item, it would only check if no new transaction needed to be made before performing a rollback. Since the transaction was already active the method didn't start the transaction itself and should not close it. This is done everywhere else in the class.

This caused problems that a rollback was performed but the above lying logic was still thinking a transaction was present and started to execute queries outside of a transaction.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by using the WTS branch merge to delete an item and then insert one while forcing an sql exception during deletion. This caused the item to not be deleted due to the rollback but still insert the new item. After extending the check the rollback was not performed and thus allowed a full rollback in the WTS.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/29553867016121/task/1209895231644200
