### PR TITLE
Allow passing of detail id when setting item detail

### DIFF
--- a/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
@@ -120,7 +120,7 @@ public abstract class WiserItemBaseModel
     /// <param name="saveAsIs">Optional: Set to <c>true</c> to skip any conversion or hashing that the GCL might do when saving this value to the database. Such as for passwords, when you already hashed them yourself.</param>
     public void SetDetail(WiserItemDetailModel detail, bool append = false, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false)
     {
-        SetDetail(detail.Key, detail.Value, append, detail.ReadOnly, detail.GroupName, detail.LanguageCode, markChangedAsFalse, format, saveAsIs, detail.IsLinkProperty, detail.LinkType, detail.ItemLinkId);
+        SetDetail(detail.Key, detail.Value, append, detail.ReadOnly, detail.GroupName, detail.LanguageCode, detail.Id, markChangedAsFalse, format, saveAsIs, detail.IsLinkProperty, detail.LinkType, detail.ItemLinkId);
     }
 
     /// <summary>
@@ -139,7 +139,7 @@ public abstract class WiserItemBaseModel
     /// <param name="isLinkProperty">Optional: Whether the detail is for wiser_itemlinkdetail, instead of wiser_itemdetail. If this is <c>true</c>, then <see cref="linkType"/> and  <see cref="itemLinkId"/> must also be specified. Default is <c>false</c>.</param>
     /// <param name="linkType">The link type number, must be specified if <see cref="isLinkProperty"/> is set to <c>true</c>.</param>
     /// <param name="itemLinkId">The ID of the link between two items, must be specified if <see cref="isLinkProperty"/> is set to <c>true</c>.</param>
-    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false, bool isLinkProperty = false, int linkType = 0, ulong itemLinkId = 0)
+    public void SetDetail(string key, object value, bool append = false, bool enableReadOnly = false, string groupName = null, string languageCode = null, ulong detailId = 0, bool markChangedAsFalse = false, string format = null, bool saveAsIs = false, bool isLinkProperty = false, int linkType = 0, ulong itemLinkId = 0)
     {
         // TODO: Add a check for read only, so that we can't use this function to update read only values?
         var detail = details.FirstOrDefault(d => String.Equals(d.Key, key, StringComparison.OrdinalIgnoreCase) &&
@@ -153,6 +153,7 @@ public abstract class WiserItemBaseModel
             // Add new item if key doesn't exist
             detail = new WiserItemDetailModel
             {
+                Id = detailId,
                 Key = key,
                 GroupName = groupName,
                 LanguageCode = languageCode,

--- a/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemBaseModel.cs
@@ -133,6 +133,7 @@ public abstract class WiserItemBaseModel
     /// <param name="enableReadOnly">Optional: Make the new value read only. Default is false.</param>
     /// <param name="groupName">Optional: The group name of the detail. Default is null.</param>
     /// <param name="languageCode">Optional: The language code of the detail. Default is null.</param>
+    /// <param name="detailId">Optional: the id of the detail. The default is 0.</param>
     /// <param name="markChangedAsFalse">Optional: Whether to mark the Changed property to false, so that it won't be saved if you save this item without changing this value after calling this function.</param>
     /// <param name="format">Optional: Formatting for converting certain types (such as numbers and dates) to string. Default is null.</param>
     /// <param name="saveAsIs">Optional: Set to <c>true</c> to skip any conversion or hashing that the GCL might do when saving this value to the database. Such as for passwords, when you already hashed them yourself.</param>


### PR DESCRIPTION
# Describe your changes

Added support for the `detailId` parameter in `WiserItemBaseModel`:
- Updated documentation to include the `detailId` parameter.
- Modified the `SetDetail` method to handle the new parameter.

Also, bumped `Magick.NET-Q8-x64` from version 14.10.1 to 14.10.2.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested a veriety of different functions that have to do with saving or updating wiser items to see if this caused behaviour changes in unexpected ways.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1151477971646641/task/1212339198871050?focus=true