### PR TITLE
Filter widgets by published environment in TemplatesService - 

### DIFF
--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1838,6 +1838,7 @@ public class TemplatesService(
                                   LEFT JOIN {WiserTableNames.WiserItemDetail} AS location ON location.item_id = widget.id AND location.`key` = '{Constants.PageWidgetLocationPropertyName}'
                                   LEFT JOIN {WiserTableNames.WiserItemLink} AS linkToParent ON linkToParent.item_id = widget.id AND linkToParent.type = {Constants.PageWidgetParentLinkType}
                                   WHERE widget.entity_type = '{Constants.PageWidgetEntityType}'
+                                        AND widget.published_environment & {(int) gclSettings.Environment} = {(int) gclSettings.Environment}
                                   ORDER BY IFNULL(linkToParent.destination_item_id, 0) ASC, IFNULL(linkToParent.ordering, widget.ordering) ASC
                                   """;
 


### PR DESCRIPTION
## Summary of Changes
- Add bitwise comparison to environment so page widgets can be separated between test, acceptance and live

## Type of Change(s)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Chore / dependency update
- [ ] Documentation

## Testing

Create a page widget and set its published_environment to 7. Check whether the widget is loaded on test and development but not production.

## Checklist

- [x] Self-reviewed the diff*
- [x] No leftover debug code or console logs*
- [x] Changes have been tested locally*
- [ ] The ticket number is in the PR title*
- [ ] Relevant tests added or updated
- [ ] Documentation updated
* Required when applicable

## Related issues

- [ ] This PR is blocked by: ...
- [ ] This PR should be merged together with: ...
- [ ] This PR relates to ticket: ...

## Additional notes